### PR TITLE
Add milkcrate:add_store rake task for store onboarding

### DIFF
--- a/app/services/discogs_client.rb
+++ b/app/services/discogs_client.rb
@@ -34,6 +34,11 @@ class DiscogsClient
     total_pages
   end
 
+  def seller_profile(username)
+    response = @connection.get("/users/#{username}")
+    handle_response(response)
+  end
+
   private
 
   def build_connection

--- a/lib/tasks/milkcrate.rake
+++ b/lib/tasks/milkcrate.rake
@@ -127,6 +127,21 @@ namespace :milkcrate do
     puts "  noise:       #{noise.round(3)}"
   end
 
+  desc "Onboard a new store: create Store, kick off full sync — rake milkcrate:add_store[discogs_username]"
+  task :add_store, [ :discogs_username ] => :environment do |_, args|
+    username = args[:discogs_username]
+    raise "Usage: rake milkcrate:add_store[discogs_username]" if username.blank?
+
+    profile = DiscogsClient.new.seller_profile(username)
+    name    = profile["name"].presence || username
+
+    store = Store.create!(discogs_username: username, name:)
+    FullStoreSyncJob.perform_later(store.id)
+
+    puts "Store created: #{store.name} (@#{store.discogs_username})"
+    puts "Sync queued. Store will be live at: /#{store.discogs_username}"
+  end
+
   desc "Print curation stats for the current store"
   task stats: :environment do
     store = default_store

--- a/spec/tasks/milkcrate_add_store_spec.rb
+++ b/spec/tasks/milkcrate_add_store_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "milkcrate:add_store" do
+  before(:all) do
+    Rake.application = Rake::Application.new
+    Rails.application.load_tasks
+  end
+
+  after do
+    Rake::Task["milkcrate:add_store"].reenable
+  end
+
+  def stub_discogs_profile(username, name:)
+    client = instance_double(DiscogsClient)
+    allow(DiscogsClient).to receive(:new).and_return(client)
+    allow(client).to receive(:seller_profile).with(username).and_return({ "name" => name })
+  end
+
+  it "creates a store with the given username and name from Discogs" do
+    stub_discogs_profile("teststore", name: "Test Store")
+
+    expect {
+      Rake::Task["milkcrate:add_store"].invoke("teststore")
+    }.to change(Store, :count).by(1)
+
+    store = Store.find_by(discogs_username: "teststore")
+    expect(store).to be_present
+    expect(store.name).to eq("Test Store")
+  end
+
+  it "enqueues FullStoreSyncJob for the new store" do
+    stub_discogs_profile("teststore2", name: "Test Store 2")
+
+    Rake::Task["milkcrate:add_store"].reenable
+    expect {
+      Rake::Task["milkcrate:add_store"].invoke("teststore2")
+    }.to have_enqueued_job(FullStoreSyncJob)
+  end
+
+  it "prints the store URL" do
+    stub_discogs_profile("teststore3", name: "Test Store 3")
+
+    Rake::Task["milkcrate:add_store"].reenable
+    expect {
+      Rake::Task["milkcrate:add_store"].invoke("teststore3")
+    }.to output(%r{/teststore3}).to_stdout
+  end
+
+  it "raises when no username given" do
+    expect {
+      Rake::Task["milkcrate:add_store"].invoke
+    }.to raise_error(RuntimeError, /Usage/)
+  end
+
+  it "raises when store already exists" do
+    create(:store, discogs_username: "existing")
+    stub_discogs_profile("existing", name: "Existing Store")
+
+    Rake::Task["milkcrate:add_store"].reenable
+    expect {
+      Rake::Task["milkcrate:add_store"].invoke("existing")
+    }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+end


### PR DESCRIPTION
Closes #65

## Summary

- Adds `DiscogsClient#seller_profile(username)` — calls `GET /users/{username}`, returns profile hash
- Adds `milkcrate:add_store[discogs_username]` rake task:
  - Fetches store name from Discogs profile
  - Creates `Store` record (raises `RecordInvalid` if already exists)
  - Enqueues `FullStoreSyncJob` for inventory sync + enrichment + curation
  - Prints confirmation and live store URL

## Test plan

- [x] Creates store with correct username and name from Discogs
- [x] Enqueues `FullStoreSyncJob` for new store
- [x] Prints store URL to stdout
- [x] Raises with usage message when no username given
- [x] Raises `ActiveRecord::RecordInvalid` when store already exists
- [x] Full suite: 109 examples, 0 failures
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)