### PR TITLE
Explain why Milkcrate picks stand out

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -27,7 +27,7 @@
   --mc-notice:      #f0e8d0;
 }
 
-/* ─── Base ───────────────────────────────────────────────────────────────── */
+/* ─── Base ──────────────────────────────────────────────────────────────── */
 
 .mc-body        { background: var(--mc-bg); color: var(--mc-text); font-family: ui-serif, Georgia, serif; transition: background 0.2s, color 0.2s; }
 .mc-header      { background: var(--mc-bg-raised); }
@@ -89,7 +89,7 @@
 .mc-crate-row::-webkit-scrollbar { display: none; }
 .mc-crate-row > * { scroll-snap-align: start; }
 
-/* ─── Record Card ────────────────────────────────────────────────────────── */
+/* ─── Record Card ──────────────────────────────────────────────────────── */
 
 .mc-record-card {
   position: relative;
@@ -125,6 +125,22 @@
 
 .mc-record-front {
   background: var(--mc-bg-card);
+}
+
+.mc-record-pick-stamp {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.6rem;
+  z-index: 1;
+  padding: 0.25rem 0.45rem;
+  border: 1px solid color-mix(in srgb, var(--mc-accent) 65%, transparent);
+  background: color-mix(in srgb, var(--mc-bg) 80%, transparent);
+  color: var(--mc-accent);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .mc-record-back {
@@ -181,6 +197,18 @@
   overflow: hidden;
   flex: 1;
   line-height: 1.6;
+}
+.mc-record-pick-reasons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.mc-record-pick-reason {
+  font-size: 0.6rem;
+  line-height: 1.4;
+  color: var(--mc-text);
+  border-left: 2px solid var(--mc-accent);
+  padding-left: 0.45rem;
 }
 .mc-record-back-actions {
   display: flex;
@@ -339,7 +367,7 @@
   opacity: 0.6;
 }
 
-/* ─── Responsive ─────────────────────────────────────────────────────────── */
+/* ─── Responsive ────────────────────────────────────────────────────────── */
 
 @media (min-width: 768px) {
   .mc-record-card { width: 240px; height: 240px; }

--- a/app/components/record_card_component.html.erb
+++ b/app/components/record_card_component.html.erb
@@ -6,6 +6,9 @@
 
     <%# Front: album cover %>
     <div class="mc-record-front">
+      <% if pick_reasons? %>
+        <div class="mc-record-pick-stamp">Milkcrate Pick</div>
+      <% end %>
       <% if cover_image? %>
         <img src="<%= @listing.cover_image_url %>"
              alt="<%= @listing.title %>"
@@ -19,6 +22,14 @@
     <div class="mc-record-back">
       <div class="mc-record-back-title"><%= @listing.title %></div>
       <div class="mc-record-back-artist"><%= @listing.artist %></div>
+
+      <% if pick_reasons? %>
+        <div class="mc-record-pick-reasons">
+          <% @pick_reasons.each do |reason| %>
+            <div class="mc-record-pick-reason"><%= reason %></div>
+          <% end %>
+        </div>
+      <% end %>
 
       <% if tracklist_lines.any? %>
         <div class="mc-record-back-tracklist">

--- a/app/components/record_card_component.rb
+++ b/app/components/record_card_component.rb
@@ -1,7 +1,8 @@
 class RecordCardComponent < ViewComponent::Base
-  def initialize(listing:, in_session: false)
+  def initialize(listing:, in_session: false, pick_reasons: [])
     @listing = listing
     @in_session = in_session
+    @pick_reasons = Array(pick_reasons).reject(&:blank?)
   end
 
   def in_session?
@@ -20,5 +21,9 @@ class RecordCardComponent < ViewComponent::Base
 
   def meta
     [ @listing.label, @listing.year, @listing.condition ].compact.join(" · ")
+  end
+
+  def pick_reasons?
+    @pick_reasons.any?
   end
 end

--- a/app/controllers/store_sections_controller.rb
+++ b/app/controllers/store_sections_controller.rb
@@ -6,6 +6,7 @@ class StoreSectionsController < ApplicationController
     @section_name = @section_slug == "new-arrivals" ? "New Arrivals" : @section_slug.titleize
     @listings = fetch_section_listings.limit(100).to_a
     @session_listing_ids = @current_dig_session&.listing_ids&.to_set || Set.new
+    @pick_reasons = @section_slug == "picks" ? PicksSelector.new(@store).reasons_for(@listings) : {}
   end
 
   private

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -3,7 +3,7 @@ class StoresController < ApplicationController
     entries = Store.rotation
     return render :no_stores if entries.empty?
 
-    entry = entries[Date.current.jd % entries.count]
+    entry = entry[Date.current.jd % entries.count]
     @store = Store.find_by(discogs_username: entry["username"])
     return render :no_stores unless @store
 
@@ -28,7 +28,9 @@ class StoresController < ApplicationController
   def picks_preview
     @store = Store.find(params[:id])
     daily_ids = daily_selection_ids(@store)
-    @picks = PicksSelector.new(@store).select(count: 20, seed: params[:seed], listing_ids: daily_ids)
+    selector = PicksSelector.new(@store)
+    @picks = selector.select(count: 20, seed: params[:seed], listing_ids: daily_ids)
+    @pick_reasons = selector.reasons_for(@picks)
     @session_listing_ids = @current_dig_session&.listing_ids&.to_set || Set.new
   end
 
@@ -42,8 +44,18 @@ class StoresController < ApplicationController
     sections = []
     daily_ids = daily_selection_ids(store)
 
-    picks = PicksSelector.new(store).select(listing_ids: daily_ids)
-    sections << { name: "Milkcrate Picks", slug: "picks", listings: picks, count: picks.size, preloaded: true } if picks.any?
+    selector = PicksSelector.new(store)
+    picks = selector.select(listing_ids: daily_ids)
+    if picks.any?
+      sections << {
+        name: "Milkcrate Picks",
+        slug: "picks",
+        listings: picks,
+        count: picks.size,
+        preloaded: true,
+        pick_reasons: selector.reasons_for(picks)
+      }
+    end
 
     new_arrivals = store.listings.new_arrivals
     sections << { name: "New Arrivals", slug: "new-arrivals", listings: new_arrivals, count: new_arrivals.size } if new_arrivals.any?

--- a/app/services/pick_narrative.rb
+++ b/app/services/pick_narrative.rb
@@ -1,0 +1,63 @@
+require_relative "picks_selector"
+
+class PickNarrative
+  MAX_REASONS = 3
+  VINTAGE_BEFORE = PicksSelector::VINTAGE_BEFORE
+  GOOD_CONDITIONS = %w[Mint NM M VG+].freeze
+
+  def initialize(listing, genre_counts:)
+    @listing = listing
+    @genre_counts = genre_counts
+  end
+
+  def reasons(limit: MAX_REASONS)
+    [
+      discovery_styles_reason,
+      crossover_reason,
+      vintage_reason,
+      rare_section_reason,
+      condition_reason
+    ].compact.first(limit)
+  end
+
+  private
+
+  attr_reader :listing, :genre_counts
+
+  def discovery_styles_reason
+    matches = Array(listing.styles) & PicksSelector::DISCOVERY_STYLES
+    return if matches.empty?
+
+    "Discovery styles: #{matches.first(2).join(', ')}"
+  end
+
+  def crossover_reason
+    genres = Array(listing.genres)
+    return unless genres.size > 1
+
+    "Genre crossover: #{genres.first(2).join(' + ')}"
+  end
+
+  def vintage_reason
+    return unless listing.year && listing.year < VINTAGE_BEFORE
+
+    "Vintage press: #{listing.year}"
+  end
+
+  def rare_section_reason
+    genre = Array(listing.genres).first
+    return if genre.nil?
+
+    count = genre_counts.fetch(genre, 0)
+    return unless count.positive? && count < 5
+
+    "From a thin section: only #{count} #{genre} records in today's crate"
+  end
+
+  def condition_reason
+    condition = listing.condition.to_s.strip
+    return unless GOOD_CONDITIONS.include?(condition)
+
+    "Clean copy: #{condition}"
+  end
+end

--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -35,6 +35,13 @@ class PicksSelector
     pool.sort_by { |listing| Digest::MD5.hexdigest("#{listing.id}#{shuffle_seed}") }.first(count)
   end
 
+  def reasons_for(listings)
+    genre_counts = @store.listings.pluck(:genres).flatten.tally
+    listings.index_with do |listing|
+      PickNarrative.new(listing, genre_counts: genre_counts).reasons
+    end
+  end
+
   private
 
   def score_all(listing_ids: nil)

--- a/app/views/store_sections/show.html.erb
+++ b/app/views/store_sections/show.html.erb
@@ -21,7 +21,8 @@
         <div class="mc-dig-slot" data-crate-target="card">
           <%= render RecordCardComponent.new(
                 listing: listing,
-                in_session: @session_listing_ids.include?(listing.id)
+                in_session: @session_listing_ids.include?(listing.id),
+                pick_reasons: @pick_reasons[listing.id]
               ) %>
         </div>
       <% end %>

--- a/app/views/stores/featured.html.erb
+++ b/app/views/stores/featured.html.erb
@@ -44,7 +44,11 @@
           <%= turbo_frame_tag "picks-preview" do %>
             <div class="mc-crate-row">
               <% section[:listings].first(20).each do |listing| %>
-                <%= render RecordCardComponent.new(listing: listing, in_session: session_listing_ids&.include?(listing.id)) %>
+                <%= render RecordCardComponent.new(
+                  listing: listing,
+                  in_session: session_listing_ids&.include?(listing.id),
+                  pick_reasons: section[:pick_reasons][listing.id]
+                ) %>
               <% end %>
             </div>
           <% end %>

--- a/app/views/stores/picks_preview.html.erb
+++ b/app/views/stores/picks_preview.html.erb
@@ -1,7 +1,11 @@
 <%= turbo_frame_tag "picks-preview" do %>
   <div class="mc-crate-row">
     <% @picks.each do |listing| %>
-      <%= render RecordCardComponent.new(listing: listing, in_session: @session_listing_ids.include?(listing.id)) %>
+      <%= render RecordCardComponent.new(
+        listing: listing,
+        in_session: @session_listing_ids.include?(listing.id),
+        pick_reasons: @pick_reasons[listing.id]
+      ) %>
     <% end %>
   </div>
 <% end %>

--- a/spec/components/record_card_component_spec.rb
+++ b/spec/components/record_card_component_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe RecordCardComponent, type: :component do
     expect(page).to have_text("B1 Pursuance")
   end
 
+  it "renders pick reasons when present" do
+    render_inline(described_class.new(
+      listing: listing,
+      in_session: false,
+      pick_reasons: [ "Discovery styles: Spiritual Jazz", "Vintage press: 1965" ]
+    ))
+
+    expect(page).to have_text("Milkcrate Pick")
+    expect(page).to have_text("Discovery styles: Spiritual Jazz")
+    expect(page).to have_text("Vintage press: 1965")
+  end
+
   it "renders meta info" do
     render_inline(component)
     expect(page).to have_text("Impulse!")

--- a/spec/services/pick_narrative_spec.rb
+++ b/spec/services/pick_narrative_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require_relative "../../app/services/pick_narrative"
+
+RSpec.describe PickNarrative do
+  ListingDouble = Struct.new(:styles, :genres, :year, :condition, keyword_init: true)
+
+  describe "#reasons" do
+    it "explains the strongest discovery signals in score order" do
+      listing = ListingDouble.new(
+        styles: [ "Afrobeat", "Experimental" ],
+        genres: [ "Jazz", "Funk" ],
+        year: 1973,
+        condition: "VG+"
+      )
+
+      reasons = described_class.new(listing, genre_counts: { "Jazz" => 3, "Funk" => 7 }).reasons
+
+      expect(reasons).to eq(
+        [
+          "Discovery styles: Afrobeat, Experimental",
+          "Genre crossover: Jazz + Funk",
+          "Vintage press: 1973"
+        ]
+      )
+    end
+
+    it "surfaces thin-section records when other signals are absent" do
+      listing = ListingDouble.new(
+        styles: [],
+        genres: [ "Gospel" ],
+        year: 1988,
+        condition: "G"
+      )
+
+      reasons = described_class.new(listing, genre_counts: { "Gospel" => 2 }).reasons
+
+      expect(reasons).to eq([ "From a thin section: only 2 Gospel records in today's crate" ])
+    end
+
+    it "limits the output to three reasons" do
+      listing = ListingDouble.new(
+        styles: [ "Dub" ],
+        genres: [ "Reggae", "Funk" ],
+        year: 1977,
+        condition: "NM"
+      )
+
+      reasons = described_class.new(listing, genre_counts: { "Reggae" => 1 }).reasons
+
+      expect(reasons.size).to eq(3)
+      expect(reasons).not_to include("Clean copy: NM")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a `PickNarrative` service that turns pick-scoring signals into short reasons
- show those reasons on pick cards in the featured picks row, shuffled picks preview, and picks dig view
- add a pure-Ruby spec for the narrative logic plus a component spec for the pick treatment

## Why this gap
Milkcrate already surfaces picks, but it does not explain why any record is interesting. That leaves the app close to a nicer Discogs inventory browser instead of a product with a point of view about crate digging. This change adds editorial context without needing new ingestion work.

## Competitive context
- Discogs exposes huge seller inventories, but discovery is still mostly filter/sort driven rather than guided interpretation.
- [Crate Diggers](https://cratediggers.barbicanstation.com/) is editorial and scene-driven, not store-inventory driven.
- [CrateScout](https://cratescout.io/) focuses on broad digging/discovery workflows, while Milkcrate can differentiate by interpreting one store's live inventory like a great in-person shop clerk would.

## Verification
- `bundle exec rspec spec/services/pick_narrative_spec.rb`
- `ruby -c app/services/pick_narrative.rb app/services/picks_selector.rb app/controllers/stores_controller.rb app/controllers/store_sections_controller.rb app/components/record_card_component.rb spec/services/pick_narrative_spec.rb`

## Notes
- Full Rails/component specs could not run here because PostgreSQL was unavailable in the sandbox.
- RuboCop could not run here because the sandbox blocks its server startup/cache behavior.
