### PR TITLE
Consolidate Milkcrate picks refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,34 @@ This README is only for local development.
 - Scores a smaller "Milkcrate Picks" set for quick browsing
 - Lets you save records into a dig session and review past sessions
 
+## Algorithm Status
+
+Current curation behavior is intentionally simple and still in active refinement.
+
+`DailySelectionService` currently mixes:
+
+- recent arrivals
+- good-condition records
+- discovery styles
+- unseen inventory from the last week
+
+`PicksSelector` currently boosts:
+
+- discovery styles
+- multi-genre crossover
+- vintage records
+- good-condition copies
+- records from tiny sections
+- discovery records buried inside crowded sections
+
+Working notes for the picks algorithm live in [docs/milkcrate-picks-algorithm-research.md](docs/milkcrate-picks-algorithm-research.md).
+
+Current gaps:
+
+- condition text is not yet normalized beyond a small allowlist
+- picks can still over-reward obvious catalog anchors
+- low-information listings do not yet receive a penalty
+
 ## Stack
 
 - Ruby `3.4.8`

--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -19,6 +19,8 @@ class PicksSelector
   # Vintage cutoff — anything from these eras gets a bump
   VINTAGE_BEFORE = 1980
   CROWDED_SECTION_THRESHOLD = 15
+  RARE_STYLE_THRESHOLD = 3
+  RARE_STYLE_BOOST = 2
 
   def initialize(store)
     @store = store
@@ -44,11 +46,12 @@ class PicksSelector
     listings = scope.to_a
 
     genre_counts = @store.listings.pluck(:genres).flatten.tally
+    style_counts = @store.listings.pluck(:styles).flatten.tally
 
-    listings.map { |listing| [ listing, score(listing, genre_counts) ] }
+    listings.map { |listing| [ listing, score(listing, genre_counts, style_counts) ] }
   end
 
-  def score(listing, genre_counts)
+  def score(listing, genre_counts, style_counts)
     points = 0
 
     # Discovery styles — the stuff worth digging for
@@ -72,6 +75,10 @@ class PicksSelector
     if matching_styles.any? && genre_counts.fetch(listing.primary_genre, 0) >= CROWDED_SECTION_THRESHOLD
       points += 3
     end
+
+    # Rare styles are closer to the record-store "wait, what's this?" feeling
+    rare_styles = listing.styles.select { |style| style_counts.fetch(style, 0) < RARE_STYLE_THRESHOLD }
+    points += rare_styles.size * RARE_STYLE_BOOST
 
     points
   end

--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -18,6 +18,7 @@ class PicksSelector
 
   # Vintage cutoff — anything from these eras gets a bump
   VINTAGE_BEFORE = 1980
+  CROWDED_SECTION_THRESHOLD = 15
 
   def initialize(store)
     @store = store
@@ -65,6 +66,12 @@ class PicksSelector
 
     # Small section penalty reversed — records from tiny sections deserve a spotlight
     points += 3 if genre_counts.fetch(listing.primary_genre, 0) < 5
+
+    # Buried bin bonus — discovery records hidden in crowded sections are
+    # exactly the kind of finds that reward patient digging in a real shop.
+    if matching_styles.any? && genre_counts.fetch(listing.primary_genre, 0) >= CROWDED_SECTION_THRESHOLD
+      points += 3
+    end
 
     points
   end

--- a/docs/milkcrate-picks-algorithm-research.md
+++ b/docs/milkcrate-picks-algorithm-research.md
@@ -1,0 +1,54 @@
+# Milkcrate Picks Algorithm Research
+
+## 2026-04-15
+
+### Competitive context
+
+- Discogs still centers marketplace inventory management, search, and filtering rather than editorial curation. Its buyer guidance emphasizes direct search, seller lookup, and browsing with filters.
+- Discogs Player is explicitly optimizing digging speed: ingest a seller inventory, filter it hard, listen quickly, and export the shortlist.
+- CrateScout is positioning around AI taste matching plus local store discovery.
+- Collection apps like Crate Digger, Gatefold, Vinyl Crate, and Recordfy are clustering around personal collection management, alerts, and recommendation layers.
+
+### What still looks open
+
+The obvious whitespace is not "better filtering" or "more AI." It is a store-specific interpretation layer that makes an actual seller inventory feel like a good in-person dig: what is hidden, what is odd, what is unexpectedly strong, and why a record is worth stopping on.
+
+That implies Milkcrate should bias toward picks that feel:
+
+- buried but rewarding
+- specific to one store's real inventory shape
+- explainable in plain language
+
+### Current selector behavior
+
+`PicksSelector` already rewards:
+
+- discovery styles
+- multi-genre crossover
+- vintage records
+- decent condition
+- records from tiny sections
+
+This is a strong start, but it over-favors obvious "specialty bin" records and under-favors weird records hidden inside crowded bins.
+
+### Refinement added this run
+
+Added a crowded-section bonus for records with discovery styles when their primary genre sits inside a large section.
+
+Why this matters:
+
+- In real stores, the hardest and most satisfying finds are often not in the tiny oddball section.
+- They are tucked inside the giant Jazz, Electronic, Rock, or Funk bins where volume creates invisibility.
+- This helps Milkcrate surface records that would realistically be missed by a faster or more literal digger.
+
+### Guardrails
+
+- Keep this bonus discovery-only. A crowded section should not boost generic catalog filler.
+- Keep the existing small-section bonus. Milkcrate should value both tiny-bin oddities and buried-in-plain-sight records.
+- Prefer score changes that sharpen taste over broadening the top pool indiscriminately.
+
+### Follow-up ideas
+
+- Add a light penalty for records with very weak metadata signals and no taste-forward attributes.
+- Normalize condition text so `Near Mint`, `NM`, and similar variants are treated consistently.
+- Consider a "too obvious" dampener if repeated mainstream anchor records dominate picks across days.

--- a/docs/milkcrate-picks-algorithm-research.md
+++ b/docs/milkcrate-picks-algorithm-research.md
@@ -52,3 +52,71 @@ Why this matters:
 - Add a light penalty for records with very weak metadata signals and no taste-forward attributes.
 - Normalize condition text so `Near Mint`, `NM`, and similar variants are treated consistently.
 - Consider a "too obvious" dampener if repeated mainstream anchor records dominate picks across days.
+
+## 2026-04-16
+
+### Current selector shape
+
+`PicksSelector` is currently a lightweight second-pass ranker layered on top of the broader `DailySelectionService`.
+
+- `DailySelectionService` answers "what should be in rotation today?"
+- `PicksSelector` answers "what feels worth stopping on right now?"
+
+That split is good. The selector should stay opinionated and small rather than turning into a second general-purpose discovery engine.
+
+### Competitive context
+
+#### Discogs marketplace
+
+Discogs still centers buyer-driven search, filtering, and seller inventory access rather than editorial curation.
+
+- Discogs buyer guidance explicitly frames browsing around filters like format, year, and price, plus direct seller inventory search.
+- Discogs seller inventory pages likewise emphasize inventory management, filtering, and sorting.
+- Discogs' own genre/style model remains hierarchical: genre is broad, style is the more precise descriptive unit.
+
+Implication for Milkcrate: competing on search or raw inventory access is a dead end. The opportunity is stronger editorial ranking inside a single seller's catalog.
+
+Sources:
+
+- https://support.discogs.com/hc/en-us/articles/360001573434-How-To-Buy-Music-On-Discogs
+- https://support.discogs.com/hc/en-us/articles/360013826974-How-To-Place-An-Order-Using-The-Android-App
+- https://support.discogs.com/hc/en-us/articles/360007714754-How-Can-I-Manage-My-Inventory
+- https://support.discogs.com/hc/en-us/articles/360005055213-Database-Guidelines-9-Genres-Styles
+
+#### CR8S
+
+CR8S positions itself as a digital crate-digging product with a curated library and a richer presentation layer. That is directionally adjacent, but it is not doing seller-inventory interpretation in the Discogs marketplace sense.
+
+Implication for Milkcrate: Milkcrate should lean harder into "this specific store has weird, promising corners" instead of trying to become a general listening platform.
+
+Source:
+
+- https://cr8s.com/
+
+### Adjustment made today
+
+Added a style-rarity boost to `PicksSelector`.
+
+Why:
+
+- Genre rarity is useful but too blunt.
+- In practice, "Electronic" or "Rock" often hides the interesting part.
+- Style is usually where the record-store texture lives.
+- Discogs itself treats style as the more specific descriptive layer, which matches the kind of signal Milkcrate should reward.
+
+New rule:
+
+- If a listing has styles that appear fewer than 3 times in the store catalog, each rare style adds a small boost.
+
+Why this is a good surgical change:
+
+- It preserves the current selector architecture.
+- It does not introduce external data or new persistence.
+- It sharpens the difference between "generally solid record" and "record that feels like a find."
+- It complements the existing tiny-section genre boost instead of replacing it.
+
+### Notes for next iterations
+
+- Consider capping total style-rarity contribution if multi-style records start dominating too aggressively.
+- Consider adding a mild penalty for ultra-generic style combinations that are heavily represented in a store.
+- If picks start feeling too niche, rebalance against recency rather than removing rarity entirely.

--- a/docs/superpowers/specs/2026-04-17-discogs-corpus-design.md
+++ b/docs/superpowers/specs/2026-04-17-discogs-corpus-design.md
@@ -1,0 +1,235 @@
+# Discogs Corpus Snapshot Design
+
+## Goal
+
+Create a realistic, reproducible listing corpus that can be seeded into development and test databases without repeatedly calling the Discogs API after database resets.
+
+## Scope
+
+In scope:
+
+- A git-committed JSON snapshot containing Discogs-derived store and listing metadata (no binary assets).
+- A manual refresh workflow that rewrites that snapshot from Discogs API responses.
+- A seed workflow that imports the snapshot into `Store` and `Listing` tables idempotently.
+- Basic corpus stats/reporting for visibility into size and composition.
+- Automated tests for importer behavior and task-level execution.
+- README workflow documentation.
+
+Out of scope:
+
+- Automatic scheduled refresh.
+- Storing images/audio/zip assets.
+- Replacing existing online sync behavior for production.
+
+## Design Principles
+
+- Realism over tiny synthetic fixtures: data should reflect real store inventory shape for algorithm tuning.
+- Deterministic output: refresh should produce stable JSON ordering for reviewable diffs.
+- Idempotent import: repeated seeding should not duplicate records.
+- Minimal coupling: corpus tooling should layer onto existing services and model schema.
+- Explicit operator control: refresh happens only on manual command.
+
+## High-Level Architecture
+
+### Files and responsibilities
+
+- `db/corpus/discogs_store_snapshot.json`
+  - Canonical committed corpus snapshot.
+  - Contains top-level snapshot metadata plus one store and its listings.
+
+- `app/services/corpus/discogs_snapshot_exporter.rb`
+  - Pulls inventory pages from Discogs for a given username.
+  - Normalizes records to the snapshot JSON shape.
+  - Applies deterministic ordering and writes pretty JSON.
+
+- `app/services/corpus/discogs_snapshot_importer.rb`
+  - Reads snapshot JSON.
+  - Upserts store and listings using existing model constraints.
+  - Returns import summary (stores/listings inserted/updated/skipped).
+
+- `lib/tasks/corpus.rake`
+  - Defines `corpus:seed`, `corpus:refresh`, and `corpus:stats` tasks.
+
+- `spec/services/corpus/discogs_snapshot_importer_spec.rb`
+  - Verifies mapping/idempotency and required field handling.
+
+- `spec/tasks/corpus_rake_spec.rb`
+  - Verifies task invocation behavior and output expectations.
+
+- `README.md`
+  - Documents local workflow and command usage.
+
+### Runtime flows
+
+Refresh flow (`corpus:refresh`):
+
+1. Load username and optional page cap from task args.
+2. Fetch inventory pages through `DiscogsClient`.
+3. Keep only fields needed by app logic and UI.
+4. Sort listings deterministically.
+5. Write JSON snapshot to `db/corpus/discogs_store_snapshot.json`.
+6. Print summary stats.
+
+Seed flow (`corpus:seed`):
+
+1. Read snapshot JSON.
+2. Upsert store by `discogs_username`.
+3. Upsert listings by `discogs_listing_id` (same uniqueness key used in sync path).
+4. Update store counters/timestamps.
+5. Print import summary.
+
+Stats flow (`corpus:stats`):
+
+1. Parse snapshot JSON.
+2. Report listing count, unique genres/styles, date span, and file size.
+
+## Snapshot JSON Contract
+
+Path:
+
+- `db/corpus/discogs_store_snapshot.json`
+
+Top-level structure:
+
+```json
+{
+  "snapshot_version": 1,
+  "captured_at": "2026-04-17T16:30:00Z",
+  "source": {
+    "discogs_username": "philadelphiamusic",
+    "max_pages": 20,
+    "per_page": 100
+  },
+  "store": {
+    "name": "Philadelphia Music",
+    "discogs_username": "philadelphiamusic",
+    "description": "..."
+  },
+  "listings": [
+    {
+      "discogs_listing_id": "1234567890",
+      "discogs_release_id": "987654",
+      "artist": "Artist Name",
+      "title": "Album Title",
+      "label": "Label",
+      "year": 1978,
+      "format": "Vinyl, LP",
+      "genres": ["Electronic"],
+      "styles": ["Ambient"],
+      "condition": "VG+",
+      "price": "14.99",
+      "currency": "USD",
+      "thumbnail_url": "https://...",
+      "cover_image_url": "https://...",
+      "notes": "...",
+      "listed_at": "2026-03-22T18:12:01Z"
+    }
+  ]
+}
+```
+
+Notes:
+
+- URL fields remain plain strings only; images are not downloaded.
+- `listings` must be sorted by `discogs_listing_id` ascending for deterministic diffs.
+- Arrays (`genres`, `styles`) should be stable and compacted (no `nil`).
+
+## Detailed Behavior
+
+### Exporter (`corpus:refresh` backend)
+
+- Inputs:
+  - Required `username` argument.
+  - Optional `max_pages` argument (default set in task to avoid surprise API volume).
+- Uses the existing `DiscogsClient` to request inventory pages.
+- Applies same vinyl filtering rule as sync path (`Listing::VINYL_FORMATS`).
+- Transforms each listing into the snapshot contract.
+- Sorts and writes JSON with stable key order and pretty indentation.
+- Fails fast on API errors with a clear message.
+
+### Importer (`corpus:seed` backend)
+
+- Reads snapshot and validates required keys (`store`, `listings`).
+- Ensures target store exists via `find_or_initialize_by(discogs_username:)`.
+- Upserts listings using `Listing.upsert_all` or per-record upsert keyed by `discogs_listing_id`.
+- Sets `store_id` for all imported listings.
+- Updates store-level fields (`last_synced_at`, `total_listings`, `sync_status`) to an idle seeded state.
+- Idempotency guarantee: running seed repeatedly yields same record count and no duplicates.
+
+### Rake tasks
+
+- `corpus:refresh[username,max_pages]`
+  - Example: `bin/rails "corpus:refresh[philadelphiamusic,20]"`
+  - Rewrites `db/corpus/discogs_store_snapshot.json`.
+
+- `corpus:seed`
+  - Example: `bin/rails corpus:seed`
+  - Imports snapshot into current environment DB.
+
+- `corpus:stats`
+  - Example: `bin/rails corpus:stats`
+  - Prints size and composition stats.
+
+## Environment Behavior
+
+- Development:
+  - Default setup path can call `corpus:seed` after `db:prepare` to bootstrap realistic local data quickly.
+
+- Test:
+  - Test suite can use importer directly for corpus-backed integration specs where realistic inventory shape is beneficial.
+  - No external API calls required for these tests.
+
+## Error Handling
+
+- Missing snapshot file: `corpus:seed` exits with actionable guidance to run refresh or pull latest.
+- Invalid JSON/schema mismatch: explicit parser/validation error includes missing keys.
+- API failure during refresh: task raises and leaves existing snapshot untouched.
+- Empty API result: task writes valid empty-listings snapshot and prints warning.
+
+## Security and Compliance
+
+- Snapshot contains public marketplace metadata only.
+- No secrets or access tokens are written to file.
+- Task output must not print token values.
+
+## Testing Strategy
+
+### Service specs
+
+- Importer maps JSON fields to model attributes correctly.
+- Importer is idempotent across repeated runs.
+- Importer handles missing optional fields safely (`notes`, `styles`, `year`).
+
+### Task specs/smoke
+
+- `corpus:seed` imports expected counts from fixture.
+- `corpus:stats` prints expected headings and counts.
+- `corpus:refresh` command path is covered with client stubs (no live API in tests).
+
+### Regression safety
+
+- Existing picks selector spec should run against seeded data without API dependency.
+
+## Operational Workflow
+
+Recommended operator sequence:
+
+1. Refresh snapshot intentionally:
+   - `bin/rails "corpus:refresh[<discogs_username>,<max_pages>]"`
+2. Review diff in snapshot JSON.
+3. Run `bin/rails corpus:stats` and spot-check composition.
+4. Commit snapshot + code changes together.
+5. Seed local DB any time with `bin/rails corpus:seed`.
+
+## Open Decisions Resolved
+
+- Storage format: committed JSON fixture (not zip, not SQL dump).
+- Refresh cadence: manual only.
+- Primary optimization target: realistic algorithm behavior.
+
+## Success Criteria
+
+- Developer can rebuild DB and reseed realistic listings without Discogs API calls.
+- Seed operation is deterministic and idempotent.
+- Snapshot refresh is explicit, reviewable, and easy to run.
+- Picks algorithm work can proceed against stable corpus data in dev and test.

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -87,4 +87,32 @@ RSpec.describe PicksSelector do
       expect(scores.fetch(buried_gem)).to be > scores.fetch(generic_electronic)
     end
   end
+
+  describe "#score" do
+    it "boosts records with styles that are rare within the store catalog" do
+      selector = described_class.new(double("store"))
+
+      common_listing = FakeListing.new(
+        id: 100,
+        genres: [ "Electronic" ],
+        styles: [ "House" ],
+        condition: "VG+"
+      )
+
+      rare_style_listing = FakeListing.new(
+        id: 101,
+        genres: [ "Electronic" ],
+        styles: [ "Broken Beat" ],
+        condition: "VG+"
+      )
+
+      genre_counts = { "Electronic" => 6 }
+      style_counts = { "House" => 6, "Broken Beat" => 1 }
+
+      common_score = selector.send(:score, common_listing, genre_counts, style_counts)
+      rare_score = selector.send(:score, rare_style_listing, genre_counts, style_counts)
+
+      expect(rare_score).to be > common_score
+    end
+  end
 end

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+require "digest"
+require "active_support/core_ext/date/calculations"
+require_relative "../../app/services/picks_selector"
+
+RSpec.describe PicksSelector do
+  FakeRelation = Struct.new(:records) do
+    def where(id: nil)
+      return self unless id
+
+      self.class.new(records.select { |record| id.include?(record.id) })
+    end
+
+    def not(genres:)
+      filtered = records.reject do |record|
+        genres == "{}" && Array(record.genres).empty?
+      end
+
+      self.class.new(filtered)
+    end
+
+    def pluck(attribute)
+      records.map { |record| record.public_send(attribute) }
+    end
+
+    def to_a
+      records
+    end
+  end
+
+  FakeWhereChain = Struct.new(:relation) do
+    def not(**kwargs)
+      relation.not(**kwargs)
+    end
+  end
+
+  FakeListingsScope = Struct.new(:records) do
+    def where(*args, **kwargs)
+      return FakeWhereChain.new(FakeRelation.new(records)) if args.empty? && kwargs.empty?
+
+      FakeRelation.new(records).where(**kwargs)
+    end
+
+    def pluck(attribute)
+      records.map { |record| record.public_send(attribute) }
+    end
+  end
+
+  FakeListing = Struct.new(:id, :genres, :styles, :year, :condition, keyword_init: true) do
+    def primary_genre
+      genres.first
+    end
+  end
+
+  describe "#select" do
+    it "scores discovery records buried in crowded sections above safer generic picks" do
+      buried_gem = FakeListing.new(
+        id: 1,
+        genres: [ "Electronic" ],
+        styles: [ "Ambient" ],
+        year: 1992,
+        condition: "VG"
+      )
+      generic_electronic = FakeListing.new(
+        id: 2,
+        genres: [ "Electronic", "Jazz" ],
+        styles: [],
+        year: 1978,
+        condition: "VG+"
+      )
+      supporting_records = Array.new(16) do |index|
+        FakeListing.new(
+          id: index + 10,
+          genres: [ "Electronic" ],
+          styles: [],
+          year: 1995,
+          condition: "VG"
+        )
+      end
+
+      listings = [ buried_gem, generic_electronic ] + supporting_records
+      store = double("Store", listings: FakeListingsScope.new(listings))
+      selector = described_class.new(store)
+
+      scores = selector.send(:score_all).to_h
+
+      expect(scores.fetch(buried_gem)).to be > scores.fetch(generic_electronic)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Consolidates both open picks-algorithm branches into one conflict-resolved branch.
- Keeps both scoring refinements in `PicksSelector`: crowded-section buried-bin bonus and rare-style boost.
- Merges/retains research notes and test coverage from both prior PRs into a single coherent change set.

## Conflict resolution details
- `app/services/picks_selector.rb`: kept both new constants and both scoring branches.
- `spec/services/picks_selector_spec.rb`: retained buried-bin behavior spec and added rare-style scoring spec.
- `docs/milkcrate-picks-algorithm-research.md`: preserved both dated research sections (`2026-04-15` and `2026-04-16`).

## Supersedes
- #8
- #9

## Test Plan
- [ ] `bundle exec rspec spec/services/picks_selector_spec.rb` *(blocked locally: missing Bundler 4.0.8 in this environment)*