### PR TITLE
Refine Milkcrate Picks algorithm

### DIFF
--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -22,6 +22,14 @@ class PicksSelector
   RARE_STYLE_THRESHOLD = 3
   RARE_STYLE_BOOST = 2
 
+  # Condition variants that count as "good"
+  GOOD_CONDITIONS = %w[Mint NM M VG+].freeze
+  CONDITION_ALIASES = {
+    "near mint" => "NM",
+    "m-" => "M",
+    "mint-" => "M"
+  }.freeze
+
   def initialize(store)
     @store = store
   end
@@ -64,8 +72,10 @@ class PicksSelector
     # Vintage
     points += 2 if listing.year && listing.year < VINTAGE_BEFORE
 
-    # Good condition
-    points += 1 if %w[Mint NM M VG+].include?(listing.condition&.strip)
+    # Good condition (normalized: NM, Near Mint, M-, etc.)
+    good = GOOD_CONDITIONS.include?(listing.condition&.strip) ||
+           CONDITION_ALIASES.include?(listing.condition&.strip&.downcase)
+    points += 1 if good
 
     # Small section penalty reversed — records from tiny sections deserve a spotlight
     points += 3 if genre_counts.fetch(listing.primary_genre, 0) < 5
@@ -79,6 +89,12 @@ class PicksSelector
     # Rare styles are closer to the record-store "wait, what's this?" feeling
     rare_styles = listing.styles.select { |style| style_counts.fetch(style, 0) < RARE_STYLE_THRESHOLD }
     points += rare_styles.size * RARE_STYLE_BOOST
+
+    # Weak metadata penalty — records with no style, single genre, and no year
+    # are low-information and probably not worth digging for
+    if listing.styles.empty? && listing.genres.size <= 1 && listing.year.nil?
+      points -= 1
+    end
 
     points
   end

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -114,5 +114,29 @@ RSpec.describe PicksSelector do
 
       expect(rare_score).to be > common_score
     end
+
+    it "normalizes condition variants (NM, Near Mint, M-) to good condition" do
+      selector = described_class.new(double("store"))
+      conditions = %w[NM Near\ Mint M- VG+]
+      conditions.each do |cond|
+        listing = FakeListing.new(id: 200, genres: ["Rock"], styles: ["Classic Rock"], condition: cond)
+        score = selector.send(:score, listing, { "Rock" => 10 }, { "Classic Rock" => 10 })
+        expect(score).to be > 0, "expected #{cond.inspect} to count as good condition"
+      end
+    end
+
+    it "penalizes records with no style, no genre diversity, and no year" do
+      selector = described_class.new(double("store"))
+      weak = FakeListing.new(id: 300, genres: ["Rock"], styles: [], condition: "Generic", year: nil)
+      strong = FakeListing.new(id: 301, genres: ["Rock"], styles: ["Classic Rock"], year: 1975, condition: "VG+")
+
+      genre_counts = { "Rock" => 10 }
+      style_counts = { "Classic Rock" => 10 }
+
+      weak_score = selector.send(:score, weak, genre_counts, style_counts)
+      strong_score = selector.send(:score, strong, genre_counts, style_counts)
+
+      expect(strong_score).to be > weak_score
+    end
   end
 end


### PR DESCRIPTION
## Summary
Two targeted refinements to the `PicksSelector` scoring:

### Condition normalization
- Added `CONDITION_ALIASES` mapping variants like `"Near Mint"`, `"M-"`, `"near mint"` to their canonical forms
- `GOOD_CONDITIONS` constants expanded to handle text noise

### Weak metadata penalty  
- Records with no styles, a single genre, AND no year get a -1 penalty
- These are low-information catalog records that shouldn't surface as picks
- Prevents bare-bones entries from competing with properly described records

### Testing
- Added spec for condition variant normalization (NM, Near Mint, M-)
- Added spec for weak metadata penalty
- All 4 existing + new specs pass