### PR TITLE
Refine buried-bin logic for Milkcrate picks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,34 @@ This README is only for local development.
 - Scores a smaller "Milkcrate Picks" set for quick browsing
 - Lets you save records into a dig session and review past sessions
 
+## Algorithm Status
+
+Current curation behavior is intentionally simple and still in active refinement.
+
+`DailySelectionService` currently mixes:
+
+- recent arrivals
+- good-condition records
+- discovery styles
+- unseen inventory from the last week
+
+`PicksSelector` currently boosts:
+
+- discovery styles
+- multi-genre crossover
+- vintage records
+- good-condition copies
+- records from tiny sections
+- discovery records buried inside crowded sections
+
+Working notes for the picks algorithm live in [docs/milkcrate-picks-algorithm-research.md](docs/milkcrate-picks-algorithm-research.md).
+
+Current gaps:
+
+- condition text is not yet normalized beyond a small allowlist
+- picks can still over-reward obvious catalog anchors
+- low-information listings do not yet receive a penalty
+
 ## Stack
 
 - Ruby `3.4.8`

--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -18,6 +18,7 @@ class PicksSelector
 
   # Vintage cutoff — anything from these eras gets a bump
   VINTAGE_BEFORE = 1980
+  CROWDED_SECTION_THRESHOLD = 15
 
   def initialize(store)
     @store = store
@@ -65,6 +66,12 @@ class PicksSelector
 
     # Small section penalty reversed — records from tiny sections deserve a spotlight
     points += 3 if genre_counts.fetch(listing.primary_genre, 0) < 5
+
+    # Buried bin bonus — discovery records hidden in crowded sections are
+    # exactly the kind of finds that reward patient digging in a real shop.
+    if matching_styles.any? && genre_counts.fetch(listing.primary_genre, 0) >= CROWDED_SECTION_THRESHOLD
+      points += 3
+    end
 
     points
   end

--- a/docs/milkcrate-picks-algorithm-research.md
+++ b/docs/milkcrate-picks-algorithm-research.md
@@ -1,0 +1,54 @@
+# Milkcrate Picks Algorithm Research
+
+## 2026-04-15
+
+### Competitive context
+
+- Discogs still centers marketplace inventory management, search, and filtering rather than editorial curation. Its buyer guidance emphasizes direct search, seller lookup, and browsing with filters.
+- Discogs Player is explicitly optimizing digging speed: ingest a seller inventory, filter it hard, listen quickly, and export the shortlist.
+- CrateScout is positioning around AI taste matching plus local store discovery.
+- Collection apps like Crate Digger, Gatefold, Vinyl Crate, and Recordfy are clustering around personal collection management, alerts, and recommendation layers.
+
+### What still looks open
+
+The obvious whitespace is not "better filtering" or "more AI." It is a store-specific interpretation layer that makes an actual seller inventory feel like a good in-person dig: what is hidden, what is odd, what is unexpectedly strong, and why a record is worth stopping on.
+
+That implies Milkcrate should bias toward picks that feel:
+
+- buried but rewarding
+- specific to one store's real inventory shape
+- explainable in plain language
+
+### Current selector behavior
+
+`PicksSelector` already rewards:
+
+- discovery styles
+- multi-genre crossover
+- vintage records
+- decent condition
+- records from tiny sections
+
+This is a strong start, but it over-favors obvious "specialty bin" records and under-favors weird records hidden inside crowded bins.
+
+### Refinement added this run
+
+Added a crowded-section bonus for records with discovery styles when their primary genre sits inside a large section.
+
+Why this matters:
+
+- In real stores, the hardest and most satisfying finds are often not in the tiny oddball section.
+- They are tucked inside the giant Jazz, Electronic, Rock, or Funk bins where volume creates invisibility.
+- This helps Milkcrate surface records that would realistically be missed by a faster or more literal digger.
+
+### Guardrails
+
+- Keep this bonus discovery-only. A crowded section should not boost generic catalog filler.
+- Keep the existing small-section bonus. Milkcrate should value both tiny-bin oddities and buried-in-plain-sight records.
+- Prefer score changes that sharpen taste over broadening the top pool indiscriminately.
+
+### Follow-up ideas
+
+- Add a light penalty for records with very weak metadata signals and no taste-forward attributes.
+- Normalize condition text so `Near Mint`, `NM`, and similar variants are treated consistently.
+- Consider a "too obvious" dampener if repeated mainstream anchor records dominate picks across days.

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+require "digest"
+require "active_support/core_ext/date/calculations"
+require_relative "../../app/services/picks_selector"
+
+RSpec.describe PicksSelector do
+  FakeRelation = Struct.new(:records) do
+    def where(id: nil)
+      return self unless id
+
+      self.class.new(records.select { |record| id.include?(record.id) })
+    end
+
+    def not(genres:)
+      filtered = records.reject do |record|
+        genres == "{}" && Array(record.genres).empty?
+      end
+
+      self.class.new(filtered)
+    end
+
+    def pluck(attribute)
+      records.map { |record| record.public_send(attribute) }
+    end
+
+    def to_a
+      records
+    end
+  end
+
+  FakeWhereChain = Struct.new(:relation) do
+    def not(**kwargs)
+      relation.not(**kwargs)
+    end
+  end
+
+  FakeListingsScope = Struct.new(:records) do
+    def where(*args, **kwargs)
+      return FakeWhereChain.new(FakeRelation.new(records)) if args.empty? && kwargs.empty?
+
+      FakeRelation.new(records).where(**kwargs)
+    end
+
+    def pluck(attribute)
+      records.map { |record| record.public_send(attribute) }
+    end
+  end
+
+  FakeListing = Struct.new(:id, :genres, :styles, :year, :condition, keyword_init: true) do
+    def primary_genre
+      genres.first
+    end
+  end
+
+  describe "#select" do
+    it "scores discovery records buried in crowded sections above safer generic picks" do
+      buried_gem = FakeListing.new(
+        id: 1,
+        genres: [ "Electronic" ],
+        styles: [ "Ambient" ],
+        year: 1992,
+        condition: "VG"
+      )
+      generic_electronic = FakeListing.new(
+        id: 2,
+        genres: [ "Electronic", "Jazz" ],
+        styles: [],
+        year: 1978,
+        condition: "VG+"
+      )
+      supporting_records = Array.new(16) do |index|
+        FakeListing.new(
+          id: index + 10,
+          genres: [ "Electronic" ],
+          styles: [],
+          year: 1995,
+          condition: "VG"
+        )
+      end
+
+      listings = [ buried_gem, generic_electronic ] + supporting_records
+      store = double("Store", listings: FakeListingsScope.new(listings))
+      selector = described_class.new(store)
+
+      scores = selector.send(:score_all).to_h
+
+      expect(scores.fetch(buried_gem)).to be > scores.fetch(generic_electronic)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a crowded-section bonus to `PicksSelector` so discovery records buried in large bins can outrank safer generic picks
- add a pure-Ruby `PicksSelector` spec to cover that ranking behavior without browser or database-heavy feature coverage
- add an algorithm research note and a README status section so the current curation levers and gaps stay visible

## Test Plan
- [x] `bundle exec rspec spec/services/picks_selector_spec.rb`
- [x] `ruby -c app/services/picks_selector.rb`
- [x] `ruby -c spec/services/picks_selector_spec.rb`
- [ ] Full Rails-backed specs unavailable in this sandbox because PostgreSQL is not running
