### PR TITLE
Interactive crate UI with vertical drag and store view

### DIFF
--- a/app/frontend/components/crate_nav.tsx
+++ b/app/frontend/components/crate_nav.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+
+interface Props {
+  index: number
+  total: number
+  onPrev: () => void
+  onNext: () => void
+}
+
+export default function CrateNav({ index, total, onPrev, onNext }: Props) {
+  return (
+    <div className="flex items-center justify-between mt-4">
+      <span></span>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onPrev}
+          disabled={index <= 0}
+          className="text-xl cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          ‹
+        </button>
+        <span className="text-sm text-gray-400 tabular-nums">
+          {total > 0 ? index + 1 : 0} / {total}
+        </span>
+        <button
+          onClick={onNext}
+          disabled={index >= total - 1}
+          className="text-xl cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          ›
+        </button>
+      </div>
+      <span className="text-xs text-gray-600">← → to browse</span>
+    </div>
+  )
+}

--- a/app/frontend/components/crate_tabs.tsx
+++ b/app/frontend/components/crate_tabs.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import type { Crate } from "../types/inertia"
+
+interface Props {
+  crates: Crate[]
+  activeSlug: string
+  onSelect: (slug: string) => void
+}
+
+export default function CrateTabs({ crates, activeSlug, onSelect }: Props) {
+  return (
+    <div className="flex gap-1 overflow-x-auto pb-1" style={{ scrollbarWidth: "thin" }}>
+      {crates.map((crate) => (
+        <button
+          key={crate.slug}
+          onClick={() => onSelect(crate.slug)}
+          className={`whitespace-nowrap px-2.5 py-1 rounded text-xs sm:text-sm cursor-pointer transition-colors ${
+            crate.slug === activeSlug
+              ? "bg-mc-accent text-mc-bg font-medium"
+              : "bg-mc-bg-raised text-mc-text-dim hover:bg-mc-bg-card hover:text-mc-text"
+          }`}
+        >
+          {crate.name}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -1,0 +1,147 @@
+import React, { useState, useCallback, useEffect, useRef } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import CrateTabs from "./crate_tabs"
+import RecordCard from "./record_card"
+import type { Crate } from "../types/inertia"
+
+interface Props {
+  crates: Crate[]
+  activeSlug: string
+  onSelectCrate: (slug: string) => void
+  onToggleMode: () => void
+}
+
+const ease = { duration: 0.2, ease: "easeOut" }
+const DRAG_THRESHOLD = 80
+
+export default function CrateView({ crates, activeSlug, onSelectCrate, onToggleMode }: Props) {
+  const activeCrate = crates.find((c) => c.slug === activeSlug) ?? crates[0]
+  const records = activeCrate?.records ?? []
+  const total = records.length
+  const [index, setIndex] = useState(0)
+  const direction = useRef(0)
+
+  useEffect(() => { setIndex(0) }, [activeSlug])
+
+  const navigate = useCallback((delta: number) => {
+    const next = index + delta
+    if (next < 0 || next >= total) return
+    direction.current = delta
+    setIndex(next)
+  }, [index, total])
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "ArrowDown") navigate(1)
+    if (e.key === "ArrowUp") navigate(-1)
+  }, [navigate])
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [handleKeyDown])
+
+  const handleDragEnd = useCallback((_: any, info: { offset: { y: number } }) => {
+    if (info.offset.y > DRAG_THRESHOLD) navigate(1)
+    else if (info.offset.y < -DRAG_THRESHOLD) navigate(-1)
+  }, [navigate])
+
+  if (!activeCrate || total === 0) {
+    return (
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
+          <button onClick={onToggleMode} className="text-xs border border-mc-border rounded px-2 py-1 cursor-pointer hover:border-mc-accent transition-colors">🏪 Store</button>
+        </div>
+        <div className="py-16 text-center mc-dim text-sm">No records in this crate yet.</div>
+      </div>
+    )
+  }
+
+  const progress = total > 0 ? ((index + 1) / total) * 100 : 0
+
+  return (
+    <div className="flex flex-col">
+      {/* Top bar: crate tabs + store toggle */}
+      <div className="flex items-center justify-between mb-4">
+        <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
+        <button onClick={onToggleMode} className="shrink-0 text-xs border border-mc-border rounded px-2 py-1 cursor-pointer hover:border-mc-accent transition-colors ml-2">
+          🏪 Store
+        </button>
+      </div>
+
+      {/* Record display — single card, no depth */}
+      <div className="flex items-center justify-center min-h-[360px] md:min-h-[440px] py-4 sm:py-6 select-none">
+        <div style={{ width: "min(85vw, 300px)", height: "min(85vw, 300px)" }}>
+          <AnimatePresence mode="wait" custom={direction.current}>
+            <motion.div
+              key={records[index].id}
+              custom={direction.current}
+              variants={{
+                initial: (d: number) => d >= 0 ? { opacity: 0, y: -80 } : { opacity: 0, y: 80 },
+                animate: { opacity: 1, y: 0 },
+                exit: (d: number) => d >= 0 ? { opacity: 0, y: 60 } : { opacity: 0 },
+              }}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              transition={{ duration: 0.2, ease: "easeOut" }}
+              className="rounded-lg overflow-hidden border border-mc-border"
+              style={{
+                width: "100%",
+                height: "100%",
+                touchAction: "none",
+              }}
+              drag="y"
+              dragConstraints={{ top: 0, bottom: 0 }}
+              dragElastic={0.3}
+              whileDrag={{ scale: 0.97, y: 0 }}
+              onDragEnd={handleDragEnd}
+            >
+              <RecordCard listing={records[index]} />
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full max-w-xs sm:max-w-sm mx-auto mb-4">
+        <div className="h-1.5 bg-mc-bg-raised rounded-full overflow-hidden">
+          <motion.div
+            className="h-full bg-mc-accent rounded-full"
+            animate={{ width: `${progress}%` }}
+            transition={ease}
+          />
+        </div>
+      </div>
+
+      {/* Paginator */}
+      <div className="flex items-center justify-center gap-4 sm:gap-6">
+        <motion.button
+          onClick={() => navigate(-1)}
+          disabled={index <= 0}
+          whileTap={{ scale: 0.92 }}
+          className="flex items-center justify-center w-14 h-14 rounded-full bg-mc-bg-raised text-mc-text text-xl disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none"
+        >
+          ↑
+        </motion.button>
+
+        <span className="text-sm text-mc-text-dim tabular-nums w-20 text-center select-none">
+          {index + 1} of {total}
+        </span>
+
+        <motion.button
+          onClick={() => navigate(1)}
+          disabled={index >= total - 1}
+          whileTap={{ scale: 0.92 }}
+          className="flex items-center justify-center w-14 h-14 rounded-full bg-mc-bg-raised text-mc-text text-xl disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none"
+        >
+          ↓
+        </motion.button>
+      </div>
+
+      <p className="text-center text-[10px] text-mc-text-dim mt-4 select-none">
+        pull down to flip forward &middot; push up to go back &middot; ↓↑ keys &middot; tap to flip
+      </p>
+    </div>
+  )
+}

--- a/app/frontend/components/record_card.tsx
+++ b/app/frontend/components/record_card.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from "react"
+import { motion } from "framer-motion"
+import { router } from "@inertiajs/react"
+import type { Listing } from "../types/inertia"
+
+interface Props {
+  listing: Listing
+}
+
+export default function RecordCard({ listing }: Props) {
+  const [flipped, setFlipped] = useState(false)
+
+  const handleFlip = (e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest("a, button, form")) return
+    setFlipped((f) => !f)
+  }
+
+  const handleAdd = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    router.post(`/listings/${listing.id}/add_to_session`)
+  }
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    router.delete(`/listings/${listing.id}/remove_from_session`)
+  }
+
+  const meta = [listing.label, listing.year, listing.condition].filter(Boolean).join(" · ")
+
+  return (
+    <div
+      className="w-full h-full flex-shrink-0 cursor-pointer"
+      style={{ perspective: 800, touchAction: "none" }}
+      onClick={handleFlip}
+    >
+      <motion.div
+        style={{
+          width: "100%",
+          height: "100%",
+          position: "relative",
+          transformStyle: "preserve-3d",
+        }}
+        animate={{ rotateY: flipped ? 180 : 0 }}
+        transition={{ type: "spring", stiffness: 260, damping: 24 }}
+      >
+        {/* Front */}
+        <div
+          className="rounded-lg overflow-hidden shadow-xl"
+          style={{
+            position: "absolute",
+            inset: 0,
+            backfaceVisibility: "hidden",
+            WebkitBackfaceVisibility: "hidden",
+          }}
+        >
+          {listing.cover_image_url ? (
+            <img
+              src={listing.cover_image_url}
+              alt={listing.title ?? ""}
+              className="w-full h-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-mc-bg-raised text-mc-text-dim text-5xl">♪</div>
+          )}
+        </div>
+
+        {/* Back */}
+        <div
+          className="rounded-lg overflow-hidden shadow-xl bg-mc-bg-card"
+          style={{
+            position: "absolute",
+            inset: 0,
+            backfaceVisibility: "hidden",
+            WebkitBackfaceVisibility: "hidden",
+            transform: "rotateY(180deg)",
+          }}
+        >
+          <div className="flex flex-col h-full p-4 gap-2">
+            <div className="text-sm font-semibold leading-tight line-clamp-3">
+              {listing.title}
+            </div>
+            <div className="text-xs text-mc-text leading-tight">
+              {listing.artist}
+            </div>
+            {meta && (
+              <div className="text-xs text-mc-text-dim">{meta}</div>
+            )}
+            {listing.genres.length > 0 && (
+              <div className="flex gap-1 flex-wrap">
+                {listing.genres.slice(0, 3).map((g) => (
+                  <span key={g} className="text-[10px] px-1.5 py-0.5 rounded bg-mc-bg-raised text-mc-text-dim">
+                    {g}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="text-sm font-medium mt-auto">
+              {listing.price ? `$${parseFloat(listing.price).toFixed(2)}` : "—"}
+            </div>
+            <div className="flex gap-1 mt-1" onClick={(e) => e.stopPropagation()}>
+              {listing.in_pile ? (
+                <button onClick={handleRemove} className="mc-btn text-xs">
+                  ✓ In pile
+                </button>
+              ) : (
+                <button onClick={handleAdd} className="mc-btn mc-btn-primary text-xs">
+                  + Pile
+                </button>
+              )}
+              <a href={listing.discogs_url} target="_blank" rel="noopener" className="mc-btn text-xs">
+                Discogs ↗
+              </a>
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/app/frontend/components/record_stack.tsx
+++ b/app/frontend/components/record_stack.tsx
@@ -1,0 +1,91 @@
+import React, { useRef, useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import RecordCard from "./record_card"
+import type { Listing } from "../types/inertia"
+
+interface Props {
+  records: Listing[]
+  index: number
+}
+
+const slideVariants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 400 : -400,
+    rotate: direction > 0 ? -12 : 12,
+    opacity: 0,
+    scale: 0.92,
+  }),
+  center: {
+    x: 0,
+    rotate: 0,
+    opacity: 1,
+    scale: 1,
+  },
+  exit: (direction: number) => ({
+    x: direction > 0 ? -400 : 400,
+    rotate: direction > 0 ? 12 : -12,
+    opacity: 0,
+    scale: 0.92,
+  }),
+}
+
+const springTransition = {
+  type: "spring" as const,
+  stiffness: 280,
+  damping: 28,
+  mass: 0.9,
+}
+
+export default function RecordStack({ records, index }: Props) {
+  const prevIndex = useRef(index)
+  const direction = index - prevIndex.current
+
+  if (index !== prevIndex.current) {
+    prevIndex.current = index
+  }
+
+  return (
+    <div className="relative flex items-center justify-center" style={{ height: "420px" }}>
+      {/* Background depth cards */}
+      {[-2, -1].map((offset) => {
+        const i = index + offset
+        if (i < 0 || i >= records.length) return null
+
+        return (
+          <motion.div
+            key={records[i].id}
+            className="absolute pointer-events-none"
+            initial={false}
+            animate={{
+              rotate: offset * -3,
+              x: offset * -40,
+              y: offset * -6,
+              scale: 0.85 + offset * 0.05,
+              zIndex: 5 + offset,
+              opacity: 0.35 + offset * -0.15,
+            }}
+            transition={springTransition}
+          >
+            <RecordCard listing={records[i]} />
+          </motion.div>
+        )
+      })}
+
+      {/* Front/active record with enter/exit animation */}
+      <AnimatePresence mode="popLayout" custom={direction}>
+        <motion.div
+          key={records[index].id}
+          className="relative z-20"
+          custom={direction}
+          variants={slideVariants}
+          initial="enter"
+          animate="center"
+          exit="exit"
+          transition={springTransition}
+        >
+          <RecordCard listing={records[index]} />
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/app/frontend/components/store_view.tsx
+++ b/app/frontend/components/store_view.tsx
@@ -1,0 +1,82 @@
+import React from "react"
+import type { Crate } from "../types/inertia"
+
+interface Props {
+  crates: Crate[]
+  onOpenCrate: (slug: string) => void
+  onToggleMode: () => void
+}
+
+export default function StoreView({ crates, onOpenCrate, onToggleMode }: Props) {
+  const picks = crates.find((c) => c.slug === "picks")
+  const genreCrates = crates.filter((c) => c.slug !== "picks")
+
+  const genreEmoji = (name: string) => {
+    const lower = name.toLowerCase()
+    if (lower.includes("jazz")) return "🎷"
+    if (lower.includes("electronic")) return "⚡"
+    if (lower.includes("rock")) return "🎸"
+    if (lower.includes("funk") || lower.includes("soul")) return "🎵"
+    if (lower.includes("hip hop") || lower.includes("rap")) return "🎤"
+    if (lower.includes("pop")) return "🎼"
+    if (lower.includes("classical")) return "🎻"
+    if (lower.includes("reggae")) return "🌴"
+    if (lower.includes("latin")) return "💃"
+    if (lower.includes("folk") || lower.includes("country")) return "🪕"
+    if (lower.includes("blues")) return "🎹"
+    return "💿"
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-sm font-semibold">Store Overview</h2>
+        <button
+          onClick={onToggleMode}
+          className="text-xs border border-purple-500 rounded px-2 py-1 cursor-pointer hover:bg-purple-900 transition-colors"
+        >
+          📦 Crate view
+        </button>
+      </div>
+
+      {picks && picks.records.length > 0 && (
+        <div className="border border-gray-800 rounded mb-4">
+          <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800">
+            <span className="font-medium text-sm">✨ {picks.name}</span>
+            <span className="text-xs text-gray-500">{picks.count} records</span>
+          </div>
+          <div className="flex gap-1 overflow-x-auto px-3 py-2">
+            {picks.records.slice(0, 10).map((record) => (
+              <div key={record.id} className="flex-shrink-0 w-12 h-12 rounded bg-gray-800 overflow-hidden">
+                {record.thumbnail_url ? (
+                  <img src={record.thumbnail_url} alt="" className="w-full h-full object-cover" />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center text-gray-600 text-sm">♪</div>
+                )}
+              </div>
+            ))}
+          </div>
+          <div className="px-3 pb-2">
+            <button onClick={() => onOpenCrate("picks")} className="text-xs text-purple-400 cursor-pointer hover:text-purple-300">
+              Open crate →
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-2">
+        {genreCrates.map((crate) => (
+          <button
+            key={crate.slug}
+            onClick={() => onOpenCrate(crate.slug)}
+            className="border border-gray-800 rounded p-3 text-center cursor-pointer hover:border-gray-600 transition-colors"
+          >
+            <div className="text-lg">{genreEmoji(crate.name)}</div>
+            <div className="text-sm mt-1">{crate.name}</div>
+            <div className="text-xs text-gray-500">{crate.count} records</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/types/inertia.ts
+++ b/app/frontend/types/inertia.ts
@@ -1,0 +1,48 @@
+export interface Store {
+  id: number
+  name: string
+  discogs_username: string
+  description: string | null
+  total_listings: number | null
+  sync_status: string
+}
+
+export interface Listing {
+  id: number
+  discogs_listing_id: string
+  artist: string | null
+  title: string | null
+  label: string | null
+  year: number | null
+  format: string | null
+  genres: string[]
+  styles: string[]
+  condition: string | null
+  price: string
+  currency: string
+  cover_image_url: string | null
+  thumbnail_url: string | null
+  notes: string | null
+  discogs_url: string
+  in_pile: boolean
+}
+
+export interface Crate {
+  slug: string
+  name: string
+  count: number
+  records: Listing[]
+}
+
+export interface CurrentSession {
+  id: number
+  name: string
+  item_ids: number[]
+}
+
+export interface FeaturedProps {
+  store: Store
+  crates: Crate[]
+  active_crate_slug: string
+  current_session: CurrentSession | null
+}


### PR DESCRIPTION
## Summary
- **RecordCard**: React component with 3D flip animation (framer-motion), add/remove from pile
- **CrateView**: Vertical drag-to-flip crate navigation with AnimatePresence exit/enter animations
- **CrateTabs**: Horizontal scrollable tabs for switching between Picks, genres, sections
- **StoreView**: Genre grid overview with cover thumbnails and crate links
- **Types**: Shared TypeScript interfaces for store, crate, listing, session data

## Interaction
- Drag DOWN to flip forward (current slides/fades, next enters from above)
- Drag UP to go backward (current fades, previous slides up from below)
- Tap record to flip it over (cover → sleeve info)
- ↑↓ keyboard arrows, ↑↓ buttons, mobile swipe gestures
- Toggle between Crate mode (default) and Store overview

## Note
- Rubocop passes clean (no Ruby changes in this PR)
- Hotwire cleanup (remove old ERB, simplify controllers) is a separate PR
- Stack depth visualization is also separate