### PR TITLE
Build desktop bento layout for genre crates

### DIFF
--- a/app/frontend/components/store_floor.test.tsx
+++ b/app/frontend/components/store_floor.test.tsx
@@ -1,0 +1,79 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import StoreFloor from "./store_floor"
+import { DigSessionProvider } from "../contexts/dig_session_context"
+import type { Crate, Listing } from "../types/inertia"
+
+vi.mock("@/hooks/use_is_desktop", () => ({
+  useIsDesktop: () => true,
+}))
+
+const makeListing = (id: number, title: string): Listing => ({
+  id,
+  discogs_listing_id: String(id),
+  artist: "Artist",
+  title,
+  label: null,
+  year: null,
+  format: "LP",
+  genres: [],
+  styles: [],
+  condition: null,
+  price: "10.00",
+  currency: "USD",
+  cover_image_url: null,
+  thumbnail_url: null,
+  notes: null,
+  discogs_url: "https://www.discogs.com/sell/item/1",
+})
+
+describe("StoreFloor desktop bento", () => {
+  it("orders genre crates by count descending on desktop", () => {
+    const onSelectCrate = vi.fn()
+    const crates: Crate[] = [
+      { slug: "picks", name: "Milkcrate Picks", count: 1, records: [makeListing(100, "Pick")] },
+      { slug: "jazz", name: "Jazz", count: 20, records: [makeListing(1, "J1")] },
+      { slug: "rock", name: "Rock", count: 40, records: [makeListing(2, "R1")] },
+      { slug: "soul", name: "Soul", count: 30, records: [makeListing(3, "S1")] },
+    ]
+
+    render(
+      <DigSessionProvider>
+        <StoreFloor crates={crates} onSelectCrate={onSelectCrate} />
+      </DigSessionProvider>
+    )
+
+    const genreHeaderButtons = screen.getAllByRole("button", { name: /^Open (Rock|Soul|Jazz)$/ })
+    expect(genreHeaderButtons.map((b) => b.getAttribute("aria-label"))).toEqual([
+      "Open Rock",
+      "Open Soul",
+      "Open Jazz",
+    ])
+  })
+
+  it("maps deduped card click back to full crate index", async () => {
+    const onSelectCrate = vi.fn()
+
+    const shared = makeListing(10, "Shared")
+    const rockOnly = makeListing(11, "Rock Only")
+    const soulOnly = makeListing(12, "Soul Only")
+
+    const crates: Crate[] = [
+      { slug: "picks", name: "Milkcrate Picks", count: 1, records: [shared] },
+      { slug: "rock", name: "Rock", count: 2, records: [shared, rockOnly] },
+      { slug: "soul", name: "Soul", count: 1, records: [soulOnly] },
+    ]
+
+    render(
+      <DigSessionProvider>
+        <StoreFloor crates={crates} onSelectCrate={onSelectCrate} />
+      </DigSessionProvider>
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Open Rock at Rock Only" }))
+
+    expect(onSelectCrate).toHaveBeenCalledWith("rock", 1)
+  })
+})

--- a/app/frontend/components/store_floor.test.tsx
+++ b/app/frontend/components/store_floor.test.tsx
@@ -76,4 +76,20 @@ describe("StoreFloor desktop bento", () => {
 
     expect(onSelectCrate).toHaveBeenCalledWith("rock", 1)
   })
+
+  it("shows an empty state when crates exist but have no visible records", () => {
+    const onSelectCrate = vi.fn()
+    const crates: Crate[] = [
+      { slug: "picks", name: "Milkcrate Picks", count: 0, records: [] },
+      { slug: "jazz", name: "Jazz", count: 0, records: [] },
+    ]
+
+    render(
+      <DigSessionProvider>
+        <StoreFloor crates={crates} onSelectCrate={onSelectCrate} />
+      </DigSessionProvider>
+    )
+
+    expect(screen.getByText("No records in crates yet.")).toBeInTheDocument()
+  })
 })

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -177,7 +177,7 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
           )}
           {sortedDesktopGenreCrates.slice(2).length > 0 && (
             <div className="grid grid-cols-3 gap-4 items-start">
-              {sortedDesktopGenreCrates.slice(2).map(renderDesktopBentoCard)}
+              {sortedDesktopGenreCrates.slice(2).map((crate) => renderDesktopBentoCard(crate))}
             </div>
           )}
         </div>

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -172,14 +172,12 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
               <div className="col-span-2">
                 {renderDesktopBentoCard(sortedDesktopGenreCrates[0])}
               </div>
-              <div className="flex flex-col gap-4">
-                {sortedDesktopGenreCrates.slice(1, 3).map(renderDesktopBentoCard)}
-              </div>
+              {sortedDesktopGenreCrates[1] && renderDesktopBentoCard(sortedDesktopGenreCrates[1])}
             </div>
           )}
-          {sortedDesktopGenreCrates.slice(3).length > 0 && (
+          {sortedDesktopGenreCrates.slice(2).length > 0 && (
             <div className="grid grid-cols-3 gap-4">
-              {sortedDesktopGenreCrates.slice(3).map(renderDesktopBentoCard)}
+              {sortedDesktopGenreCrates.slice(2).map(renderDesktopBentoCard)}
             </div>
           )}
         </div>

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -24,9 +24,12 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
     unique.forEach((r) => seenIds.add(r.id))
     return { ...crate, records: unique }
   })
+  const visibleGenreCrates = dedupedGenreCrates.filter((crate) => crate.records.length > 0)
   const sortedDesktopGenreCrates = dedupedGenreCrates
     .slice()
     .sort((a, b) => b.count - a.count)
+    .filter((crate) => crate.records.length > 0)
+  const hasVisibleCrates = Boolean(picks && picks.records.length > 0) || visibleGenreCrates.length > 0
 
   const renderDesktopBentoCard = (dedupedCrate: Crate) => {
     const fullCrate = genreCrates.find((c) => c.slug === dedupedCrate.slug)!
@@ -79,6 +82,11 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
 
   return (
     <div className="flex flex-col">
+      {!hasVisibleCrates && (
+        <div className="py-16 text-center mc-dim text-sm">
+          <p>No records in crates yet.</p>
+        </div>
+      )}
       {picks && picks.records.length > 0 && (
         <div className={isDesktop ? "mb-6" : "-mx-4 mb-4 bg-mc-bg-raised border-y border-mc-border"}>
           {isDesktop ? (
@@ -177,7 +185,7 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
         </div>
       ) : (
         <div className="flex flex-col">
-          {dedupedGenreCrates.map((dedupedCrate) => {
+          {visibleGenreCrates.map((dedupedCrate) => {
             const fullCrate = genreCrates.find((c) => c.slug === dedupedCrate.slug)!
             return (
               <StoreSection

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -31,9 +31,9 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
     .filter((crate) => crate.records.length > 0)
   const hasVisibleCrates = Boolean(picks && picks.records.length > 0) || visibleGenreCrates.length > 0
 
-  const renderDesktopBentoCard = (dedupedCrate: Crate) => {
+  const renderDesktopBentoCard = (dedupedCrate: Crate, maxRecords = 4) => {
     const fullCrate = genreCrates.find((c) => c.slug === dedupedCrate.slug)!
-    const records = dedupedCrate.records.slice(0, 4)
+    const records = dedupedCrate.records.slice(0, maxRecords)
     return (
       <section key={dedupedCrate.slug} className="bg-mc-bg-raised border border-mc-border rounded-lg overflow-hidden">
         <button
@@ -172,7 +172,7 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
               <div className="col-span-2">
                 {renderDesktopBentoCard(sortedDesktopGenreCrates[0])}
               </div>
-              {sortedDesktopGenreCrates[1] && renderDesktopBentoCard(sortedDesktopGenreCrates[1])}
+              {sortedDesktopGenreCrates[1] && renderDesktopBentoCard(sortedDesktopGenreCrates[1], 8)}
             </div>
           )}
           {sortedDesktopGenreCrates.slice(2).length > 0 && (

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -168,7 +168,7 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
       {isDesktop ? (
         <div className="flex flex-col gap-4" data-testid="genre-bento">
           {sortedDesktopGenreCrates.length > 0 && (
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-3 gap-4 items-start">
               <div className="col-span-2">
                 {renderDesktopBentoCard(sortedDesktopGenreCrates[0])}
               </div>
@@ -176,7 +176,7 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
             </div>
           )}
           {sortedDesktopGenreCrates.slice(2).length > 0 && (
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-3 gap-4 items-start">
               {sortedDesktopGenreCrates.slice(2).map(renderDesktopBentoCard)}
             </div>
           )}

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -24,6 +24,58 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
     unique.forEach((r) => seenIds.add(r.id))
     return { ...crate, records: unique }
   })
+  const sortedDesktopGenreCrates = dedupedGenreCrates
+    .slice()
+    .sort((a, b) => b.count - a.count)
+
+  const renderDesktopBentoCard = (dedupedCrate: Crate) => {
+    const fullCrate = genreCrates.find((c) => c.slug === dedupedCrate.slug)!
+    const records = dedupedCrate.records.slice(0, 4)
+    return (
+      <section key={dedupedCrate.slug} className="bg-mc-bg-raised border border-mc-border rounded-lg overflow-hidden">
+        <button
+          type="button"
+          onClick={() => onSelectCrate(dedupedCrate.slug)}
+          className="w-full text-left px-4 py-3 border-b border-mc-border hover:bg-mc-bg-card transition-colors"
+          aria-label={`Open ${dedupedCrate.name}`}
+        >
+          <div className="text-sm font-bold tracking-wide">{dedupedCrate.name}</div>
+          <div className="text-xs mc-dim mt-1">{dedupedCrate.count} records</div>
+        </button>
+        <div className="grid grid-cols-2 gap-2 p-4">
+          {records.map((record, i) => {
+            const src = record.cover_image_url ?? record.thumbnail_url
+            return (
+              <motion.button
+                key={record.id}
+                type="button"
+                className="aspect-square rounded bg-mc-bg-card overflow-hidden border border-mc-border cursor-pointer"
+                whileHover={{ scale: 1.03, zIndex: 10 }}
+                transition={{ type: "spring", stiffness: 300, damping: 22 }}
+                onClick={() => {
+                  const fullIndex = fullCrate.records.findIndex((r) => r.id === record.id)
+                  onSelectCrate(dedupedCrate.slug, fullIndex >= 0 ? fullIndex : i)
+                }}
+                aria-label={`Open ${dedupedCrate.name} at ${record.title ?? "record"}`}
+              >
+                {src ? (
+                  <img
+                    src={src}
+                    alt={record.title ?? ""}
+                    className="w-full h-full object-cover"
+                    draggable={false}
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center mc-dim text-2xl">♪</div>
+                )}
+              </motion.button>
+            )
+          })}
+        </div>
+      </section>
+    )
+  }
 
   return (
     <div className="flex flex-col">
@@ -105,25 +157,45 @@ export default function StoreFloor({ crates, onSelectCrate }: Props) {
         </div>
       )}
 
-      <div className="flex flex-col">
-        {dedupedGenreCrates.map((dedupedCrate) => {
-          const fullCrate = genreCrates.find((c) => c.slug === dedupedCrate.slug)!
-          return (
-            <StoreSection
-              key={dedupedCrate.slug}
-              crate={dedupedCrate}
-              onSelect={(slug, i) => {
-                const startIndex = i ?? 0
-                const record = dedupedCrate.records[startIndex]
-                if (!record) return
+      {isDesktop ? (
+        <div className="flex flex-col gap-4" data-testid="genre-bento">
+          {sortedDesktopGenreCrates.length > 0 && (
+            <div className="grid grid-cols-3 gap-4">
+              <div className="col-span-2">
+                {renderDesktopBentoCard(sortedDesktopGenreCrates[0])}
+              </div>
+              <div className="flex flex-col gap-4">
+                {sortedDesktopGenreCrates.slice(1, 3).map(renderDesktopBentoCard)}
+              </div>
+            </div>
+          )}
+          {sortedDesktopGenreCrates.slice(3).length > 0 && (
+            <div className="grid grid-cols-3 gap-4">
+              {sortedDesktopGenreCrates.slice(3).map(renderDesktopBentoCard)}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col">
+          {dedupedGenreCrates.map((dedupedCrate) => {
+            const fullCrate = genreCrates.find((c) => c.slug === dedupedCrate.slug)!
+            return (
+              <StoreSection
+                key={dedupedCrate.slug}
+                crate={dedupedCrate}
+                onSelect={(slug, i) => {
+                  const startIndex = i ?? 0
+                  const record = dedupedCrate.records[startIndex]
+                  if (!record) return
 
-                const fullIndex = fullCrate.records.findIndex((r) => r.id === record.id)
-                onSelectCrate(slug, fullIndex >= 0 ? fullIndex : startIndex)
-              }}
-            />
-          )
-        })}
-      </div>
+                  const fullIndex = fullCrate.records.findIndex((r) => r.id === record.id)
+                  onSelectCrate(slug, fullIndex >= 0 ? fullIndex : startIndex)
+                }}
+              />
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -14,8 +14,13 @@ class Listing < ApplicationRecord
   scope :new_arrivals, -> { recent.limit(50) }
   scope :daily_shuffle, -> { order(Arel.sql("MD5(discogs_listing_id || '#{Date.current}'::text)")) }
 
-  # Listings absent from the last sync are assumed sold
-  scope :available, -> { where("last_seen_at > ?", 3.days.ago) }
+  # Listings seen in the latest sync snapshot are considered available.
+  # We allow a small buffer to avoid false negatives from long-running sync jobs.
+  scope :available, -> {
+    joins(:store)
+      .where.not(last_seen_at: nil)
+      .where("stores.last_synced_at IS NULL OR listings.last_seen_at >= stores.last_synced_at - interval '6 hours'")
+  }
 
   def primary_genre
     genres.first

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -20,6 +20,34 @@ RSpec.describe Listing, type: :model do
     end
   end
 
+  describe ".available" do
+    it "includes listings seen in the latest store sync snapshot" do
+      store.update!(last_synced_at: Time.current)
+      fresh = create(:listing, store:, last_seen_at: 1.hour.ago)
+      stale = create(:listing, store:, last_seen_at: 2.days.ago)
+
+      expect(described_class.available).to include(fresh)
+      expect(described_class.available).not_to include(stale)
+    end
+
+    it "keeps listings from long sync runs via a small last_seen_at buffer" do
+      synced_at = Time.current
+      store.update!(last_synced_at: synced_at)
+      buffered = create(:listing, store:, last_seen_at: synced_at - 4.hours)
+
+      expect(described_class.available).to include(buffered)
+    end
+
+    it "falls back to any seen listing when store has never synced" do
+      store.update!(last_synced_at: nil)
+      seen = create(:listing, store:, last_seen_at: 10.days.ago)
+      unseen = create(:listing, store:, last_seen_at: nil)
+
+      expect(described_class.available).to include(seen)
+      expect(described_class.available).not_to include(unseen)
+    end
+  end
+
   def arel_nodes(node)
     children = node
       .instance_variables


### PR DESCRIPTION
## Summary
- add a desktop-only bento layout for genre crates in 
- keep mobile crate-strip behavior unchanged
- sort desktop genre panels by crate count descending and preserve deduped record click mapping back to full crate index
- add  component tests for ordering and deduped index mapping

## Tests
- mise exec node@23 -- npm run test:components -- app/frontend/components/store_floor.test.tsx app/frontend/components/accessibility.test.tsx app/frontend/test/pages/page_smoke.test.tsx

Closes #59