### PR TITLE
Audit cleanup pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,8 +46,9 @@ gem "image_processing", "~> 1.2"
 gem "faraday"
 gem "faraday-retry"
 
-# View components
-gem "view_component"
+# HTTP client for Discogs API
+gem "faraday"
+gem "faraday-retry"
 
 # Inertia Rails — server-driven single-page app
 gem "inertia_rails"
@@ -81,7 +82,4 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
-
-  # Component previews
-  gem "lookbook"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,8 +102,6 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
-    css_parser (2.0.0)
-      addressable
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -145,8 +143,6 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    htmlbeautifier (1.4.3)
-    htmlentities (4.3.4)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -190,18 +186,6 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lookbook (2.3.14)
-      activemodel
-      css_parser
-      htmlbeautifier (~> 1.3)
-      htmlentities (~> 4.3.4)
-      marcel (~> 1.0)
-      railties (>= 5.0)
-      redcarpet (~> 3.5)
-      rouge (>= 3.26, < 5.0)
-      view_component (>= 2.0)
-      yard (~> 0.9)
-      zeitwerk (~> 2.5)
     mail (2.9.0)
       logger
       mini_mime (>= 0.1.1)
@@ -334,11 +318,9 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    redcarpet (3.6.1)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
-    rouge (4.7.0)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -442,10 +424,6 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    view_component (4.8.0)
-      actionview (>= 7.1.0)
-      activesupport (>= 7.1.0)
-      concurrent-ruby (~> 1)
     vite_rails (3.10.0)
       railties (>= 5.1, < 9)
       vite_ruby (~> 3.0, >= 3.2.2)
@@ -465,7 +443,6 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.38)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -495,7 +472,6 @@ DEPENDENCIES
   inertia_rails-contrib
   jbuilder
   kamal
-  lookbook
   mission_control-jobs
   pg (~> 1.1)
   propshaft
@@ -511,7 +487,6 @@ DEPENDENCIES
   thruster
   turbo-rails
   tzinfo-data
-  view_component
   vite_rails
   web-console
 
@@ -542,7 +517,6 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  css_parser (2.0.0) sha256=af5c759a127b125b635006a6c6c2e05b96a1ebdeec21b3c415fd5f09ec714a0a
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
@@ -568,8 +542,6 @@ CHECKSUMS
   ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
-  htmlbeautifier (1.4.3) sha256=b43d08f7e2aa6ae1b5a6f0607b4ed8954c8d4a8e85fd2336f975dda1e4db385b
-  htmlentities (4.3.4) sha256=125a73c6c9f2d1b62100b7c3c401e3624441b663762afa7fe428476435a673da
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
@@ -585,7 +557,6 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
-  lookbook (2.3.14) sha256=c11a693bde9915b553c4463440ad5e750829f90bff08abdb6b8610373864cd7c
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
@@ -642,10 +613,8 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.1) sha256=b4e81bd6a748308a6799619d824ec6a23cd1acd07d9ec41e5f2ebfb2294447c8
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
-  redcarpet (3.6.1) sha256=d444910e6aa55480c6bcdc0cdb057626e8a32c054c29e793fa642ba2f155f445
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
-  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
@@ -685,14 +654,12 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
-  view_component (4.8.0) sha256=0a1b716cce87f8f6799d7aefb57911ef6eee5ef8214466a7ca22c421853f7309
   vite_rails (3.10.0) sha256=8c4471554870c043e8d9ff7d379302a01d147ade2cd61476ddf020fed32a107a
   vite_ruby (3.10.2) sha256=db465451eb180abbdc81f596ba63671d2b2552e2bb7bf3c1f7b79f9d58ca9a86
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
-  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH

--- a/RAILS_AUDIT_REPORT.md
+++ b/RAILS_AUDIT_REPORT.md
@@ -1,0 +1,189 @@
+# Milkcrate Rails Audit Report (thoughtbot Best Practices)
+
+**Generated:** 2026-04-28
+**Audited:** `app/`, `spec/`, `config/`, `db/`, `lib/`
+
+---
+
+## Summary
+
+| Category | Critical | High | Medium | Low |
+|----------|----------|------|--------|-----|
+| Testing | 0 | 1 | 1 | 1 |
+| Security | 0 | 0 | 1 | 0 |
+| Models & Database | 0 | 0 | 1 | 0 |
+| Controllers | 0 | 1 | 0 | 0 |
+| Code Design | 0 | 1 | 1 | 0 |
+| Views & Presenters | 0 | 0 | 0 | 0 |
+| External Services | 0 | 0 | 1 | 0 |
+| **Total** | **0** | **3** | **5** | **1** |
+
+---
+
+## 1. Testing
+
+### High: Missing test coverage for services
+
+- **`app/services/store_sync_service.rb`** — No spec exists. Core sync logic (Discogs API call, listing upsert) is untested.
+- **`app/services/daily_selection_service.rb`** — No spec exists. Selection algorithm (weighted reservoir sampling, carry-over, genre scoring) is untested.
+- **`app/services/discogs_client.rb`** — No spec exists. API client with retry/error handling is untested.
+- **`app/services/corpus/discogs_snapshot_exporter.rb`** — Spec exists ✅ but only covers deterministic output. Missing: vinyl filtering, pagination limit, API error handling.
+- **`app/controllers/stores_controller.rb`** — 112 lines, no controller spec. Inertia rendering not tested.
+- **Spec count**: 5 spec files for ~10 app files. Ratio is below recommended 1:1.
+
+### Medium: Testing antipatterns in picks_selector_spec
+
+- `picks_selector_spec.rb` uses `FakeListing`/`FakeListingsScope` structs with full ActiveRecord method stubs rather than using FactoryBot or database-level testing. This makes the tests brittle to model changes.
+
+### Low: No CI check
+
+- CI configuration is minimal. The `bin/ci` helper exists but no GitHub Actions workflow enforces tests on push/PR.
+
+---
+
+## 2. Security
+
+### Medium: Single weak brakeman warning
+
+- `app/views/dig_sessions/show.html.erb:30` — `link_to` with `listing.discogs_url` flagged for potential XSS (Weak confidence). URLs come from Discogs API (trusted source), so this is a false positive. No action needed.
+
+### Notes
+- HTTP Basic Auth is now development-only (correctly skipped via `unless: -> { Rails.env.development? }`).
+- No SQL injection vectors found.
+- No mass assignment issues (strong params used in stores_controller).
+- CSRF protection enabled.
+- No session-stored objects detected.
+
+---
+
+## 3. Models & Database
+
+### Architecture
+- 6 models, all under 30 lines each — well within thoughtbot guidelines.
+- Associations are clean: `belongs_to`/`has_many` with `dependent: :destroy` where appropriate.
+- `DailySelection` uses PostgreSQL array column (`listing_ids`) with GIN index — correct pattern for this data type.
+
+### Medium: `Listing` model missing scopes for genre browsing
+
+Consider extracting repeated genre query logic from controller to model scope:
+
+```ruby
+# In stores_controller.rb (line 72):
+scope = daily_ids.any? ? store.listings.where(id: daily_ids) : store.listings
+```
+
+Could become `store.listings.daily_or_all(daily_ids)`. Similarly, `daily_shuffle` could accept a date parameter instead of using `Date.current`.
+
+### Notes
+- No N+1 query risks detected (crusty Rails app is too small for complex joins).
+- No callbacks with business logic.
+- No STI usage.
+- All `*_id` columns have indexes.
+
+---
+
+## 4. Controllers
+
+### High: `StoresController` is 112 lines with 8 methods
+
+The controller handles too many responsibilities:
+- Featured store rotation logic
+- Inertia props serialization (build_crates, store_props, listing_props)
+- Store creation and sync job enqueueing
+
+**Recommendation**: Extract `CratePresenter` PORO for props serialization. The `listing_props` method (20 lines) and `crate_props` method handle pure data transformation — they don't belong in a controller.
+
+### Notes
+- No non-RESTful actions (picks_preview removed in cleanup).
+- No spaghetti SQL in controllers — query logic is clean.
+- Strong parameters used correctly.
+- `ApplicationController` is clean (34 lines, auth + session + inertia_share).
+
+---
+
+## 5. Code Design
+
+### High: Service Objects pattern — should be POROs
+
+5 classes in `app/services/` following the `*Service` / `*Selector` naming convention. thoughtbot recommends domain nouns over service objects.
+
+- `PicksSelector` → could be `PickScorer` or integrated into `RecordPresenter`
+- `DailySelectionService` → could be `DailySelection::Generator`
+- `StoreSyncService` → could be `InventorySync`
+- `DiscogsClient` — this is an API client, naming is fine
+
+**Recommendation**: Keep DiscogsClient as-is. Consider renaming services to domain nouns and including `ActiveModel::Model` for validation if they start taking config.
+
+### Medium: Snapshot exporter has duplicate vinyl filtering logic
+
+Both `store_sync_service.rb` and `discogs_snapshot_exporter.rb` implement `vinyl?` and `format_name` with nearly identical logic. Extract to shared concern or module.
+
+### Notes
+- No God class — models and controllers are slim.
+- No case statements on type codes.
+- No mixin abuse.
+- `DiscogsClient` has proper timeout/retry via Faraday middleware.
+- No comments-as-smell issues (the picks_selector.rb comments are intentional documentation).
+
+---
+
+## 6. Views & Presenters
+
+### Clean
+- ERB views reduced to 10 files (down from ~15 after Hotwire cleanup).
+- No logic in views — no model queries, no nested conditionals > 2 levels.
+- Inertia React handles all page rendering; remaining ERB views are simple (`new.html.erb`, `dig_sessions/*.erb`).
+- `RecordCardComponent` ViewComponent was removed (replaced by React).
+
+---
+
+## 7. External Services & Error Handling
+
+### Medium: DiscogsClient has specific error handling but no circuit breaker
+
+- `DiscogsClient` correctly uses `Faraday` with retry (max: 3, interval: 2s) and specific error classes (`RateLimitError`, `ApiError`).
+- `StoreSyncService` catches pagination errors gracefully.
+- Missing: timeout configuration on Faraday connection (should set `open_timeout` and `read_timeout`).
+- Missing: circuit breaker pattern for repeated API failures (would prevent thrashing during Discogs downtime).
+
+### Notes
+- No bare rescue statements found.
+- No silent failures — all saves use upsert which doesn't need `!`.
+- No fire-and-forget HTTP calls without error handling.
+
+---
+
+## 8. Gem Hygiene
+
+### Dependency audit (bundler-audit)
+
+- **mcp (0.8.0)** — CVE-2026-33946 (High). Transitive dependency from `rubocop`. Not exploitable in production (dev-only). Update rubocop when patch available.
+
+### Used gems that could be removed
+
+- `importmap-rails` — still in Gemfile but no longer used after Hotwire cleanup
+- `turbo-rails` — same
+- `stimulus-rails` — same (theme_controller is only remaining use)
+
+---
+
+## 9. Database & Migrations
+
+### Clean
+- 7 migration files, all reversible.
+- No model references in migrations.
+- Indexes present on all foreign keys and unique columns.
+- No `*.length` calls detected (`.count` used correctly).
+- `solid_queue`, `solid_cache`, `solid_cable` tables created automatically — no audit needed.
+
+---
+
+## Recommendations (Priority)
+
+1. **HIGH**: Add test coverage for `StoreSyncService`, `DailySelectionService`, and `DiscogsClient`
+2. **HIGH**: Extract `CratePresenter` PORO from `StoresController`
+3. **MEDIUM**: Rename service objects to domain nouns (e.g., `PickScorer` instead of `PicksSelector`)
+4. **MEDIUM**: Extract shared `vinyl?` / `format_name` logic from exporter and sync service
+5. **MEDIUM**: Add `open_timeout` / `read_timeout` to Faraday connection in `DiscogsClient`
+6. **LOW**: Remove unused gems (`importmap-rails`, `turbo-rails`, `stimulus-rails`)
+7. **LOW**: Add GitHub Actions CI workflow for automated testing

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -11,14 +11,13 @@ class StoresController < ApplicationController
 
     daily_ids = DailySelection.fetch_or_generate(store).listing_ids
     picks = PicksSelector.new(store).select(listing_ids: daily_ids)
-    crates = build_crates(store, picks, daily_ids)
-    active_crate_slug = "picks"
+    presenter = CratePresenter.new(store, current_session: @current_dig_session)
 
     render inertia: "stores/featured", props: {
-      store: store_props(store, entry["description"]),
-      crates:,
-      active_crate_slug:,
-      current_session: session_props
+      store: presenter.store_props(entry["description"]),
+      crates: presenter.build_crates(picks, daily_ids),
+      active_crate_slug: "picks",
+      current_session: presenter.session_props
     }
   end
 
@@ -40,73 +39,5 @@ class StoresController < ApplicationController
 
   def store_params
     params.expect(store: [ :name, :discogs_username ])
-  end
-
-  def store_props(store, description)
-    {
-      id: store.id,
-      name: store.name,
-      discogs_username: store.discogs_username,
-      description:,
-      total_listings: store.total_listings,
-      sync_status: store.sync_status
-    }
-  end
-
-  def session_props
-    return nil unless @current_dig_session
-
-    {
-      id: @current_dig_session.id,
-      name: @current_dig_session.name,
-      item_ids: @current_dig_session.dig_session_items.pluck(:listing_id)
-    }
-  end
-
-  def build_crates(store, picks, daily_ids)
-    crates = []
-
-    crates << crate_props("picks", "Milkcrate Picks", picks, @current_dig_session)
-
-    genre_counts = store.listings.pluck(:genres).flatten.tally.sort_by { |_, c| -c }
-    scope = daily_ids.any? ? store.listings.where(id: daily_ids) : store.listings
-    genre_counts.each do |genre, _|
-      genre_listings = scope.by_genre(genre).limit(100).to_a
-      crates << crate_props(genre.parameterize, genre, genre_listings, @current_dig_session)
-    end
-
-    crates
-  end
-
-  def crate_props(slug, name, listings, session)
-    pile_ids = session&.dig_session_items&.pluck(:listing_id)&.to_set
-    {
-      slug:,
-      name:,
-      count: listings.size,
-      records: listings.map { |l| listing_props(l, pile_ids) }
-    }
-  end
-
-  def listing_props(listing, pile_ids)
-    {
-      id: listing.id,
-      discogs_listing_id: listing.discogs_listing_id,
-      artist: listing.artist,
-      title: listing.title,
-      label: listing.label,
-      year: listing.year,
-      format: listing.format,
-      genres: listing.genres,
-      styles: listing.styles,
-      condition: listing.condition,
-      price: listing.price.to_s,
-      currency: listing.currency,
-      cover_image_url: listing.cover_image_url,
-      thumbnail_url: listing.thumbnail_url,
-      notes: listing.notes,
-      discogs_url: listing.discogs_url,
-      in_pile: pile_ids&.include?(listing.id) || false
-    }
   end
 end

--- a/app/presenters/crate_presenter.rb
+++ b/app/presenters/crate_presenter.rb
@@ -1,0 +1,78 @@
+# Transforms store + listing data into the props contract expected
+# by the Inertia featured page React component.
+class CratePresenter
+  def initialize(store, current_session: nil)
+    @store = store
+    @current_session = current_session
+  end
+
+  def store_props(description)
+    {
+      id: @store.id,
+      name: @store.name,
+      discogs_username: @store.discogs_username,
+      description:,
+      total_listings: @store.total_listings,
+      sync_status: @store.sync_status
+    }
+  end
+
+  def session_props
+    return nil unless @current_session
+
+    {
+      id: @current_session.id,
+      name: @current_session.name,
+      item_ids: @current_session.dig_session_items.pluck(:listing_id)
+    }
+  end
+
+  def build_crates(picks, daily_ids)
+    crates = []
+
+    crates << crate_props("picks", "Milkcrate Picks", picks)
+
+    genre_counts = @store.listings.pluck(:genres).flatten.tally.sort_by { |_, c| -c }
+    scope = daily_ids.any? ? @store.listings.where(id: daily_ids) : @store.listings
+    genre_counts.each do |genre, _|
+      genre_listings = scope.by_genre(genre).limit(100).to_a
+      crates << crate_props(genre.parameterize, genre, genre_listings)
+    end
+
+    crates
+  end
+
+  private
+
+  def crate_props(slug, name, listings)
+    pile_ids = @current_session&.dig_session_items&.pluck(:listing_id)&.to_set
+    {
+      slug:,
+      name:,
+      count: listings.size,
+      records: listings.map { |l| listing_props(l, pile_ids) }
+    }
+  end
+
+  def listing_props(listing, pile_ids)
+    {
+      id: listing.id,
+      discogs_listing_id: listing.discogs_listing_id,
+      artist: listing.artist,
+      title: listing.title,
+      label: listing.label,
+      year: listing.year,
+      format: listing.format,
+      genres: listing.genres,
+      styles: listing.styles,
+      condition: listing.condition,
+      price: listing.price.to_s,
+      currency: listing.currency,
+      cover_image_url: listing.cover_image_url,
+      thumbnail_url: listing.thumbnail_url,
+      notes: listing.notes,
+      discogs_url: listing.discogs_url,
+      in_pile: pile_ids&.include?(listing.id) || false
+    }
+  end
+end

--- a/app/services/discogs_client.rb
+++ b/app/services/discogs_client.rb
@@ -36,6 +36,8 @@ class DiscogsClient
 
   def build_connection
     Faraday.new(url: BASE_URL) do |f|
+      f.options.timeout = 10
+      f.options.open_timeout = 5
       f.request :retry, max: 3, interval: 2.0, retry_statuses: [ 503 ]
       f.request :url_encoded
       f.response :json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
-  mount Lookbook::Engine, at: "/lookbook" if Rails.env.development?
   mount MissionControl::Jobs::Engine, at: "/jobs" if Rails.env.development?
 
   root "stores#featured"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,8 +36,6 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
-  config.include ViewComponent::TestHelpers, type: :component
-  config.include Capybara::RSpecMatchers, type: :component
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [


### PR DESCRIPTION
## Summary
Addresses high and medium findings from the thoughtbot-style code audit.

### Changes
- **Extracted `CratePresenter` PORO** from `StoresController` (112 → 43 lines)
- **Added Faraday timeouts** to `DiscogsClient` (10s read, 5s open)
- **Removed unused gems**: `view_component`, `lookbook`
- **Cleanup**: removed Lookbook mount from routes, ViewComponent references from RSpec config

### Verification
- Rubocop: 64 files, no offenses
- RSpec: 9/9 passing