### PR TITLE
Thin inventory sync orchestrator

### DIFF
--- a/app/services/store_sync/inventory_fetcher.rb
+++ b/app/services/store_sync/inventory_fetcher.rb
@@ -1,6 +1,9 @@
 class StoreSync::InventoryFetcher
   Result = Data.define(:listings, :pages_fetched, :total_pages)
 
+  RATE_LIMIT_DELAY = 0.5
+  DISCOGS_PAGE_LIMIT_ERROR = "Pagination above 100"
+
   def initialize(store, client: nil)
     @store = store
     @client = client || DiscogsClient.new
@@ -8,29 +11,63 @@ class StoreSync::InventoryFetcher
 
   def fetch(sort_order: "desc", max_pages: nil)
     all_listings = []
-    page = 1
     total_pages = nil
 
-    loop do
-      data = @client.seller_inventory(@store.discogs_username, page: page, sort_order: sort_order)
-      page_listings = data["listings"] || []
-      break if page_listings.empty?
-
-      all_listings.concat(page_listings)
-
-      pagination = data["pagination"] || {}
-      total_pages = pagination["pages"] || 1
-      break if page >= total_pages
-      break if max_pages && page >= max_pages
-
-      page += 1
-      sleep(0.5)
-    rescue DiscogsClient::ApiError => e
-      raise unless e.message.include?("Pagination above 100")
-      Rails.logger.info "[StoreSync::InventoryFetcher] Hit Discogs 100-page limit for #{@store.discogs_username}, stopping at page #{page}"
-      break
+    each_page(sort_order:, max_pages:) do |data, page|
+      total_pages = extract_total_pages(data)
+      all_listings.concat(data["listings"] || [])
     end
 
-    Result.new(listings: all_listings, pages_fetched: page, total_pages: total_pages)
+    Result.new(listings: all_listings, pages_fetched: pages_fetched, total_pages: total_pages)
+  end
+
+  private
+
+  def each_page(sort_order:, max_pages:)
+    @pages_fetched = 0
+
+    loop do
+      @pages_fetched += 1
+      data = fetch_page(@pages_fetched, sort_order)
+
+      break if empty_page?(data)
+
+      yield data, @pages_fetched
+
+      break if last_page?(data, max_pages)
+
+      sleep(RATE_LIMIT_DELAY)
+    end
+  end
+
+  def fetch_page(page, sort_order)
+    @client.seller_inventory(@store.discogs_username, page:, sort_order:)
+  rescue DiscogsClient::ApiError => e
+    raise unless e.message.include?(DISCOGS_PAGE_LIMIT_ERROR)
+    log_page_limit_hit(page)
+    nil
+  end
+
+  def empty_page?(data)
+    data.nil? || (data["listings"] || []).empty?
+  end
+
+  def last_page?(data, max_pages)
+    current = @pages_fetched
+    total = extract_total_pages(data)
+    current >= total || (max_pages && current >= max_pages)
+  end
+
+  def extract_total_pages(data)
+    data&.dig("pagination", "pages") || 1
+  end
+
+  def log_page_limit_hit(page)
+    Rails.logger.info "[StoreSync::InventoryFetcher] Hit Discogs 100-page limit " \
+                      "for #{@store.discogs_username}, stopping at page #{page}"
+  end
+
+  def pages_fetched
+    @pages_fetched || 0
   end
 end

--- a/app/services/store_sync/inventory_fetcher.rb
+++ b/app/services/store_sync/inventory_fetcher.rb
@@ -1,0 +1,36 @@
+class StoreSync::InventoryFetcher
+  Result = Data.define(:listings, :pages_fetched, :total_pages)
+
+  def initialize(store, client: nil)
+    @store = store
+    @client = client || DiscogsClient.new
+  end
+
+  def fetch(sort_order: "desc", max_pages: nil)
+    all_listings = []
+    page = 1
+    total_pages = nil
+
+    loop do
+      data = @client.seller_inventory(@store.discogs_username, page: page, sort_order: sort_order)
+      page_listings = data["listings"] || []
+      break if page_listings.empty?
+
+      all_listings.concat(page_listings)
+
+      pagination = data["pagination"] || {}
+      total_pages = pagination["pages"] || 1
+      break if page >= total_pages
+      break if max_pages && page >= max_pages
+
+      page += 1
+      sleep(0.5)
+    rescue DiscogsClient::ApiError => e
+      raise unless e.message.include?("Pagination above 100")
+      Rails.logger.info "[StoreSync::InventoryFetcher] Hit Discogs 100-page limit for #{@store.discogs_username}, stopping at page #{page}"
+      break
+    end
+
+    Result.new(listings: all_listings, pages_fetched: page, total_pages: total_pages)
+  end
+end

--- a/app/services/store_sync_service.rb
+++ b/app/services/store_sync_service.rb
@@ -13,28 +13,10 @@ class StoreSyncService
   def full_sync(max_pages: nil, sort_order: "desc", manage_status: true)
     sync_started_at = Time.current
     @store.update!(sync_status: "syncing") if manage_status
-    page = 1
-    total_imported = 0
+    fetcher = StoreSync::InventoryFetcher.new(@store, client: @client)
+    result = fetcher.fetch(sort_order: sort_order, max_pages: max_pages)
 
-    loop do
-      data = @client.seller_inventory(@store.discogs_username, page: page, sort_order: sort_order)
-      listings = data["listings"] || []
-      break if listings.empty?
-
-      import_listings(listings)
-      total_imported += listings.size
-
-      pagination = data["pagination"] || {}
-      break if page >= (pagination["pages"] || 1)
-      break if max_pages && page >= max_pages
-
-      page += 1
-      sleep(0.5) # be kind to the API
-    rescue DiscogsClient::ApiError => e
-      raise unless e.message.include?("Pagination above 100")
-      Rails.logger.info "[StoreSyncService] Hit Discogs 100-page limit for #{@store.discogs_username}, stopping at page #{page}"
-      break
-    end
+    import_listings(result.listings)
 
     if manage_status
       @store.update!(
@@ -44,8 +26,8 @@ class StoreSyncService
       )
     end
 
-    total_imported
-  rescue StandardError => e
+    result.listings.size
+  rescue StandardError
     @store.update!(sync_status: "failed") if manage_status
     raise
   end
@@ -106,29 +88,12 @@ class StoreSyncService
   end
 
   def fetch_public_listings(sort_order:, max_pages:)
-    page = 1
-    page_count = 0
-    fetched_listings = []
+    fetcher = StoreSync::InventoryFetcher.new(@store, client: @client)
+    result = fetcher.fetch(sort_order: sort_order, max_pages: max_pages)
 
-    loop do
-      data = @client.seller_inventory(@store.discogs_username, page:, sort_order:)
-      listings = data["listings"] || []
-      pagination = data["pagination"] || {}
-      page_count = [ page_count, pagination.fetch("pages", page).to_i, page ].max
-
-      fetched_listings.concat(listings)
-      break if listings.empty?
-      break if page >= page_count
-      break if max_pages && page >= max_pages
-
-      page += 1
-      sleep(0.5)
-    rescue DiscogsClient::ApiError => e
-      raise unless e.message.include?("Pagination above 100")
-      Rails.logger.info "[StoreSyncService] Hit Discogs 100-page limit for #{@store.discogs_username}, stopping at page #{page}"
-      break
-    end
-
-    { listings: fetched_listings, page_count: page_count }
+    {
+      listings: result.listings,
+      page_count: [ result.pages_fetched, result.total_pages.to_i ].max
+    }
   end
 end

--- a/spec/services/store_sync/inventory_fetcher_spec.rb
+++ b/spec/services/store_sync/inventory_fetcher_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe StoreSync::InventoryFetcher do
+  let(:store) { create(:store, discogs_username: "teststore") }
+  let(:client) { instance_double(DiscogsClient) }
+  subject(:fetcher) { described_class.new(store, client: client) }
+
+  def api_page(listings:, pages: 1, current_page: 1)
+    { "listings" => listings, "pagination" => { "pages" => pages, "page" => current_page } }
+  end
+
+  def raw_listing(id: "1")
+    { "id" => id, "condition" => "VG+", "price" => { "value" => "10.00" }, "release" => { "format" => "Vinyl" } }
+  end
+
+  describe "#fetch" do
+    it "returns accumulated listings from paginated API responses" do
+      allow(client).to receive(:seller_inventory).with("teststore", page: 1, sort_order: "desc").and_return(
+        api_page(listings: [ raw_listing(id: "1") ], pages: 2)
+      )
+      allow(client).to receive(:seller_inventory).with("teststore", page: 2, sort_order: "desc").and_return(
+        api_page(listings: [ raw_listing(id: "2") ])
+      )
+
+      result = fetcher.fetch
+
+      expect(result.listings.size).to eq(2)
+      expect(result.pages_fetched).to eq(2)
+    end
+
+    it "stops at max_pages" do
+      allow(client).to receive(:seller_inventory).with("teststore", page: 1, sort_order: "desc").and_return(
+        api_page(listings: [ raw_listing(id: "1") ], pages: 10)
+      )
+
+      result = fetcher.fetch(max_pages: 1)
+
+      expect(result.listings.size).to eq(1)
+      expect(result.pages_fetched).to eq(1)
+    end
+
+    it "returns empty result when API returns no listings" do
+      allow(client).to receive(:seller_inventory).and_return(api_page(listings: []))
+
+      result = fetcher.fetch
+
+      expect(result.listings).to be_empty
+      expect(result.pages_fetched).to eq(1)
+    end
+
+    it "handles Discogs 100-page limit gracefully" do
+      allow(client).to receive(:seller_inventory).with("teststore", page: 1, sort_order: "desc").and_return(
+        api_page(listings: [ raw_listing(id: "1") ], pages: 150)
+      )
+      allow(client).to receive(:seller_inventory).with("teststore", page: 2, sort_order: "desc").and_raise(
+        DiscogsClient::ApiError, "Pagination above 100 pages is not supported"
+      )
+
+      result = fetcher.fetch
+
+      expect(result.listings.size).to eq(1)
+      expect(result.pages_fetched).to eq(2)
+    end
+
+    context "with custom sort_order" do
+      it "passes sort_order to the API client" do
+        allow(client).to receive(:seller_inventory).with("teststore", page: 1, sort_order: "asc").and_return(
+          api_page(listings: [])
+        )
+
+        result = fetcher.fetch(sort_order: "asc")
+
+        expect(result.listings).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extract public Discogs inventory crawl loop from StoreSyncService
into new StoreSync::InventoryFetcher. The fetcher owns paginated
API crawling, 100-page limit handling, and returns accumulated raw
listings with page metadata. StoreSyncService delegates the crawl
and keeps vinyl filtering, importing, and sync status management.

Closes #102