### PR TITLE
Add RSpec job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,28 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  test_js:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Run frontend lib tests
+        run: npm run test:frontend
+
+      - name: Run component tests
+        run: npm run test:components
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,18 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Build Vite assets
+        run: bin/vite build --mode=test
+
       - name: Set up database
         run: bin/rails db:create db:schema:load
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,8 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Load database schema
-        run: bin/rails db:schema:load
+      - name: Set up database
+        run: bin/rails db:create db:schema:load
 
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,41 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: ["5432:5432"]
+
+    env:
+      RAILS_ENV: test
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Load database schema
+        run: bin/rails db:schema:load
+
+      - name: Run tests
+        run: bundle exec rspec
+


### PR DESCRIPTION
## Summary

- Adds `test` job to `.github/workflows/ci.yml`
- Runs `bundle exec rspec` against PostgreSQL 16 on every push to `main` and all PRs
- Loads schema via `db:schema:load` before test run
- No `RAILS_MASTER_KEY` needed — credentials only used in production

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm `test` job appears in GitHub Actions tab
- [ ] Enable branch protection on `main` requiring `test` status check after workflow is green

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)