### PR TITLE
Add PWA manifest and service worker

### DIFF
--- a/app/views/layouts/inertia_application.html.erb
+++ b/app/views/layouts/inertia_application.html.erb
@@ -3,6 +3,10 @@
   <head>
     <title><%= content_for(:title) || "Milkcrate" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="theme-color" content="#15120e" data-theme="dark">
+    <meta name="theme-color" content="#f2ebe0" data-theme="light">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="manifest" href="/manifest.json">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= yield :head %>
@@ -11,6 +15,9 @@
     <%= vite_client_tag %>
     <%= vite_react_refresh_tag %>
     <%= vite_javascript_tag "application.tsx" %>
+    <% if Rails.env.production? %>
+      <script>addEventListener("load", () => navigator.serviceWorker?.register("/sw.js"))</script>
+    <% end %>
   </head>
   <body class="mc-body min-h-screen">
     <%= yield %>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "Milkcrate",
+  "short_name": "Milkcrate",
+  "description": "Dig through record store crates",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#15120e",
+  "background_color": "#15120e",
+  "orientation": "portrait-primary"
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,2 @@
+self.addEventListener("install", () => self.skipWaiting())
+self.addEventListener("activate", () => self.clients.claim())


### PR DESCRIPTION
## Summary
- Add `public/manifest.json` with Milkcrate branding, standalone display, dark/light theme colors
- Add `public/sw.js` with basic skip-waiting and claim handler (caching layer can be added later)
- Add `<link rel="manifest">`, `<meta name="theme-color">`, and `<meta apple-mobile-web-app-capable>` to Inertia layout
- Register service worker in production only (avoids dev caching headaches)