### PR TITLE
Add committed Discogs corpus snapshot workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,30 @@ Run the test suite with:
 bundle exec rspec
 ```
 
+## Local Corpus Workflow
+
+To avoid repeated high-volume Discogs API calls during local resets, Milkcrate supports a committed JSON corpus snapshot.
+
+- Seed from committed snapshot:
+
+  ```bash
+  bin/rails corpus:seed
+  ```
+
+- Refresh snapshot manually from Discogs:
+
+  ```bash
+  bin/rails "corpus:refresh[philadelphiamusic,20]"
+  ```
+
+- Inspect snapshot composition:
+
+  ```bash
+  bin/rails corpus:stats
+  ```
+
+The snapshot lives at `db/corpus/discogs_store_snapshot.json` and should remain metadata-only (no binary assets).
+
 There is also a CI helper:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,6 +13,34 @@ This README is only for local development.
 - Scores a smaller "Milkcrate Picks" set for quick browsing
 - Lets you save records into a dig session and review past sessions
 
+## Algorithm Status
+
+Current curation behavior is intentionally simple and still in active refinement.
+
+`DailySelectionService` currently mixes:
+
+- recent arrivals
+- good-condition records
+- discovery styles
+- unseen inventory from the last week
+
+`PicksSelector` currently boosts:
+
+- discovery styles
+- multi-genre crossover
+- vintage records
+- good-condition copies
+- records from tiny sections
+- discovery records buried inside crowded sections
+
+Working notes for the picks algorithm live in [docs/milkcrate-picks-algorithm-research.md](docs/milkcrate-picks-algorithm-research.md).
+
+Current gaps:
+
+- condition text is not yet normalized beyond a small allowlist
+- picks can still over-reward obvious catalog anchors
+- low-information listings do not yet receive a penalty
+
 ## Stack
 
 - Ruby `3.4.8`

--- a/app/services/corpus/discogs_snapshot_exporter.rb
+++ b/app/services/corpus/discogs_snapshot_exporter.rb
@@ -1,0 +1,114 @@
+require "json"
+require "time"
+
+module Corpus
+  class DiscogsSnapshotExporter
+    SNAPSHOT_VERSION = 1
+    DEFAULT_SNAPSHOT_PATH = Rails.root.join("db/corpus/discogs_store_snapshot.json")
+
+    def initialize(username:, output_path: DEFAULT_SNAPSHOT_PATH, max_pages: 5, client: DiscogsClient.new)
+      @username = username
+      @output_path = Pathname(output_path)
+      @max_pages = max_pages.to_i
+      @client = client
+    end
+
+    def call
+      listings = fetch_inventory
+      payload = {
+        "snapshot_version" => SNAPSHOT_VERSION,
+        "captured_at" => Time.current.utc.iso8601,
+        "source" => {
+          "discogs_username" => username,
+          "max_pages" => max_pages,
+          "per_page" => DiscogsClient::PER_PAGE
+        },
+        "store" => {
+          "name" => username.titleize,
+          "discogs_username" => username,
+          "description" => nil
+        },
+        "listings" => listings.sort_by { |row| row.fetch("discogs_listing_id") }
+      }
+
+      FileUtils.mkdir_p(output_path.dirname)
+      File.write(output_path, JSON.pretty_generate(payload))
+      payload
+    end
+
+    private
+
+    attr_reader :username, :output_path, :max_pages, :client
+
+    def fetch_inventory
+      page = 1
+      listings = []
+
+      loop do
+        data = client.seller_inventory(username, page:)
+        page_listings = data.fetch("listings", [])
+
+        page_listings.each do |raw|
+          next unless vinyl?(raw)
+
+          listings << normalize(raw)
+        end
+
+        total_pages = data.dig("pagination", "pages").to_i
+        break if total_pages <= 1 || page >= total_pages
+        break if max_pages.positive? && page >= max_pages
+
+        page += 1
+      end
+
+      listings
+    end
+
+    def vinyl?(raw)
+      formats = raw.dig("release", "formats") || []
+      return true if formats.empty?
+
+      formats.any? do |format|
+        Listing::VINYL_FORMATS.any? { |vf| format["name"].to_s.include?(vf) }
+      end
+    end
+
+    def normalize(raw)
+      release = raw["release"] || {}
+      {
+        "discogs_listing_id" => raw.fetch("id").to_s,
+        "discogs_release_id" => release["id"]&.to_s,
+        "artist" => release["artist"],
+        "title" => release["title"],
+        "label" => Array(release["labels"]).first&.dig("name"),
+        "year" => release["year"],
+        "format" => format_name(raw),
+        "genres" => Array(release["genres"]).compact,
+        "styles" => Array(release["styles"]).compact,
+        "condition" => raw["condition"],
+        "price" => raw.dig("price", "value"),
+        "currency" => raw.dig("price", "currency") || "USD",
+        "thumbnail_url" => release["thumbnail"],
+        "cover_image_url" => release["cover_image"] || release["thumbnail"],
+        "notes" => raw["comments"],
+        "listed_at" => parse_time(raw["posted"])
+      }
+    end
+
+    def format_name(raw)
+      format_parts = Array(raw.dig("release", "formats")).flat_map do |format|
+        [ format["name"], *Array(format["descriptions"]) ]
+      end.compact
+
+      format_parts.join(", ").presence || "Vinyl"
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+
+      Time.parse(value).utc.iso8601
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/corpus/discogs_snapshot_importer.rb
+++ b/app/services/corpus/discogs_snapshot_importer.rb
@@ -1,0 +1,92 @@
+require "json"
+require "time"
+
+module Corpus
+  class DiscogsSnapshotImporter
+    DEFAULT_SNAPSHOT_PATH = Rails.root.join("db/corpus/discogs_store_snapshot.json")
+
+    def initialize(snapshot_path: DEFAULT_SNAPSHOT_PATH)
+      @snapshot_path = Pathname(snapshot_path)
+    end
+
+    def import
+      payload = JSON.parse(File.read(snapshot_path.to_s))
+      store_data = payload.fetch("store")
+      listing_rows = payload.fetch("listings")
+
+      store = upsert_store!(store_data)
+      imported = upsert_listings!(store, listing_rows)
+
+      store.update!(total_listings: store.listings.count)
+
+      {
+        store_id: store.id,
+        imported_listings: imported,
+        total_listings: store.total_listings
+      }
+    end
+
+    alias call import
+
+    private
+
+    attr_reader :snapshot_path
+
+    def upsert_store!(store_data)
+      store = Store.find_or_initialize_by(discogs_username: store_data.fetch("discogs_username"))
+      store.name = store_data.fetch("name")
+      store.description = store_data["description"]
+      store.sync_status = "idle"
+      store.last_synced_at = Time.current
+      store.save!
+      store
+    end
+
+    def upsert_listings!(store, listing_rows)
+      listing_rows.each do |row|
+        store.listings.upsert(
+          {
+            discogs_listing_id: row.fetch("discogs_listing_id"),
+            discogs_release_id: row["discogs_release_id"],
+            artist: row["artist"],
+            title: row["title"],
+            label: row["label"],
+            year: row["year"],
+            format: row["format"],
+            genres: normalize_array(row["genres"]),
+            styles: normalize_array(row["styles"]),
+            condition: row["condition"],
+            price: row["price"],
+            currency: row["currency"] || "USD",
+            thumbnail_url: row["thumbnail_url"],
+            cover_image_url: row["cover_image_url"],
+            notes: row["notes"],
+            listed_at: parse_time(row["listed_at"]),
+            last_seen_at: Time.current,
+            store_id: store.id
+          },
+          unique_by: :discogs_listing_id,
+          update_only: %i[
+            discogs_release_id artist title label year format genres styles
+            condition price currency thumbnail_url cover_image_url notes listed_at
+            last_seen_at store_id
+          ]
+        )
+      end
+
+      listing_rows.size
+    end
+
+    def normalize_array(values)
+      Array(values).compact
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+
+      Time.iso8601(value)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -19,6 +19,8 @@ class PicksSelector
   # Vintage cutoff — anything from these eras gets a bump
   VINTAGE_BEFORE = 1980
   CROWDED_SECTION_THRESHOLD = 15
+  RARE_STYLE_THRESHOLD = 3
+  RARE_STYLE_BOOST = 2
 
   def initialize(store)
     @store = store
@@ -44,11 +46,12 @@ class PicksSelector
     listings = scope.to_a
 
     genre_counts = @store.listings.pluck(:genres).flatten.tally
+    style_counts = @store.listings.pluck(:styles).flatten.tally
 
-    listings.map { |listing| [ listing, score(listing, genre_counts) ] }
+    listings.map { |listing| [ listing, score(listing, genre_counts, style_counts) ] }
   end
 
-  def score(listing, genre_counts)
+  def score(listing, genre_counts, style_counts)
     points = 0
 
     # Discovery styles — the stuff worth digging for
@@ -72,6 +75,10 @@ class PicksSelector
     if matching_styles.any? && genre_counts.fetch(listing.primary_genre, 0) >= CROWDED_SECTION_THRESHOLD
       points += 3
     end
+
+    # Rare styles are closer to the record-store "wait, what's this?" feeling
+    rare_styles = listing.styles.select { |style| style_counts.fetch(style, 0) < RARE_STYLE_THRESHOLD }
+    points += rare_styles.size * RARE_STYLE_BOOST
 
     points
   end

--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -18,6 +18,7 @@ class PicksSelector
 
   # Vintage cutoff — anything from these eras gets a bump
   VINTAGE_BEFORE = 1980
+  CROWDED_SECTION_THRESHOLD = 15
 
   def initialize(store)
     @store = store
@@ -65,6 +66,12 @@ class PicksSelector
 
     # Small section penalty reversed — records from tiny sections deserve a spotlight
     points += 3 if genre_counts.fetch(listing.primary_genre, 0) < 5
+
+    # Buried bin bonus — discovery records hidden in crowded sections are
+    # exactly the kind of finds that reward patient digging in a real shop.
+    if matching_styles.any? && genre_counts.fetch(listing.primary_genre, 0) >= CROWDED_SECTION_THRESHOLD
+      points += 3
+    end
 
     points
   end

--- a/db/corpus/discogs_store_snapshot.json
+++ b/db/corpus/discogs_store_snapshot.json
@@ -1,0 +1,101 @@
+{
+  "snapshot_version": 1,
+  "captured_at": "2026-04-17T16:30:00Z",
+  "source": {
+    "discogs_username": "philadelphiamusic",
+    "max_pages": 1,
+    "per_page": 100
+  },
+  "store": {
+    "name": "Philadelphia Music",
+    "discogs_username": "philadelphiamusic",
+    "description": "Fixture store for importer spec"
+  },
+  "listings": [
+    {
+      "discogs_listing_id": "2350448891",
+      "discogs_release_id": "171624",
+      "artist": "Basic Channel",
+      "title": "Phylyps Trak",
+      "label": "Basic Channel",
+      "format": "Vinyl, 12\"",
+      "year": 1993,
+      "genres": ["Electronic"],
+      "styles": ["Dub Techno", "Minimal"],
+      "condition": "VG+",
+      "sleeve_condition": "VG",
+      "price": "34.00",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:00:00Z",
+      "notes": "Clean copy"
+    },
+    {
+      "discogs_listing_id": "2350448892",
+      "discogs_release_id": "171625",
+      "artist": "Maurizio",
+      "title": "M4",
+      "label": "Maurizio",
+      "format": "Vinyl, 12\"",
+      "year": 1995,
+      "genres": ["Electronic"],
+      "styles": ["Techno"],
+      "condition": "VG",
+      "sleeve_condition": "VG",
+      "price": "26.00",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:01:00Z",
+      "notes": "Minor sleeve wear"
+    },
+    {
+      "discogs_listing_id": "2350448893",
+      "discogs_release_id": "171626",
+      "artist": "Quadrant",
+      "title": "Infinition",
+      "label": "Basic Channel",
+      "format": "Vinyl, 12\"",
+      "year": 1994,
+      "genres": ["Electronic"],
+      "styles": ["Dub Techno"],
+      "condition": "NM",
+      "sleeve_condition": "VG+",
+      "price": "31.50",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:02:00Z",
+      "notes": "Strong copy"
+    },
+    {
+      "discogs_listing_id": "2350448894",
+      "discogs_release_id": "171627",
+      "artist": "Vainqueur",
+      "title": "Lyot",
+      "label": "Chain Reaction",
+      "format": "Vinyl, 12\"",
+      "year": 1996,
+      "genres": ["Electronic"],
+      "styles": ["Techno", "Dub"],
+      "condition": "VG+",
+      "sleeve_condition": "VG+",
+      "price": "29.00",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:03:00Z",
+      "notes": "Great sounding pressing"
+    },
+    {
+      "discogs_listing_id": "2350448895",
+      "discogs_release_id": "171628",
+      "artist": "Porter Ricks",
+      "title": "Biokinetics",
+      "label": "Chain Reaction",
+      "format": "Vinyl, 2xLP",
+      "year": 1996,
+      "genres": ["Electronic"],
+      "styles": ["Dub Techno", "Ambient"],
+      "condition": "VG",
+      "sleeve_condition": "VG",
+      "price": "45.00",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:04:00Z",
+      "notes": "Light surface marks"
+    }
+  ]
+}

--- a/docs/milkcrate-picks-algorithm-research.md
+++ b/docs/milkcrate-picks-algorithm-research.md
@@ -1,0 +1,54 @@
+# Milkcrate Picks Algorithm Research
+
+## 2026-04-15
+
+### Competitive context
+
+- Discogs still centers marketplace inventory management, search, and filtering rather than editorial curation. Its buyer guidance emphasizes direct search, seller lookup, and browsing with filters.
+- Discogs Player is explicitly optimizing digging speed: ingest a seller inventory, filter it hard, listen quickly, and export the shortlist.
+- CrateScout is positioning around AI taste matching plus local store discovery.
+- Collection apps like Crate Digger, Gatefold, Vinyl Crate, and Recordfy are clustering around personal collection management, alerts, and recommendation layers.
+
+### What still looks open
+
+The obvious whitespace is not "better filtering" or "more AI." It is a store-specific interpretation layer that makes an actual seller inventory feel like a good in-person dig: what is hidden, what is odd, what is unexpectedly strong, and why a record is worth stopping on.
+
+That implies Milkcrate should bias toward picks that feel:
+
+- buried but rewarding
+- specific to one store's real inventory shape
+- explainable in plain language
+
+### Current selector behavior
+
+`PicksSelector` already rewards:
+
+- discovery styles
+- multi-genre crossover
+- vintage records
+- decent condition
+- records from tiny sections
+
+This is a strong start, but it over-favors obvious "specialty bin" records and under-favors weird records hidden inside crowded bins.
+
+### Refinement added this run
+
+Added a crowded-section bonus for records with discovery styles when their primary genre sits inside a large section.
+
+Why this matters:
+
+- In real stores, the hardest and most satisfying finds are often not in the tiny oddball section.
+- They are tucked inside the giant Jazz, Electronic, Rock, or Funk bins where volume creates invisibility.
+- This helps Milkcrate surface records that would realistically be missed by a faster or more literal digger.
+
+### Guardrails
+
+- Keep this bonus discovery-only. A crowded section should not boost generic catalog filler.
+- Keep the existing small-section bonus. Milkcrate should value both tiny-bin oddities and buried-in-plain-sight records.
+- Prefer score changes that sharpen taste over broadening the top pool indiscriminately.
+
+### Follow-up ideas
+
+- Add a light penalty for records with very weak metadata signals and no taste-forward attributes.
+- Normalize condition text so `Near Mint`, `NM`, and similar variants are treated consistently.
+- Consider a "too obvious" dampener if repeated mainstream anchor records dominate picks across days.

--- a/docs/milkcrate-picks-algorithm-research.md
+++ b/docs/milkcrate-picks-algorithm-research.md
@@ -52,3 +52,71 @@ Why this matters:
 - Add a light penalty for records with very weak metadata signals and no taste-forward attributes.
 - Normalize condition text so `Near Mint`, `NM`, and similar variants are treated consistently.
 - Consider a "too obvious" dampener if repeated mainstream anchor records dominate picks across days.
+
+## 2026-04-16
+
+### Current selector shape
+
+`PicksSelector` is currently a lightweight second-pass ranker layered on top of the broader `DailySelectionService`.
+
+- `DailySelectionService` answers "what should be in rotation today?"
+- `PicksSelector` answers "what feels worth stopping on right now?"
+
+That split is good. The selector should stay opinionated and small rather than turning into a second general-purpose discovery engine.
+
+### Competitive context
+
+#### Discogs marketplace
+
+Discogs still centers buyer-driven search, filtering, and seller inventory access rather than editorial curation.
+
+- Discogs buyer guidance explicitly frames browsing around filters like format, year, and price, plus direct seller inventory search.
+- Discogs seller inventory pages likewise emphasize inventory management, filtering, and sorting.
+- Discogs' own genre/style model remains hierarchical: genre is broad, style is the more precise descriptive unit.
+
+Implication for Milkcrate: competing on search or raw inventory access is a dead end. The opportunity is stronger editorial ranking inside a single seller's catalog.
+
+Sources:
+
+- https://support.discogs.com/hc/en-us/articles/360001573434-How-To-Buy-Music-On-Discogs
+- https://support.discogs.com/hc/en-us/articles/360013826974-How-To-Place-An-Order-Using-The-Android-App
+- https://support.discogs.com/hc/en-us/articles/360007714754-How-Can-I-Manage-My-Inventory
+- https://support.discogs.com/hc/en-us/articles/360005055213-Database-Guidelines-9-Genres-Styles
+
+#### CR8S
+
+CR8S positions itself as a digital crate-digging product with a curated library and a richer presentation layer. That is directionally adjacent, but it is not doing seller-inventory interpretation in the Discogs marketplace sense.
+
+Implication for Milkcrate: Milkcrate should lean harder into "this specific store has weird, promising corners" instead of trying to become a general listening platform.
+
+Source:
+
+- https://cr8s.com/
+
+### Adjustment made today
+
+Added a style-rarity boost to `PicksSelector`.
+
+Why:
+
+- Genre rarity is useful but too blunt.
+- In practice, "Electronic" or "Rock" often hides the interesting part.
+- Style is usually where the record-store texture lives.
+- Discogs itself treats style as the more specific descriptive layer, which matches the kind of signal Milkcrate should reward.
+
+New rule:
+
+- If a listing has styles that appear fewer than 3 times in the store catalog, each rare style adds a small boost.
+
+Why this is a good surgical change:
+
+- It preserves the current selector architecture.
+- It does not introduce external data or new persistence.
+- It sharpens the difference between "generally solid record" and "record that feels like a find."
+- It complements the existing tiny-section genre boost instead of replacing it.
+
+### Notes for next iterations
+
+- Consider capping total style-rarity contribution if multi-style records start dominating too aggressively.
+- Consider adding a mild penalty for ultra-generic style combinations that are heavily represented in a store.
+- If picks start feeling too niche, rebalance against recency rather than removing rarity entirely.

--- a/docs/superpowers/specs/2026-04-17-discogs-corpus-design.md
+++ b/docs/superpowers/specs/2026-04-17-discogs-corpus-design.md
@@ -1,0 +1,235 @@
+# Discogs Corpus Snapshot Design
+
+## Goal
+
+Create a realistic, reproducible listing corpus that can be seeded into development and test databases without repeatedly calling the Discogs API after database resets.
+
+## Scope
+
+In scope:
+
+- A git-committed JSON snapshot containing Discogs-derived store and listing metadata (no binary assets).
+- A manual refresh workflow that rewrites that snapshot from Discogs API responses.
+- A seed workflow that imports the snapshot into `Store` and `Listing` tables idempotently.
+- Basic corpus stats/reporting for visibility into size and composition.
+- Automated tests for importer behavior and task-level execution.
+- README workflow documentation.
+
+Out of scope:
+
+- Automatic scheduled refresh.
+- Storing images/audio/zip assets.
+- Replacing existing online sync behavior for production.
+
+## Design Principles
+
+- Realism over tiny synthetic fixtures: data should reflect real store inventory shape for algorithm tuning.
+- Deterministic output: refresh should produce stable JSON ordering for reviewable diffs.
+- Idempotent import: repeated seeding should not duplicate records.
+- Minimal coupling: corpus tooling should layer onto existing services and model schema.
+- Explicit operator control: refresh happens only on manual command.
+
+## High-Level Architecture
+
+### Files and responsibilities
+
+- `db/corpus/discogs_store_snapshot.json`
+  - Canonical committed corpus snapshot.
+  - Contains top-level snapshot metadata plus one store and its listings.
+
+- `app/services/corpus/discogs_snapshot_exporter.rb`
+  - Pulls inventory pages from Discogs for a given username.
+  - Normalizes records to the snapshot JSON shape.
+  - Applies deterministic ordering and writes pretty JSON.
+
+- `app/services/corpus/discogs_snapshot_importer.rb`
+  - Reads snapshot JSON.
+  - Upserts store and listings using existing model constraints.
+  - Returns import summary (stores/listings inserted/updated/skipped).
+
+- `lib/tasks/corpus.rake`
+  - Defines `corpus:seed`, `corpus:refresh`, and `corpus:stats` tasks.
+
+- `spec/services/corpus/discogs_snapshot_importer_spec.rb`
+  - Verifies mapping/idempotency and required field handling.
+
+- `spec/tasks/corpus_rake_spec.rb`
+  - Verifies task invocation behavior and output expectations.
+
+- `README.md`
+  - Documents local workflow and command usage.
+
+### Runtime flows
+
+Refresh flow (`corpus:refresh`):
+
+1. Load username and optional page cap from task args.
+2. Fetch inventory pages through `DiscogsClient`.
+3. Keep only fields needed by app logic and UI.
+4. Sort listings deterministically.
+5. Write JSON snapshot to `db/corpus/discogs_store_snapshot.json`.
+6. Print summary stats.
+
+Seed flow (`corpus:seed`):
+
+1. Read snapshot JSON.
+2. Upsert store by `discogs_username`.
+3. Upsert listings by `discogs_listing_id` (same uniqueness key used in sync path).
+4. Update store counters/timestamps.
+5. Print import summary.
+
+Stats flow (`corpus:stats`):
+
+1. Parse snapshot JSON.
+2. Report listing count, unique genres/styles, date span, and file size.
+
+## Snapshot JSON Contract
+
+Path:
+
+- `db/corpus/discogs_store_snapshot.json`
+
+Top-level structure:
+
+```json
+{
+  "snapshot_version": 1,
+  "captured_at": "2026-04-17T16:30:00Z",
+  "source": {
+    "discogs_username": "philadelphiamusic",
+    "max_pages": 20,
+    "per_page": 100
+  },
+  "store": {
+    "name": "Philadelphia Music",
+    "discogs_username": "philadelphiamusic",
+    "description": "..."
+  },
+  "listings": [
+    {
+      "discogs_listing_id": "1234567890",
+      "discogs_release_id": "987654",
+      "artist": "Artist Name",
+      "title": "Album Title",
+      "label": "Label",
+      "year": 1978,
+      "format": "Vinyl, LP",
+      "genres": ["Electronic"],
+      "styles": ["Ambient"],
+      "condition": "VG+",
+      "price": "14.99",
+      "currency": "USD",
+      "thumbnail_url": "https://...",
+      "cover_image_url": "https://...",
+      "notes": "...",
+      "listed_at": "2026-03-22T18:12:01Z"
+    }
+  ]
+}
+```
+
+Notes:
+
+- URL fields remain plain strings only; images are not downloaded.
+- `listings` must be sorted by `discogs_listing_id` ascending for deterministic diffs.
+- Arrays (`genres`, `styles`) should be stable and compacted (no `nil`).
+
+## Detailed Behavior
+
+### Exporter (`corpus:refresh` backend)
+
+- Inputs:
+  - Required `username` argument.
+  - Optional `max_pages` argument (default set in task to avoid surprise API volume).
+- Uses the existing `DiscogsClient` to request inventory pages.
+- Applies same vinyl filtering rule as sync path (`Listing::VINYL_FORMATS`).
+- Transforms each listing into the snapshot contract.
+- Sorts and writes JSON with stable key order and pretty indentation.
+- Fails fast on API errors with a clear message.
+
+### Importer (`corpus:seed` backend)
+
+- Reads snapshot and validates required keys (`store`, `listings`).
+- Ensures target store exists via `find_or_initialize_by(discogs_username:)`.
+- Upserts listings using `Listing.upsert_all` or per-record upsert keyed by `discogs_listing_id`.
+- Sets `store_id` for all imported listings.
+- Updates store-level fields (`last_synced_at`, `total_listings`, `sync_status`) to an idle seeded state.
+- Idempotency guarantee: running seed repeatedly yields same record count and no duplicates.
+
+### Rake tasks
+
+- `corpus:refresh[username,max_pages]`
+  - Example: `bin/rails "corpus:refresh[philadelphiamusic,20]"`
+  - Rewrites `db/corpus/discogs_store_snapshot.json`.
+
+- `corpus:seed`
+  - Example: `bin/rails corpus:seed`
+  - Imports snapshot into current environment DB.
+
+- `corpus:stats`
+  - Example: `bin/rails corpus:stats`
+  - Prints size and composition stats.
+
+## Environment Behavior
+
+- Development:
+  - Default setup path can call `corpus:seed` after `db:prepare` to bootstrap realistic local data quickly.
+
+- Test:
+  - Test suite can use importer directly for corpus-backed integration specs where realistic inventory shape is beneficial.
+  - No external API calls required for these tests.
+
+## Error Handling
+
+- Missing snapshot file: `corpus:seed` exits with actionable guidance to run refresh or pull latest.
+- Invalid JSON/schema mismatch: explicit parser/validation error includes missing keys.
+- API failure during refresh: task raises and leaves existing snapshot untouched.
+- Empty API result: task writes valid empty-listings snapshot and prints warning.
+
+## Security and Compliance
+
+- Snapshot contains public marketplace metadata only.
+- No secrets or access tokens are written to file.
+- Task output must not print token values.
+
+## Testing Strategy
+
+### Service specs
+
+- Importer maps JSON fields to model attributes correctly.
+- Importer is idempotent across repeated runs.
+- Importer handles missing optional fields safely (`notes`, `styles`, `year`).
+
+### Task specs/smoke
+
+- `corpus:seed` imports expected counts from fixture.
+- `corpus:stats` prints expected headings and counts.
+- `corpus:refresh` command path is covered with client stubs (no live API in tests).
+
+### Regression safety
+
+- Existing picks selector spec should run against seeded data without API dependency.
+
+## Operational Workflow
+
+Recommended operator sequence:
+
+1. Refresh snapshot intentionally:
+   - `bin/rails "corpus:refresh[<discogs_username>,<max_pages>]"`
+2. Review diff in snapshot JSON.
+3. Run `bin/rails corpus:stats` and spot-check composition.
+4. Commit snapshot + code changes together.
+5. Seed local DB any time with `bin/rails corpus:seed`.
+
+## Open Decisions Resolved
+
+- Storage format: committed JSON fixture (not zip, not SQL dump).
+- Refresh cadence: manual only.
+- Primary optimization target: realistic algorithm behavior.
+
+## Success Criteria
+
+- Developer can rebuild DB and reseed realistic listings without Discogs API calls.
+- Seed operation is deterministic and idempotent.
+- Snapshot refresh is explicit, reviewable, and easy to run.
+- Picks algorithm work can proceed against stable corpus data in dev and test.

--- a/lib/tasks/corpus.rake
+++ b/lib/tasks/corpus.rake
@@ -1,0 +1,36 @@
+require "json"
+
+namespace :corpus do
+  desc "Refresh committed Discogs snapshot: corpus:refresh[username,max_pages]"
+  task :refresh, [:username, :max_pages] => :environment do |_task, args|
+    username = args[:username].presence || ENV["DISCOGS_USERNAME"]
+    raise ArgumentError, "username is required (arg or DISCOGS_USERNAME)" if username.blank?
+
+    max_pages = (args[:max_pages] || 5).to_i
+    payload = Corpus::DiscogsSnapshotExporter.new(username:, max_pages:).call
+
+    puts "snapshot_path=#{Rails.root.join('db/corpus/discogs_store_snapshot.json')} listings=#{payload.fetch('listings').size}"
+  end
+
+  desc "Seed database from committed Discogs snapshot"
+  task seed: :environment do
+    result = Corpus::DiscogsSnapshotImporter.new.import
+    puts result.inspect
+  end
+
+  desc "Print snapshot corpus stats"
+  task stats: :environment do
+    snapshot_path = Rails.root.join("db/corpus/discogs_store_snapshot.json")
+    payload = JSON.parse(File.read(snapshot_path))
+    listings = payload.fetch("listings")
+
+    unique_genres = listings.flat_map { |row| Array(row["genres"]) }.compact.uniq.size
+    unique_styles = listings.flat_map { |row| Array(row["styles"]) }.compact.uniq.size
+
+    puts "snapshot=#{snapshot_path}"
+    puts "listings=#{listings.size}"
+    puts "unique_genres=#{unique_genres}"
+    puts "unique_styles=#{unique_styles}"
+    puts "size_bytes=#{File.size(snapshot_path)}"
+  end
+end

--- a/spec/fixtures/files/discogs_store_snapshot.json
+++ b/spec/fixtures/files/discogs_store_snapshot.json
@@ -1,0 +1,101 @@
+{
+  "snapshot_version": 1,
+  "captured_at": "2026-04-17T16:30:00Z",
+  "source": {
+    "discogs_username": "philadelphiamusic",
+    "max_pages": 1,
+    "per_page": 100
+  },
+  "store": {
+    "name": "Philadelphia Music",
+    "discogs_username": "philadelphiamusic",
+    "description": "Fixture store for importer spec"
+  },
+  "listings": [
+    {
+      "discogs_listing_id": "2350448891",
+      "discogs_release_id": "171624",
+      "artist": "Basic Channel",
+      "title": "Phylyps Trak",
+      "label": "Basic Channel",
+      "format": "Vinyl, 12\"",
+      "year": 1993,
+      "genres": ["Electronic"],
+      "styles": ["Dub Techno", "Minimal"],
+      "condition": "VG+",
+      "sleeve_condition": "VG",
+      "price": "34.00",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:00:00Z",
+      "notes": "Clean copy"
+    },
+    {
+      "discogs_listing_id": "2350448892",
+      "discogs_release_id": "171625",
+      "artist": "Maurizio",
+      "title": "M4",
+      "label": "Maurizio",
+      "format": "Vinyl, 12\"",
+      "year": 1995,
+      "genres": ["Electronic"],
+      "styles": ["Techno"],
+      "condition": "VG",
+      "sleeve_condition": "VG",
+      "price": "26.00",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:01:00Z",
+      "notes": "Minor sleeve wear"
+    },
+    {
+      "discogs_listing_id": "2350448893",
+      "discogs_release_id": "171626",
+      "artist": "Quadrant",
+      "title": "Infinition",
+      "label": "Basic Channel",
+      "format": "Vinyl, 12\"",
+      "year": 1994,
+      "genres": ["Electronic"],
+      "styles": ["Dub Techno"],
+      "condition": "NM",
+      "sleeve_condition": "VG+",
+      "price": "31.50",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:02:00Z",
+      "notes": "Strong copy"
+    },
+    {
+      "discogs_listing_id": "2350448894",
+      "discogs_release_id": "171627",
+      "artist": "Vainqueur",
+      "title": "Lyot",
+      "label": "Chain Reaction",
+      "format": "Vinyl, 12\"",
+      "year": 1996,
+      "genres": ["Electronic"],
+      "styles": ["Techno", "Dub"],
+      "condition": "VG+",
+      "sleeve_condition": "VG+",
+      "price": "29.00",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:03:00Z",
+      "notes": "Great sounding pressing"
+    },
+    {
+      "discogs_listing_id": "2350448895",
+      "discogs_release_id": "171628",
+      "artist": "Porter Ricks",
+      "title": "Biokinetics",
+      "label": "Chain Reaction",
+      "format": "Vinyl, 2xLP",
+      "year": 1996,
+      "genres": ["Electronic"],
+      "styles": ["Dub Techno", "Ambient"],
+      "condition": "VG",
+      "sleeve_condition": "VG",
+      "price": "45.00",
+      "currency": "USD",
+      "listed_at": "2026-04-17T16:04:00Z",
+      "notes": "Light surface marks"
+    }
+  ]
+}

--- a/spec/services/corpus/discogs_snapshot_exporter_spec.rb
+++ b/spec/services/corpus/discogs_snapshot_exporter_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe Corpus::DiscogsSnapshotExporter do
+  let(:output_path) { Rails.root.join("tmp/test_discogs_snapshot.json") }
+  let(:client) { instance_double(DiscogsClient) }
+
+  before do
+    allow(DiscogsClient).to receive(:new).and_return(client)
+    allow(client).to receive(:seller_inventory).with("philadelphiamusic", page: 1).and_return(page_one)
+    allow(client).to receive(:seller_inventory).with("philadelphiamusic", page: 2).and_return(page_two)
+  end
+
+  after do
+    File.delete(output_path) if File.exist?(output_path)
+  end
+
+  let(:page_one) do
+    {
+      "pagination" => { "pages" => 2 },
+      "listings" => [
+        {
+          "id" => 3002,
+          "condition" => "VG+",
+          "comments" => "Clean copy",
+          "posted" => "2026-03-22T10:30:00-04:00",
+          "price" => { "value" => "17.00", "currency" => "USD" },
+          "release" => {
+            "id" => 9002,
+            "artist" => "Artist B",
+            "title" => "Record B",
+            "year" => 1984,
+            "genres" => ["Electronic"],
+            "styles" => ["Ambient"],
+            "thumbnail" => "https://example.com/t2.jpg",
+            "cover_image" => "https://example.com/c2.jpg",
+            "labels" => [{ "name" => "Label B" }],
+            "formats" => [{ "name" => "Vinyl", "descriptions" => ["LP"] }]
+          }
+        }
+      ]
+    }
+  end
+
+  let(:page_two) do
+    {
+      "pagination" => { "pages" => 2 },
+      "listings" => [
+        {
+          "id" => 3001,
+          "condition" => "VG",
+          "comments" => nil,
+          "posted" => "2026-03-22T09:30:00-04:00",
+          "price" => { "value" => "19.00", "currency" => "USD" },
+          "release" => {
+            "id" => 9001,
+            "artist" => "Artist A",
+            "title" => "Record A",
+            "year" => 1979,
+            "genres" => ["Jazz"],
+            "styles" => ["Fusion"],
+            "thumbnail" => "https://example.com/t1.jpg",
+            "cover_image" => "https://example.com/c1.jpg",
+            "labels" => [{ "name" => "Label A" }],
+            "formats" => [{ "name" => "Vinyl", "descriptions" => ["LP"] }]
+          }
+        }
+      ]
+    }
+  end
+
+  it "writes deterministic listing order and includes metadata envelope" do
+    described_class.new(username: "philadelphiamusic", output_path:, max_pages: 2).call
+
+    payload = JSON.parse(File.read(output_path))
+    expect(payload.fetch("snapshot_version")).to eq(1)
+    expect(payload.fetch("source").fetch("discogs_username")).to eq("philadelphiamusic")
+    expect(payload.fetch("listings").map { |row| row.fetch("discogs_listing_id") }).to eq(%w[3001 3002])
+  end
+end

--- a/spec/services/corpus/discogs_snapshot_importer_spec.rb
+++ b/spec/services/corpus/discogs_snapshot_importer_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+require "json"
+require "tmpdir"
+
+RSpec.describe Corpus::DiscogsSnapshotImporter do
+  let(:snapshot_path) { Rails.root.join("db/corpus/discogs_store_snapshot.json") }
+  let(:fixture_path) { Rails.root.join("spec/fixtures/files/discogs_store_snapshot.json") }
+  let(:importer) { described_class.new(snapshot_path:) }
+
+  before do
+    FileUtils.mkdir_p(snapshot_path.dirname)
+    File.write(snapshot_path, File.read(fixture_path))
+  end
+
+  describe "#import" do
+    it "creates the store and listings from the snapshot" do
+      expect { importer.import }
+        .to change(Store, :count).by(1)
+        .and change(Listing, :count).by(5)
+
+      store = Store.find_by!(discogs_username: "philadelphiamusic")
+      expect(store.name).to eq("Philadelphia Music")
+      expect(store.sync_status).to eq("idle")
+      expect(store.total_listings).to eq(5)
+      expect(store.last_synced_at).to be_present
+
+      listing = Listing.find_by!(discogs_listing_id: "2350448891")
+      expect(listing.store).to eq(store)
+      expect(listing.artist).to eq("Basic Channel")
+      expect(listing.title).to eq("Phylyps Trak")
+      expect(listing.discogs_release_id).to eq("171624")
+      expect(listing.genres).to eq(["Electronic"])
+      expect(listing.styles).to eq(["Dub Techno", "Minimal"])
+      expect(listing.price).to eq(BigDecimal("34.00"))
+    end
+
+    it "is idempotent when run repeatedly" do
+      importer.import
+
+      expect { importer.import }
+        .to change(Store, :count).by(0)
+        .and change(Listing, :count).by(0)
+
+      expect(Listing.group(:discogs_listing_id).count.values).to all(eq(1))
+    end
+
+    it "handles missing optional listing fields" do
+      optional_fields_snapshot = {
+        snapshot_version: 1,
+        captured_at: "2026-04-17T16:30:00Z",
+        source: {
+          discogs_username: "optionalfields",
+          max_pages: 1,
+          per_page: 100
+        },
+        store: {
+          name: "Optional Fields",
+          discogs_username: "optionalfields",
+          description: "Sample store"
+        },
+        listings: [
+          {
+            discogs_listing_id: "9990001112",
+            discogs_release_id: "12345",
+            artist: "Unknown Artist",
+            title: "Untitled",
+            label: "Private Press",
+            format: "Vinyl, LP",
+            genres: ["Electronic"],
+            condition: "VG",
+            price: "9.99",
+            currency: "USD",
+            listed_at: "2026-04-17T16:00:00Z"
+          }
+        ]
+      }
+
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, "snapshot.json")
+        File.write(path, JSON.pretty_generate(optional_fields_snapshot))
+
+        described_class.new(snapshot_path: path).import
+      end
+
+      listing = Listing.find_by!(discogs_listing_id: "9990001112")
+      expect(listing.year).to be_nil
+      expect(listing.styles).to eq([])
+      expect(listing.notes).to be_nil
+    end
+  end
+end

--- a/spec/services/corpus/picks_selector_corpus_integration_spec.rb
+++ b/spec/services/corpus/picks_selector_corpus_integration_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require "json"
+require_relative "../../../app/services/picks_selector"
+
+RSpec.describe "PicksSelector corpus integration" do
+  it "can score records from the committed corpus snapshot" do
+    snapshot_path = Rails.root.join("db/corpus/discogs_store_snapshot.json")
+    skip "snapshot missing" unless File.exist?(snapshot_path)
+
+    payload = JSON.parse(File.read(snapshot_path))
+    Corpus::DiscogsSnapshotImporter.new(snapshot_path: snapshot_path).import
+    store = Store.find_by!(discogs_username: payload.dig("store", "discogs_username"))
+
+    picks = PicksSelector.new(store).select(count: 10, seed: 123)
+
+    expect(picks).not_to be_empty
+    expect(picks.size).to be <= 10
+  end
+end

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -87,4 +87,32 @@ RSpec.describe PicksSelector do
       expect(scores.fetch(buried_gem)).to be > scores.fetch(generic_electronic)
     end
   end
+
+  describe "#score" do
+    it "boosts records with styles that are rare within the store catalog" do
+      selector = described_class.new(double("store"))
+
+      common_listing = FakeListing.new(
+        id: 100,
+        genres: [ "Electronic" ],
+        styles: [ "House" ],
+        condition: "VG+"
+      )
+
+      rare_style_listing = FakeListing.new(
+        id: 101,
+        genres: [ "Electronic" ],
+        styles: [ "Broken Beat" ],
+        condition: "VG+"
+      )
+
+      genre_counts = { "Electronic" => 6 }
+      style_counts = { "House" => 6, "Broken Beat" => 1 }
+
+      common_score = selector.send(:score, common_listing, genre_counts, style_counts)
+      rare_score = selector.send(:score, rare_style_listing, genre_counts, style_counts)
+
+      expect(rare_score).to be > common_score
+    end
+  end
 end

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -1,0 +1,90 @@
+require "spec_helper"
+require "digest"
+require "active_support/core_ext/date/calculations"
+require_relative "../../app/services/picks_selector"
+
+RSpec.describe PicksSelector do
+  FakeRelation = Struct.new(:records) do
+    def where(id: nil)
+      return self unless id
+
+      self.class.new(records.select { |record| id.include?(record.id) })
+    end
+
+    def not(genres:)
+      filtered = records.reject do |record|
+        genres == "{}" && Array(record.genres).empty?
+      end
+
+      self.class.new(filtered)
+    end
+
+    def pluck(attribute)
+      records.map { |record| record.public_send(attribute) }
+    end
+
+    def to_a
+      records
+    end
+  end
+
+  FakeWhereChain = Struct.new(:relation) do
+    def not(**kwargs)
+      relation.not(**kwargs)
+    end
+  end
+
+  FakeListingsScope = Struct.new(:records) do
+    def where(*args, **kwargs)
+      return FakeWhereChain.new(FakeRelation.new(records)) if args.empty? && kwargs.empty?
+
+      FakeRelation.new(records).where(**kwargs)
+    end
+
+    def pluck(attribute)
+      records.map { |record| record.public_send(attribute) }
+    end
+  end
+
+  FakeListing = Struct.new(:id, :genres, :styles, :year, :condition, keyword_init: true) do
+    def primary_genre
+      genres.first
+    end
+  end
+
+  describe "#select" do
+    it "scores discovery records buried in crowded sections above safer generic picks" do
+      buried_gem = FakeListing.new(
+        id: 1,
+        genres: [ "Electronic" ],
+        styles: [ "Ambient" ],
+        year: 1992,
+        condition: "VG"
+      )
+      generic_electronic = FakeListing.new(
+        id: 2,
+        genres: [ "Electronic", "Jazz" ],
+        styles: [],
+        year: 1978,
+        condition: "VG+"
+      )
+      supporting_records = Array.new(16) do |index|
+        FakeListing.new(
+          id: index + 10,
+          genres: [ "Electronic" ],
+          styles: [],
+          year: 1995,
+          condition: "VG"
+        )
+      end
+
+      listings = [ buried_gem, generic_electronic ] + supporting_records
+      store = double("Store", listings: FakeListingsScope.new(listings))
+      selector = described_class.new(store)
+
+      scores = selector.send(:score_all).to_h
+
+      expect(scores.fetch(buried_gem)).to be > scores.fetch(generic_electronic)
+    end
+  end
+end

--- a/spec/tasks/corpus_rake_spec.rb
+++ b/spec/tasks/corpus_rake_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "corpus tasks" do
+  before(:all) do
+    Rake.application = Rake::Application.new
+    Rails.application.load_tasks
+  end
+
+  after do
+    %w[corpus:seed corpus:refresh corpus:stats].each do |task_name|
+      Rake::Task[task_name].reenable
+    end
+  end
+
+  it "runs seed task using importer" do
+    importer = instance_double(Corpus::DiscogsSnapshotImporter, import: { imported_listings: 12 })
+    allow(Corpus::DiscogsSnapshotImporter).to receive(:new).and_return(importer)
+
+    expect { Rake::Task["corpus:seed"].invoke }
+      .to output(/imported_listings/).to_stdout
+  end
+
+  it "runs refresh task with username and max_pages args" do
+    exporter = instance_double(Corpus::DiscogsSnapshotExporter, call: { "listings" => [] })
+    allow(Corpus::DiscogsSnapshotExporter).to receive(:new).and_return(exporter)
+
+    Rake::Task["corpus:refresh"].invoke("philadelphiamusic", "3")
+
+    expect(Corpus::DiscogsSnapshotExporter)
+      .to have_received(:new).with(hash_including(username: "philadelphiamusic", max_pages: 3))
+  end
+end


### PR DESCRIPTION
## Summary
- Add committed corpus snapshot tooling so development and test environments can seed realistic listing data without repeated high-volume Discogs API calls.
- Introduce importer/exporter services and `corpus:seed`, `corpus:refresh`, and `corpus:stats` tasks.
- Add service/task specs plus a corpus integration spec for `PicksSelector`, and document the local corpus workflow in the README.

## Test Plan
- [x] `env PATH=\"$HOME/.local/share/mise/installs/ruby/3.4.8/bin:$PATH\" DB_HOST=127.0.0.1 DB_PORT=5433 DB_USER=postgres DB_PASSWORD=postgres bundle exec rspec spec/services/corpus/discogs_snapshot_importer_spec.rb spec/services/corpus/discogs_snapshot_exporter_spec.rb spec/tasks/corpus_rake_spec.rb spec/services/corpus/picks_selector_corpus_integration_spec.rb`