### PR TITLE
Finish storefront curation/presentation split and regression cleanup (closes #80, #81)

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -20,10 +20,11 @@ class StoresController < ApplicationController
   def render_store(store)
     curation  = StorefrontCuration.new(store)
     presenter = CratePresenter.new(store)
+    curated_crates = curation.crates
 
     render inertia: "stores/featured", props: {
       store: presenter.store_props,
-      crates: presenter.build_crates(curation),
+      crates: presenter.build_crates(curated_crates),
       active_crate_slug: "picks"
     }
   end

--- a/app/jobs/daily_curation_job.rb
+++ b/app/jobs/daily_curation_job.rb
@@ -10,15 +10,14 @@ class DailyCurationJob < ApplicationJob
 
   def curate(store)
     curation = StorefrontCuration.new(store)
-    picks = curation.picks
-    genre_listings = curation.genre_crates.values.flatten
-    surfaced = (picks + genre_listings).map(&:id).uniq
+    surfaced = curation.surfaced_listings
+    picks_count = curation.crates.find { |crate| crate.slug == "picks" }&.listings&.size || 0
 
     Listing.where(id: surfaced).update_all(
       last_surfaced_at: Time.current,
       surface_count: Arel.sql("surface_count + 1")
     )
 
-    Rails.logger.info "[DailyCurationJob] store=#{store.name} surfaced=#{surfaced.size} picks=#{picks.size}"
+    Rails.logger.info "[DailyCurationJob] store=#{store.name} surfaced=#{surfaced.size} picks=#{picks_count}"
   end
 end

--- a/app/presenters/crate_presenter.rb
+++ b/app/presenters/crate_presenter.rb
@@ -14,14 +14,10 @@ class CratePresenter
     }
   end
 
-  def build_crates(curation)
-    crates = [ crate_props("picks", "Milkcrate Picks", curation.picks) ]
-
-    curation.genre_crates.each do |genre, listings|
-      crates << crate_props(genre.parameterize, genre, listings)
+  def build_crates(curated_crates)
+    curated_crates.map do |crate|
+      crate_props(crate.slug, crate.name, crate.listings)
     end
-
-    crates
   end
 
   private

--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -39,13 +39,6 @@ class PicksSelector
       .map(&:first)
   end
 
-  # Legacy: used by tests + crate_presenter for picks crate building
-  def rank(listing_ids: nil)
-    score_all(listing_ids: listing_ids)
-      .sort_by { |_, s| -s }
-      .map(&:first)
-  end
-
   private
 
   def score_all(listing_ids: nil)

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -1,22 +1,28 @@
 class StorefrontCuration
+  CuratedCrate = Struct.new(:slug, :name, :listings, keyword_init: true)
+
   def initialize(store)
     @store = store
   end
 
-  def picks
-    selector.select_picks(count: 12)
-  end
-
-  def genre_crates
-    picks_ids = picks.map(&:id).to_set
+  def crates
+    picks_list = selector.select_picks(count: 12)
+    crates = [ CuratedCrate.new(slug: "picks", name: "Milkcrate Picks", listings: picks_list) ]
+    picks_ids = picks_list.map(&:id).to_set
 
     genre_counts.filter_map do |genre, _|
       listings = selector.rank_genre(genre)
-        .reject { |l| picks_ids.include?(l.id) }
+        .reject { |listing| picks_ids.include?(listing.id) }
         .first(50)
       next if listings.empty?
-      [ genre, listings ]
-    end.to_h
+      crates << CuratedCrate.new(slug: genre.parameterize, name: genre, listings: listings)
+    end
+
+    crates
+  end
+
+  def surfaced_listings
+    crates.flat_map(&:listings).uniq(&:id)
   end
 
   private

--- a/spec/jobs/daily_curation_job_spec.rb
+++ b/spec/jobs/daily_curation_job_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe DailyCurationJob do
 
         curation = instance_double(
           StorefrontCuration,
-          picks: [ pick ],
-          genre_crates: { "Rock" => [ genre_listing ] }
+          crates: [ StorefrontCuration::CuratedCrate.new(slug: "picks", name: "Milkcrate Picks", listings: [ pick ]) ],
+          surfaced_listings: [ pick, genre_listing ]
         )
         allow(StorefrontCuration).to receive(:new).with(store).and_return(curation)
 
@@ -43,8 +43,8 @@ RSpec.describe DailyCurationJob do
 
         curation = instance_double(
           StorefrontCuration,
-          picks: [ listing ],
-          genre_crates: { "Jazz" => [ listing ] }
+          crates: [ StorefrontCuration::CuratedCrate.new(slug: "picks", name: "Milkcrate Picks", listings: [ listing ]) ],
+          surfaced_listings: [ listing ]
         )
         allow(StorefrontCuration).to receive(:new).with(store).and_return(curation)
 
@@ -60,8 +60,16 @@ RSpec.describe DailyCurationJob do
         store2 = create(:store)
         store2_listing = create(:listing, store: store2, format: "LP", genres: [ "Soul" ], last_seen_at: Time.current)
 
-        store1_curation = instance_double(StorefrontCuration, picks: [ store1_listing ], genre_crates: {})
-        store2_curation = instance_double(StorefrontCuration, picks: [], genre_crates: { "Soul" => [ store2_listing ] })
+        store1_curation = instance_double(
+          StorefrontCuration,
+          crates: [ StorefrontCuration::CuratedCrate.new(slug: "picks", name: "Milkcrate Picks", listings: [ store1_listing ]) ],
+          surfaced_listings: [ store1_listing ]
+        )
+        store2_curation = instance_double(
+          StorefrontCuration,
+          crates: [ StorefrontCuration::CuratedCrate.new(slug: "picks", name: "Milkcrate Picks", listings: []) ],
+          surfaced_listings: [ store2_listing ]
+        )
         allow(StorefrontCuration).to receive(:new).with(store).and_return(store1_curation)
         allow(StorefrontCuration).to receive(:new).with(store2).and_return(store2_curation)
 

--- a/spec/presenters/crate_presenter_spec.rb
+++ b/spec/presenters/crate_presenter_spec.rb
@@ -60,11 +60,8 @@ RSpec.describe CratePresenter do
     store
   end
 
-  def fake_curation(picks: [], genre_crates: {})
-    curation = double("StorefrontCuration")
-    allow(curation).to receive(:picks).and_return(picks)
-    allow(curation).to receive(:genre_crates).and_return(genre_crates)
-    curation
+  def fake_curated_crate(slug:, name:, listings:)
+    StorefrontCuration::CuratedCrate.new(slug:, name:, listings:)
   end
 
   describe "#store_props" do
@@ -114,8 +111,8 @@ RSpec.describe CratePresenter do
 
     it "places picks first with slug 'picks'" do
       store    = fake_store
-      curation = fake_curation(picks: [ jazz ])
-      crates   = described_class.new(store).build_crates(curation)
+      curated_crates = [ fake_curated_crate(slug: "picks", name: "Milkcrate Picks", listings: [ jazz ]) ]
+      crates   = described_class.new(store).build_crates(curated_crates)
 
       expect(crates.first[:slug]).to eq("picks")
       expect(crates.first[:name]).to eq("Milkcrate Picks")
@@ -123,26 +120,30 @@ RSpec.describe CratePresenter do
 
     it "includes picks records in the first crate" do
       store    = fake_store
-      curation = fake_curation(picks: [ jazz ])
-      crates   = described_class.new(store).build_crates(curation)
+      curated_crates = [ fake_curated_crate(slug: "picks", name: "Milkcrate Picks", listings: [ jazz ]) ]
+      crates   = described_class.new(store).build_crates(curated_crates)
 
       expect(crates.first[:count]).to eq(1)
       expect(crates.first[:records].first[:id]).to eq(1)
     end
 
-    it "parameterizes multi-word genre names as slugs" do
+    it "uses crate slugs from curated crate input" do
       hip_hop  = fake_listing(id: 3, genres: [ "Hip Hop" ])
       store    = fake_store
-      curation = fake_curation(genre_crates: { "Hip Hop" => [ hip_hop ] })
-      crates   = described_class.new(store).build_crates(curation)
+      curated_crates = [ fake_curated_crate(slug: "hip-hop", name: "Hip Hop", listings: [ hip_hop ]) ]
+      crates   = described_class.new(store).build_crates(curated_crates)
 
       expect(crates.map { |c| c[:slug] }).to include("hip-hop")
     end
 
     it "produces one crate per unique primary genre" do
       store    = fake_store
-      curation = fake_curation(genre_crates: { "Jazz" => [ jazz ], "Rock" => [ rock ] })
-      crates   = described_class.new(store).build_crates(curation)
+      curated_crates = [
+        fake_curated_crate(slug: "picks", name: "Milkcrate Picks", listings: []),
+        fake_curated_crate(slug: "jazz", name: "Jazz", listings: [ jazz ]),
+        fake_curated_crate(slug: "rock", name: "Rock", listings: [ rock ])
+      ]
+      crates   = described_class.new(store).build_crates(curated_crates)
 
       genre_slugs = crates.reject { |c| c[:slug] == "picks" }.map { |c| c[:slug] }
       expect(genre_slugs).to match_array(%w[jazz rock])
@@ -150,8 +151,8 @@ RSpec.describe CratePresenter do
 
     it "skips genre crates with no records" do
       store    = fake_store
-      curation = fake_curation(genre_crates: {})
-      crates   = described_class.new(store).build_crates(curation)
+      curated_crates = [ fake_curated_crate(slug: "picks", name: "Milkcrate Picks", listings: []) ]
+      crates   = described_class.new(store).build_crates(curated_crates)
 
       genre_slugs = crates.reject { |c| c[:slug] == "picks" }.map { |c| c[:slug] }
       expect(genre_slugs).to be_empty

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe "Stores", type: :request do
       let!(:store) { create(:store, discogs_username: "teststore") }
 
       before do
-        selector = instance_double(PicksSelector, select_picks: [], rank_genre: [])
+        curation = instance_double(StorefrontCuration, crates: [])
         presenter_double = instance_double(CratePresenter,
           store_props: { id: store.id, name: store.name },
           build_crates: []
         )
-        allow(PicksSelector).to receive(:new).and_return(selector)
+        allow(StorefrontCuration).to receive(:new).and_return(curation)
         allow(CratePresenter).to receive(:new).and_return(presenter_double)
       end
 

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -80,24 +80,4 @@ RSpec.describe PicksSelector do
     end
   end
 
-  describe "#rank" do
-    it "returns listings sorted by score descending" do
-      high = fake_listing(id: 1, genres: [ "Jazz" ], styles: [ "Afro-Jazz" ], year: 1972, condition: "NM")
-      low  = fake_listing(id: 2, genres: [ "Rock" ], styles: [], year: nil, condition: "Generic")
-
-      result = described_class.new(fake_store(listings: [ high, low ])).rank
-
-      expect(result.first).to eq(high)
-      expect(result.last).to eq(low)
-    end
-
-    it "filters to provided listing_ids" do
-      included = fake_listing(id: 1, genres: [ "Jazz" ], styles: [ "Afro-Jazz" ], year: 1972, condition: "NM")
-      excluded = fake_listing(id: 2, genres: [ "Rock" ], styles: [ "Classic Rock" ], year: 1975, condition: "VG+")
-
-      result = described_class.new(fake_store(listings: [ included, excluded ])).rank(listing_ids: [ 1 ])
-
-      expect(result.map(&:id)).to eq([ 1 ])
-    end
-  end
 end

--- a/spec/services/picks_selector_spec.rb
+++ b/spec/services/picks_selector_spec.rb
@@ -3,7 +3,6 @@ require "digest"
 require "active_support/core_ext/date/calculations"
 require "active_support/core_ext/numeric/time"
 
-
 require_relative "../../app/services/picks_selector"
 
 RSpec.describe PicksSelector do
@@ -79,5 +78,4 @@ RSpec.describe PicksSelector do
       expect(jazz_count).to be <= 4
     end
   end
-
 end

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -5,40 +5,44 @@ RSpec.describe StorefrontCuration do
     create(:listing, store:, format: "LP", last_seen_at: Time.current, **overrides)
   end
 
-  describe "#picks" do
-    it "returns an array of listings" do
+  describe "#crates" do
+    it "returns an array of curated crates" do
       store = create(:store)
       lp_listing(store, genres: [ "Jazz" ])
 
       curation = described_class.new(store)
-      expect(curation.picks).to be_an(Array)
+      expect(curation.crates).to all(be_a(StorefrontCuration::CuratedCrate))
     end
 
-    it "returns at most 12 records" do
+    it "returns picks crate with at most 12 records" do
       store = create(:store)
       15.times { |i| lp_listing(store, genres: [ "Genre#{i}" ]) }
 
       curation = described_class.new(store)
-      expect(curation.picks.size).to be <= 12
+      picks_crate = curation.crates.find { |crate| crate.slug == "picks" }
+      expect(picks_crate.listings.size).to be <= 12
     end
 
-    it "returns only available LP listings" do
+    it "returns only available LP listings in picks crate" do
       store = create(:store)
       lp_listing(store, genres: [ "Jazz" ])
       create(:listing, store:, format: "LP", last_seen_at: 10.days.ago, genres: [ "Rock" ])
 
       curation = described_class.new(store)
-      expect(curation.picks.size).to eq(1)
+      picks_crate = curation.crates.find { |crate| crate.slug == "picks" }
+      expect(picks_crate.listings.size).to eq(1)
     end
-  end
 
-  describe "#genre_crates" do
-    it "returns a hash keyed by genre name" do
+    it "adds genre crates after picks" do
       store = create(:store)
-      lp_listing(store, genres: [ "Jazz" ])
+      listing = lp_listing(store, genres: [ "Jazz" ])
+      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([])
+      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ listing ])
 
       curation = described_class.new(store)
-      expect(curation.genre_crates).to be_a(Hash)
+      crates = curation.crates
+      expect(crates.first.slug).to eq("picks")
+      expect(crates.map(&:name)).to include("Jazz")
     end
 
     it "excludes records that appear in picks" do
@@ -47,7 +51,8 @@ RSpec.describe StorefrontCuration do
       allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ listing ])
 
       curation = described_class.new(store)
-      expect(curation.genre_crates.fetch("Jazz", [])).not_to include(listing)
+      jazz_crate = curation.crates.find { |crate| crate.name == "Jazz" }
+      expect(jazz_crate&.listings || []).not_to include(listing)
     end
 
     it "skips genres with no records remaining after picks exclusion" do
@@ -57,7 +62,7 @@ RSpec.describe StorefrontCuration do
       allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ listing ])
 
       curation = described_class.new(store)
-      expect(curation.genre_crates).not_to have_key("Jazz")
+      expect(curation.crates.map(&:name)).not_to include("Jazz")
     end
 
     it "includes genres that have records not in picks" do
@@ -68,8 +73,22 @@ RSpec.describe StorefrontCuration do
       allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ jazz1, jazz2 ])
 
       curation = described_class.new(store)
-      expect(curation.genre_crates).to have_key("Jazz")
-      expect(curation.genre_crates["Jazz"]).to eq([ jazz2 ])
+      jazz_crate = curation.crates.find { |crate| crate.name == "Jazz" }
+      expect(jazz_crate).to be_present
+      expect(jazz_crate.listings).to eq([ jazz2 ])
+    end
+  end
+
+  describe "#surfaced_listings" do
+    it "returns unique listings from all curated crates" do
+      store = create(:store)
+      listing = lp_listing(store, genres: [ "Jazz" ])
+
+      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ listing ])
+      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ listing ])
+
+      curation = described_class.new(store)
+      expect(curation.surfaced_listings).to eq([ listing ])
     end
   end
 end

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe StorefrontCuration do
     create(:listing, store:, format: "LP", last_seen_at: Time.current, **overrides)
   end
 
+  def curation_with_selector(store, picks:, rank_genre_map:)
+    selector = instance_double(PicksSelector)
+    allow(selector).to receive(:select_picks).with(count: 12).and_return(picks)
+    allow(selector).to receive(:rank_genre) do |genre|
+      rank_genre_map.fetch(genre, [])
+    end
+    allow(PicksSelector).to receive(:new).with(store).and_return(selector)
+    described_class.new(store)
+  end
+
   describe "#crates" do
     it "returns an array of curated crates" do
       store = create(:store)
@@ -36,10 +46,8 @@ RSpec.describe StorefrontCuration do
     it "adds genre crates after picks" do
       store = create(:store)
       listing = lp_listing(store, genres: [ "Jazz" ])
-      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([])
-      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ listing ])
 
-      curation = described_class.new(store)
+      curation = curation_with_selector(store, picks: [], rank_genre_map: { "Jazz" => [ listing ] })
       crates = curation.crates
       expect(crates.first.slug).to eq("picks")
       expect(crates.map(&:name)).to include("Jazz")
@@ -48,9 +56,8 @@ RSpec.describe StorefrontCuration do
     it "excludes records that appear in picks" do
       store = create(:store)
       listing = lp_listing(store, genres: [ "Jazz" ])
-      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ listing ])
 
-      curation = described_class.new(store)
+      curation = curation_with_selector(store, picks: [ listing ], rank_genre_map: { "Jazz" => [ listing ] })
       jazz_crate = curation.crates.find { |crate| crate.name == "Jazz" }
       expect(jazz_crate&.listings || []).not_to include(listing)
     end
@@ -58,10 +65,8 @@ RSpec.describe StorefrontCuration do
     it "skips genres with no records remaining after picks exclusion" do
       store = create(:store)
       listing = lp_listing(store, genres: [ "Jazz" ])
-      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ listing ])
-      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ listing ])
 
-      curation = described_class.new(store)
+      curation = curation_with_selector(store, picks: [ listing ], rank_genre_map: { "Jazz" => [ listing ] })
       expect(curation.crates.map(&:name)).not_to include("Jazz")
     end
 
@@ -69,10 +74,8 @@ RSpec.describe StorefrontCuration do
       store = create(:store)
       jazz1 = lp_listing(store, genres: [ "Jazz" ])
       jazz2 = lp_listing(store, genres: [ "Jazz" ])
-      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ jazz1 ])
-      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ jazz1, jazz2 ])
 
-      curation = described_class.new(store)
+      curation = curation_with_selector(store, picks: [ jazz1 ], rank_genre_map: { "Jazz" => [ jazz1, jazz2 ] })
       jazz_crate = curation.crates.find { |crate| crate.name == "Jazz" }
       expect(jazz_crate).to be_present
       expect(jazz_crate.listings).to eq([ jazz2 ])
@@ -84,10 +87,7 @@ RSpec.describe StorefrontCuration do
       store = create(:store)
       listing = lp_listing(store, genres: [ "Jazz" ])
 
-      allow_any_instance_of(PicksSelector).to receive(:select_picks).and_return([ listing ])
-      allow_any_instance_of(PicksSelector).to receive(:rank_genre).and_return([ listing ])
-
-      curation = described_class.new(store)
+      curation = curation_with_selector(store, picks: [ listing ], rank_genre_map: { "Jazz" => [ listing ] })
       expect(curation.surfaced_listings).to eq([ listing ])
     end
   end


### PR DESCRIPTION
## Summary
- make StorefrontCuration expose a single curated-crates interface (crates) plus surfaced_listings
- update StoresController and CratePresenter so presentation consumes curated crate input only
- update DailyCurationJob to use the same curation output path for surfaced-record bookkeeping
- remove unused legacy PicksSelector#rank surface and align specs around curation as behavior owner

## Regression coverage
- presenter specs now focus on prop shaping from curated crate inputs
- curation specs own picks/genre membership and duplicate handling behavior
- job/request specs updated for the new curation interface

## Verification
- bundle exec rspec spec/services/storefront_curation_spec.rb spec/presenters/crate_presenter_spec.rb spec/jobs/daily_curation_job_spec.rb spec/requests/stores_spec.rb spec/services/picks_selector_spec.rb
