### PR TITLE
Add docker-compose Postgres for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Discogs API — generate at discogs.com/settings/developers
+DISCOGS_TOKEN=your_token_here
+
+# Local Postgres (intended for docker compose)
+DB_HOST=127.0.0.1
+DB_PORT=5433
+DB_USER=postgres
+DB_PASSWORD=postgres
+
+# HTTP Basic Auth for the app
+MILKCRATE_USER=milkcrate
+MILKCRATE_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This README is only for local development.
 Install these before setup:
 
 - Ruby `3.4.8`
-- PostgreSQL running locally
 - Bundler
+- Docker with Docker Compose support
 
 You will also need a Discogs personal access token.
 
@@ -45,6 +45,14 @@ Required variables:
 
 - `DISCOGS_TOKEN`
   Used for inventory sync and release enrichment.
+- `DB_HOST`
+  Local Postgres host. Use `127.0.0.1` for the compose setup.
+- `DB_PORT`
+  Local Postgres port. The example setup uses `5433` to avoid colliding with another local Postgres instance.
+- `DB_USER`
+  Local Postgres username.
+- `DB_PASSWORD`
+  Local Postgres password.
 - `MILKCRATE_USER`
   HTTP basic auth username for the app.
 - `MILKCRATE_PASSWORD`
@@ -54,7 +62,15 @@ Without `MILKCRATE_PASSWORD`, requests will fail because the app always checks b
 
 ## Local Setup
 
-Install dependencies and prepare the database:
+Start Postgres first:
+
+```bash
+docker compose up -d postgres
+```
+
+The compose file binds the container's Postgres port to `${DB_PORT}` on the host and defaults to `5433`.
+
+Then install dependencies and prepare the database:
 
 ```bash
 bin/setup
@@ -78,9 +94,15 @@ The local databases are:
 - `milkcrate_development`
 - `milkcrate_test`
 
+To stop the database later:
+
+```bash
+docker compose down
+```
+
 ## Running The App
 
-Start the full local development stack with:
+With the Postgres container running, start the full local development stack with:
 
 ```bash
 bin/dev
@@ -175,7 +197,8 @@ bin/ci
 
 ## Notes For Developers
 
-- This repo includes a production `Dockerfile` and Kamal config, but they are not part of the local development flow.
+- Local development uses `docker-compose.yml` only for Postgres. The Rails server, Tailwind watcher, and job worker still run on the host via `bin/dev`.
+- This repo also includes a production `Dockerfile` and Kamal config, which are separate from the local development flow.
 - `config/recurring.yml` defines recurring jobs for production; local development usually relies on manual actions and the running job worker.
 - Store rotation is file-driven. If a store exists in the database but not in `config/stores.yml`, it will not appear on the homepage.
 - Inventory import is Discogs-rate-limited by design, so large syncs and enrichment runs can take a while.

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,6 +23,18 @@ default: &default
 development:
   <<: *default
   database: milkcrate_development
+  <% if ENV["DB_USER"] && !ENV["DB_USER"].empty? %>
+  username: <%= ENV["DB_USER"] %>
+  <% end %>
+  <% if ENV["DB_PASSWORD"] && !ENV["DB_PASSWORD"].empty? %>
+  password: <%= ENV["DB_PASSWORD"] %>
+  <% end %>
+  <% if ENV["DB_HOST"] && !ENV["DB_HOST"].empty? %>
+  host: <%= ENV["DB_HOST"] %>
+  <% end %>
+  <% if ENV["DB_PORT"] && !ENV["DB_PORT"].empty? %>
+  port: <%= ENV["DB_PORT"] %>
+  <% end %>
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
@@ -57,6 +69,18 @@ development:
 test:
   <<: *default
   database: milkcrate_test
+  <% if ENV["DB_USER"] && !ENV["DB_USER"].empty? %>
+  username: <%= ENV["DB_USER"] %>
+  <% end %>
+  <% if ENV["DB_PASSWORD"] && !ENV["DB_PASSWORD"].empty? %>
+  password: <%= ENV["DB_PASSWORD"] %>
+  <% end %>
+  <% if ENV["DB_HOST"] && !ENV["DB_HOST"].empty? %>
+  host: <%= ENV["DB_HOST"] %>
+  <% end %>
+  <% if ENV["DB_PORT"] && !ENV["DB_PORT"].empty? %>
+  port: <%= ENV["DB_PORT"] %>
+  <% end %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "${DB_PORT:-5433}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add a docker compose postgres service for local development
- make Rails development and test database config use DB_* env vars
- document the host-run Rails plus containerized Postgres workflow

## Verification
- docker compose config
- render config/database.yml with DB_HOST/DB_PORT/DB_USER/DB_PASSWORD set

## Notes
- default the compose host port to 5433 to avoid collisions with another local Postgres instance
- live container startup was not verified here because Docker access from the sandbox was denied