### PR TITLE
Boost rare styles in Milkcrate picks

### DIFF
--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -18,6 +18,8 @@ class PicksSelector
 
   # Vintage cutoff — anything from these eras gets a bump
   VINTAGE_BEFORE = 1980
+  RARE_STYLE_THRESHOLD = 3
+  RARE_STYLE_BOOST = 2
 
   def initialize(store)
     @store = store
@@ -43,11 +45,12 @@ class PicksSelector
     listings = scope.to_a
 
     genre_counts = @store.listings.pluck(:genres).flatten.tally
+    style_counts = @store.listings.pluck(:styles).flatten.tally
 
-    listings.map { |listing| [ listing, score(listing, genre_counts) ] }
+    listings.map { |listing| [ listing, score(listing, genre_counts, style_counts) ] }
   end
 
-  def score(listing, genre_counts)
+  def score(listing, genre_counts, style_counts)
     points = 0
 
     # Discovery styles — the stuff worth digging for
@@ -65,6 +68,10 @@ class PicksSelector
 
     # Small section penalty reversed — records from tiny sections deserve a spotlight
     points += 3 if genre_counts.fetch(listing.primary_genre, 0) < 5
+
+    # Rare styles are closer to the record-store "wait, what's this?" feeling
+    rare_styles = listing.styles.select { |style| style_counts.fetch(style, 0) < RARE_STYLE_THRESHOLD }
+    points += rare_styles.size * RARE_STYLE_BOOST
 
     points
   end

--- a/docs/milkcrate-picks-algorithm-research.md
+++ b/docs/milkcrate-picks-algorithm-research.md
@@ -1,0 +1,69 @@
+# Milkcrate Picks Algorithm Research
+
+## 2026-04-16
+
+### Current selector shape
+
+`PicksSelector` is currently a lightweight second-pass ranker layered on top of the broader `DailySelectionService`.
+
+- `DailySelectionService` answers "what should be in rotation today?"
+- `PicksSelector` answers "what feels worth stopping on right now?"
+
+That split is good. The selector should stay opinionated and small rather than turning into a second general-purpose discovery engine.
+
+### Competitive context
+
+#### Discogs marketplace
+
+Discogs still centers buyer-driven search, filtering, and seller inventory access rather than editorial curation.
+
+- Discogs buyer guidance explicitly frames browsing around filters like format, year, and price, plus direct seller inventory search.
+- Discogs seller inventory pages likewise emphasize inventory management, filtering, and sorting.
+- Discogs' own genre/style model remains hierarchical: genre is broad, style is the more precise descriptive unit.
+
+Implication for Milkcrate: competing on search or raw inventory access is a dead end. The opportunity is stronger editorial ranking inside a single seller's catalog.
+
+Sources:
+
+- https://support.discogs.com/hc/en-us/articles/360001573434-How-To-Buy-Music-On-Discogs
+- https://support.discogs.com/hc/en-us/articles/360013826974-How-To-Place-An-Order-Using-The-Android-App
+- https://support.discogs.com/hc/en-us/articles/360007714754-How-Can-I-Manage-My-Inventory
+- https://support.discogs.com/hc/en-us/articles/360005055213-Database-Guidelines-9-Genres-Styles
+
+#### CR8S
+
+CR8S positions itself as a digital crate-digging product with a curated library and a richer presentation layer. That is directionally adjacent, but it is not doing seller-inventory interpretation in the Discogs marketplace sense.
+
+Implication for Milkcrate: Milkcrate should lean harder into "this specific store has weird, promising corners" instead of trying to become a general listening platform.
+
+Source:
+
+- https://cr8s.com/
+
+### Adjustment made today
+
+Added a style-rarity boost to `PicksSelector`.
+
+Why:
+
+- Genre rarity is useful but too blunt.
+- In practice, "Electronic" or "Rock" often hides the interesting part.
+- Style is usually where the record-store texture lives.
+- Discogs itself treats style as the more specific descriptive layer, which matches the kind of signal Milkcrate should reward.
+
+New rule:
+
+- If a listing has styles that appear fewer than 3 times in the store catalog, each rare style adds a small boost.
+
+Why this is a good surgical change:
+
+- It preserves the current selector architecture.
+- It does not introduce external data or new persistence.
+- It sharpens the difference between "generally solid record" and "record that feels like a find."
+- It complements the existing tiny-section genre boost instead of replacing it.
+
+### Notes for next iterations
+
+- Consider capping total style-rarity contribution if multi-style records start dominating too aggressively.
+- Consider adding a mild penalty for ultra-generic style combinations that are heavily represented in a store.
+- If picks start feeling too niche, rebalance against recency rather than removing rarity entirely.

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+require "digest"
+require_relative "../../app/services/picks_selector"
+
+RSpec.describe PicksSelector do
+  ListingStub = Struct.new(:styles, :genres, :year, :condition, keyword_init: true) do
+    def primary_genre
+      genres.first
+    end
+  end
+
+  describe "#score" do
+    it "boosts records with styles that are rare within the store catalog" do
+      selector = described_class.new(double("store"))
+
+      common_listing = ListingStub.new(
+        genres: [ "Electronic" ],
+        styles: [ "House" ],
+        condition: "VG+"
+      )
+
+      rare_style_listing = ListingStub.new(
+        genres: [ "Electronic" ],
+        styles: [ "Broken Beat" ],
+        condition: "VG+"
+      )
+
+      genre_counts = { "Electronic" => 6 }
+      style_counts = { "House" => 6, "Broken Beat" => 1 }
+
+      common_score = selector.send(:score, common_listing, genre_counts, style_counts)
+      rare_score = selector.send(:score, rare_style_listing, genre_counts, style_counts)
+
+      expect(rare_score).to be > common_score
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a small store-relative style rarity boost to `PicksSelector` so picks surface records that feel more like real finds
- add a focused `PicksSelector` spec for the new scoring rule without expanding browser coverage
- document the algorithm rationale and competitive context in `docs/milkcrate-picks-algorithm-research.md`

## Test Plan
- [x] `bundle exec rspec spec/services/picks_selector_spec.rb`
- [x] `ruby -c app/services/picks_selector.rb`
- [ ] full Rails-backed specs are still blocked in this environment because local Postgres is unavailable
