### PR TITLE
Introduce StorefrontCuration as single curation interface

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -18,12 +18,12 @@ class StoresController < ApplicationController
   private
 
   def render_store(store)
-    selector = PicksSelector.new(store)
+    curation  = StorefrontCuration.new(store)
     presenter = CratePresenter.new(store)
 
     render inertia: "stores/featured", props: {
       store: presenter.store_props,
-      crates: presenter.build_crates(selector),
+      crates: presenter.build_crates(curation),
       active_crate_slug: "picks"
     }
   end

--- a/app/presenters/crate_presenter.rb
+++ b/app/presenters/crate_presenter.rb
@@ -14,25 +14,11 @@ class CratePresenter
     }
   end
 
-  def build_crates(selector)
-    picks = selector.select_picks(count: 12)
-    crates = [ crate_props("picks", "Milkcrate Picks", picks) ]
+  def build_crates(curation)
+    crates = [ crate_props("picks", "Milkcrate Picks", curation.picks) ]
 
-    picks_ids = picks.map(&:id).to_set
-
-    genre_counts = @store.listings.available.lp_only
-      .pluck(:genres)
-      .map(&:first)
-      .compact
-      .tally
-      .sort_by { |_, c| -c }
-
-    genre_counts.each do |genre, _|
-      genre_listings = selector.rank_genre(genre)
-        .reject { |l| picks_ids.include?(l.id) }
-        .first(50)
-      next if genre_listings.empty?
-      crates << crate_props(genre.parameterize, genre, genre_listings)
+    curation.genre_crates.each do |genre, listings|
+      crates << crate_props(genre.parameterize, genre, listings)
     end
 
     crates

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -1,0 +1,36 @@
+class StorefrontCuration
+  def initialize(store)
+    @store = store
+  end
+
+  def picks
+    selector.select_picks(count: 12)
+  end
+
+  def genre_crates
+    picks_ids = picks.map(&:id).to_set
+
+    genre_counts.filter_map do |genre, _|
+      listings = selector.rank_genre(genre)
+        .reject { |l| picks_ids.include?(l.id) }
+        .first(50)
+      next if listings.empty?
+      [ genre, listings ]
+    end.to_h
+  end
+
+  private
+
+  def selector
+    @selector ||= PicksSelector.new(@store)
+  end
+
+  def genre_counts
+    @genre_counts ||= @store.listings.available.lp_only
+      .pluck(:genres)
+      .map(&:first)
+      .compact
+      .tally
+      .sort_by { |_, c| -c }
+  end
+end

--- a/spec/presenters/crate_presenter_spec.rb
+++ b/spec/presenters/crate_presenter_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe CratePresenter do
     store
   end
 
-  def fake_selector(picks: [], genre_map: {})
-    selector = double("PicksSelector")
-    allow(selector).to receive(:select_picks).and_return(picks)
-    allow(selector).to receive(:rank_genre) { |genre| genre_map.fetch(genre, []) }
-    selector
+  def fake_curation(picks: [], genre_crates: {})
+    curation = double("StorefrontCuration")
+    allow(curation).to receive(:picks).and_return(picks)
+    allow(curation).to receive(:genre_crates).and_return(genre_crates)
+    curation
   end
 
   describe "#store_props" do
@@ -113,18 +113,18 @@ RSpec.describe CratePresenter do
     let(:rock) { fake_listing(id: 2, genres: [ "Rock" ]) }
 
     it "places picks first with slug 'picks'" do
-      store    = fake_store(listings: [ jazz ])
-      selector = fake_selector(picks: [ jazz ])
-      crates   = described_class.new(store).build_crates(selector)
+      store    = fake_store
+      curation = fake_curation(picks: [ jazz ])
+      crates   = described_class.new(store).build_crates(curation)
 
       expect(crates.first[:slug]).to eq("picks")
       expect(crates.first[:name]).to eq("Milkcrate Picks")
     end
 
     it "includes picks records in the first crate" do
-      store    = fake_store(listings: [ jazz ])
-      selector = fake_selector(picks: [ jazz ])
-      crates   = described_class.new(store).build_crates(selector)
+      store    = fake_store
+      curation = fake_curation(picks: [ jazz ])
+      crates   = described_class.new(store).build_crates(curation)
 
       expect(crates.first[:count]).to eq(1)
       expect(crates.first[:records].first[:id]).to eq(1)
@@ -132,26 +132,26 @@ RSpec.describe CratePresenter do
 
     it "parameterizes multi-word genre names as slugs" do
       hip_hop  = fake_listing(id: 3, genres: [ "Hip Hop" ])
-      store    = fake_store(listings: [ hip_hop ])
-      selector = fake_selector(genre_map: { "Hip Hop" => [ hip_hop ] })
-      crates   = described_class.new(store).build_crates(selector)
+      store    = fake_store
+      curation = fake_curation(genre_crates: { "Hip Hop" => [ hip_hop ] })
+      crates   = described_class.new(store).build_crates(curation)
 
       expect(crates.map { |c| c[:slug] }).to include("hip-hop")
     end
 
     it "produces one crate per unique primary genre" do
-      store    = fake_store(listings: [ jazz, rock ])
-      selector = fake_selector(genre_map: { "Jazz" => [ jazz ], "Rock" => [ rock ] })
-      crates   = described_class.new(store).build_crates(selector)
+      store    = fake_store
+      curation = fake_curation(genre_crates: { "Jazz" => [ jazz ], "Rock" => [ rock ] })
+      crates   = described_class.new(store).build_crates(curation)
 
       genre_slugs = crates.reject { |c| c[:slug] == "picks" }.map { |c| c[:slug] }
       expect(genre_slugs).to match_array(%w[jazz rock])
     end
 
     it "skips genre crates with no records" do
-      store    = fake_store(listings: [ jazz ])
-      selector = fake_selector(genre_map: { "Jazz" => [] })
-      crates   = described_class.new(store).build_crates(selector)
+      store    = fake_store
+      curation = fake_curation(genre_crates: {})
+      crates   = described_class.new(store).build_crates(curation)
 
       genre_slugs = crates.reject { |c| c[:slug] == "picks" }.map { |c| c[:slug] }
       expect(genre_slugs).to be_empty

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe StorefrontCuration do
+  def lp_listing(store, overrides = {})
+    create(:listing, store:, format: "LP", last_seen_at: Time.current, **overrides)
+  end
+
+  describe "#picks" do
+    it "returns an array of listings" do
+      store = create(:store)
+      lp_listing(store, genres: ["Jazz"])
+
+      curation = described_class.new(store)
+      expect(curation.picks).to be_an(Array)
+    end
+
+    it "returns at most 12 records" do
+      store = create(:store)
+      15.times { |i| lp_listing(store, genres: ["Genre#{i}"]) }
+
+      curation = described_class.new(store)
+      expect(curation.picks.size).to be <= 12
+    end
+
+    it "returns only available LP listings" do
+      store = create(:store)
+      lp_listing(store, genres: ["Jazz"])
+      create(:listing, store:, format: "LP", last_seen_at: 10.days.ago, genres: ["Rock"])
+
+      curation = described_class.new(store)
+      expect(curation.picks.size).to eq(1)
+    end
+  end
+
+  describe "#genre_crates" do
+    it "returns a hash keyed by genre name" do
+      store = create(:store)
+      lp_listing(store, genres: ["Jazz"])
+
+      curation = described_class.new(store)
+      expect(curation.genre_crates).to be_a(Hash)
+    end
+
+    it "excludes records that appear in picks" do
+      store = create(:store)
+      listing = lp_listing(store, genres: ["Jazz"])
+      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([listing])
+
+      curation = described_class.new(store)
+      expect(curation.genre_crates.fetch("Jazz", [])).not_to include(listing)
+    end
+
+    it "skips genres with no records remaining after picks exclusion" do
+      store = create(:store)
+      listing = lp_listing(store, genres: ["Jazz"])
+      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([listing])
+      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([listing])
+
+      curation = described_class.new(store)
+      expect(curation.genre_crates).not_to have_key("Jazz")
+    end
+
+    it "includes genres that have records not in picks" do
+      store = create(:store)
+      jazz1 = lp_listing(store, genres: ["Jazz"])
+      jazz2 = lp_listing(store, genres: ["Jazz"])
+      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([jazz1])
+      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([jazz1, jazz2])
+
+      curation = described_class.new(store)
+      expect(curation.genre_crates).to have_key("Jazz")
+      expect(curation.genre_crates["Jazz"]).to eq([jazz2])
+    end
+  end
+end

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StorefrontCuration do
   describe "#picks" do
     it "returns an array of listings" do
       store = create(:store)
-      lp_listing(store, genres: ["Jazz"])
+      lp_listing(store, genres: [ "Jazz" ])
 
       curation = described_class.new(store)
       expect(curation.picks).to be_an(Array)
@@ -16,7 +16,7 @@ RSpec.describe StorefrontCuration do
 
     it "returns at most 12 records" do
       store = create(:store)
-      15.times { |i| lp_listing(store, genres: ["Genre#{i}"]) }
+      15.times { |i| lp_listing(store, genres: [ "Genre#{i}" ]) }
 
       curation = described_class.new(store)
       expect(curation.picks.size).to be <= 12
@@ -24,8 +24,8 @@ RSpec.describe StorefrontCuration do
 
     it "returns only available LP listings" do
       store = create(:store)
-      lp_listing(store, genres: ["Jazz"])
-      create(:listing, store:, format: "LP", last_seen_at: 10.days.ago, genres: ["Rock"])
+      lp_listing(store, genres: [ "Jazz" ])
+      create(:listing, store:, format: "LP", last_seen_at: 10.days.ago, genres: [ "Rock" ])
 
       curation = described_class.new(store)
       expect(curation.picks.size).to eq(1)
@@ -35,7 +35,7 @@ RSpec.describe StorefrontCuration do
   describe "#genre_crates" do
     it "returns a hash keyed by genre name" do
       store = create(:store)
-      lp_listing(store, genres: ["Jazz"])
+      lp_listing(store, genres: [ "Jazz" ])
 
       curation = described_class.new(store)
       expect(curation.genre_crates).to be_a(Hash)
@@ -43,8 +43,8 @@ RSpec.describe StorefrontCuration do
 
     it "excludes records that appear in picks" do
       store = create(:store)
-      listing = lp_listing(store, genres: ["Jazz"])
-      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([listing])
+      listing = lp_listing(store, genres: [ "Jazz" ])
+      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ listing ])
 
       curation = described_class.new(store)
       expect(curation.genre_crates.fetch("Jazz", [])).not_to include(listing)
@@ -52,9 +52,9 @@ RSpec.describe StorefrontCuration do
 
     it "skips genres with no records remaining after picks exclusion" do
       store = create(:store)
-      listing = lp_listing(store, genres: ["Jazz"])
-      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([listing])
-      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([listing])
+      listing = lp_listing(store, genres: [ "Jazz" ])
+      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ listing ])
+      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ listing ])
 
       curation = described_class.new(store)
       expect(curation.genre_crates).not_to have_key("Jazz")
@@ -62,14 +62,14 @@ RSpec.describe StorefrontCuration do
 
     it "includes genres that have records not in picks" do
       store = create(:store)
-      jazz1 = lp_listing(store, genres: ["Jazz"])
-      jazz2 = lp_listing(store, genres: ["Jazz"])
-      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([jazz1])
-      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([jazz1, jazz2])
+      jazz1 = lp_listing(store, genres: [ "Jazz" ])
+      jazz2 = lp_listing(store, genres: [ "Jazz" ])
+      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ jazz1 ])
+      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ jazz1, jazz2 ])
 
       curation = described_class.new(store)
       expect(curation.genre_crates).to have_key("Jazz")
-      expect(curation.genre_crates["Jazz"]).to eq([jazz2])
+      expect(curation.genre_crates["Jazz"]).to eq([ jazz2 ])
     end
   end
 end


### PR DESCRIPTION
Closes #77

## Summary

- Adds `StorefrontCuration` service with `picks` and `genre_crates` public methods
- `StoresController` now routes through `StorefrontCuration` instead of coordinating `PicksSelector` + `CratePresenter` directly
- Deduplication logic (picks excluded from genre crates) moves from `CratePresenter#build_crates` into `StorefrontCuration`
- `CratePresenter#build_crates` now accepts a curation object; presenter tests updated to use `fake_curation` double
- Underlying implementation still delegates to `PicksSelector` — behavior is behavior-preserving

## Test plan

- [ ] `StorefrontCuration#picks` returns array of listings, capped at 12, available LP only
- [ ] `StorefrontCuration#genre_crates` returns hash keyed by genre, picks excluded, empty genres skipped
- [ ] `CratePresenter#build_crates` picks-first ordering, genre slug parameterization, empty genre handling
- [ ] Full RSpec suite: 111 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)