### PR TITLE
Repair score debug task

### DIFF
--- a/app/services/picks_selector.rb
+++ b/app/services/picks_selector.rb
@@ -39,6 +39,11 @@ class PicksSelector
       .map(&:first)
   end
 
+  # Returns a breakdown hash of scoring components for a single listing.
+  # Used by the score debug rake task to produce detailed output.
+  def score_breakdown_for(listing)
+    scorer_for(store_genre_counts).score_breakdown(listing)
+  end
   private
 
   def score_all(listing_ids: nil)
@@ -49,13 +54,16 @@ class PicksSelector
   def scored_inventory
     @scored_inventory ||= begin
       listings = @store.listings.available.lp_only.to_a
-      gc = store_genre_counts
-      scorer = RecordScorer.new(genre_counts: gc, today: @today)
+      scorer = scorer_for(store_genre_counts)
       listings.map { |l| [ l, scorer.score(l) ] }
     end
   end
 
   def store_genre_counts
     @store_genre_counts ||= @store.listings.available.lp_only.pluck(:genres).map(&:first).compact.tally
+  end
+
+  def scorer_for(genre_counts)
+    RecordScorer.new(genre_counts:, today: @today)
   end
 end

--- a/app/services/record_scorer.rb
+++ b/app/services/record_scorer.rb
@@ -33,13 +33,19 @@ class RecordScorer
   end
 
   def score(listing)
-    vintage_points(listing) +
-      condition_points(listing) +
-      section_points(listing) +
-      desirability_points(listing) +
-      metadata_penalty(listing) +
-      freshness_score(listing) +
-      daily_noise(listing)
+    score_breakdown(listing).values.sum
+  end
+
+  def score_breakdown(listing)
+    {
+      vintage: vintage_points(listing),
+      condition: condition_points(listing),
+      section: section_points(listing),
+      desirability: desirability_points(listing),
+      metadata: metadata_penalty(listing),
+      freshness: freshness_score(listing),
+      noise: daily_noise(listing)
+    }
   end
 
   private

--- a/lib/tasks/milkcrate.rake
+++ b/lib/tasks/milkcrate.rake
@@ -88,43 +88,13 @@ namespace :milkcrate do
     store    = default_store
     listing  = store.listings.find(args[:id])
     selector = PicksSelector.new(store)
-
-    gc = store.listings.available.lp_only.pluck(:genres).map(&:first).compact.tally
+    breakdown = selector.score_breakdown_for(listing)
+    score    = breakdown.values.sum
 
     today    = Date.today
     have     = listing.have_count.to_i
     want     = listing.want_count.to_i
     total    = want + have
-
-    vintage     = listing.year && listing.year < PicksSelector::VINTAGE_BEFORE ? 2.0 : 0.0
-    condition   = (PicksSelector::GOOD_CONDITIONS.include?(listing.condition&.strip) ||
-                   PicksSelector::CONDITION_ALIASES.include?(listing.condition&.strip&.downcase)) ? 1.0 : 0.0
-
-    genre_count = gc.fetch(listing.primary_genre.to_s, 0)
-    section     = genre_count < PicksSelector::SMALL_GENRE_THRESHOLD ? PicksSelector::SMALL_GENRE_BOOST.to_f : 0.0
-
-    desirability  = 0.0
-    desirability += Math.log10(total).clamp(0, PicksSelector::DESIRABILITY_LOG_CAP) if total > 0
-    if have >= PicksSelector::WANT_HAVE_MIN_HAVE
-      ratio = want.to_f / have
-      desirability += PicksSelector::WANT_HAVE_HIGH_BONUS  if ratio >= PicksSelector::WANT_HAVE_RATIO_HIGH
-      desirability += PicksSelector::WANT_HAVE_LOW_PENALTY if ratio <= PicksSelector::WANT_HAVE_RATIO_LOW
-    end
-
-    meta      = listing.styles.empty? && listing.genres.size <= 1 && listing.year.nil? ? -1.0 : 0.0
-    freshness = if listing.last_surfaced_at.nil?
-      3.0
-    else
-      days_ago = (today - listing.last_surfaced_at.to_date).to_i
-      if    days_ago <= 3  then -5.0
-      elsif days_ago <= 7  then -3.0
-      elsif days_ago <= 14 then -1.0
-      else 1.0
-      end
-    end
-    noise_unit = Digest::MD5.hexdigest("#{listing.id}-#{today}").to_i(16).to_f / (2**128)
-    noise      = (noise_unit * 2 - 1) * PicksSelector::NOISE_MAGNITUDE
-    score      = vintage + condition + section + desirability + meta + freshness + noise
 
     puts "#{listing.artist} – #{listing.title} (#{listing.year})"
     puts "  ID:        #{listing.id}"
@@ -138,15 +108,14 @@ namespace :milkcrate do
     puts
     puts "  TOTAL SCORE: #{score.round(3)}"
     puts "  ─────────────────────────────"
-    puts "  vintage:     #{vintage}"
-    puts "  condition:   #{condition}#{condition == 0 ? " (condition=#{listing.condition.inspect} not matched)" : ""}"
-    puts "  section:     #{section}  (genre_count=#{genre_count}, threshold=#{PicksSelector::SMALL_GENRE_THRESHOLD})"
-    puts "  desirability: #{desirability.round(3)}"
-    puts "    log10(#{total}).clamp(0,#{PicksSelector::DESIRABILITY_LOG_CAP}): #{total > 0 ? Math.log10(total).clamp(0, PicksSelector::DESIRABILITY_LOG_CAP).round(3) : 0}"
-    puts "    ratio bonus/penalty: #{have >= PicksSelector::WANT_HAVE_MIN_HAVE ? (want.to_f / have >= PicksSelector::WANT_HAVE_RATIO_HIGH ? "+#{PicksSelector::WANT_HAVE_HIGH_BONUS}" : (want.to_f / have <= PicksSelector::WANT_HAVE_RATIO_LOW ? "#{PicksSelector::WANT_HAVE_LOW_PENALTY}" : "none")) : "n/a (have < #{PicksSelector::WANT_HAVE_MIN_HAVE})"}"
-    puts "  metadata:    #{meta}"
-    puts "  freshness:   #{freshness}"
-    puts "  noise:       #{noise.round(3)}"
+    puts "  vintage:     #{breakdown[:vintage]}"
+    puts "  condition:   #{breakdown[:condition]}#{breakdown[:condition] == 0 ? " (condition=#{listing.condition.inspect} not matched)" : ""}"
+    puts "  desirability: #{breakdown[:desirability].round(3)}"
+    puts "    log10(#{total}).clamp(0,#{RecordScorer::DESIRABILITY_LOG_CAP}): #{total > 0 ? Math.log10(total).clamp(0, RecordScorer::DESIRABILITY_LOG_CAP).round(3) : 0}"
+    puts "    ratio bonus/penalty: #{have >= RecordScorer::WANT_HAVE_MIN_HAVE ? (want.to_f / have >= RecordScorer::WANT_HAVE_RATIO_HIGH ? "+#{RecordScorer::WANT_HAVE_HIGH_BONUS}" : (want.to_f / have <= RecordScorer::WANT_HAVE_RATIO_LOW ? "#{RecordScorer::WANT_HAVE_LOW_PENALTY}" : "none")) : "n/a (have < #{RecordScorer::WANT_HAVE_MIN_HAVE})"}"
+    puts "  metadata:    #{breakdown[:metadata]}"
+    puts "  freshness:   #{breakdown[:freshness]}"
+    puts "  noise:       #{breakdown[:noise].round(3)}"
   end
 
   desc "Onboard a new store: create Store, kick off full sync — rake milkcrate:add_store[discogs_username]"

--- a/spec/tasks/milkcrate_score_spec.rb
+++ b/spec/tasks/milkcrate_score_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "milkcrate:score" do
+  let!(:store) { create(:store, discogs_username: "philadelphiamusic") }
+  let!(:listing) do
+    create(
+      :listing,
+      store: store,
+      artist: "Test",
+      title: "Record",
+      year: 1975,
+      genres: [ "Jazz" ],
+      styles: [ "Bebop" ],
+      condition: "VG+",
+      want_count: 40,
+      have_count: 20,
+      last_surfaced_at: nil
+    )
+  end
+  let(:expected_breakdown) { PicksSelector.new(store).score_breakdown_for(listing) }
+  let(:expected_total) { expected_breakdown.values.sum.round(3) }
+
+  before(:all) do
+    Rake.application = Rake::Application.new
+    Rails.application.load_tasks
+  end
+
+  after do
+    Rake::Task["milkcrate:score"].reenable
+  end
+
+  it "prints a score breakdown for a valid listing" do
+    expect { Rake::Task["milkcrate:score"].invoke(listing.id.to_s) }
+      .to output(/TOTAL SCORE: #{Regexp.escape(expected_total.to_s)}/).to_stdout
+  end
+
+  it "prints the listing artist and title" do
+    expect { Rake::Task["milkcrate:score"].invoke(listing.id.to_s) }
+      .to output(/Test – Record/).to_stdout
+  end
+
+  it "prints the live scoring breakdown" do
+    expect { Rake::Task["milkcrate:score"].invoke(listing.id.to_s) }
+      .to output(/vintage:\s+#{Regexp.escape(expected_breakdown[:vintage].to_s)}/).to_stdout
+  end
+
+  it "raises without a listing ID" do
+    expect { Rake::Task["milkcrate:score"].invoke }
+      .to raise_error(RuntimeError, /Usage/)
+  end
+end


### PR DESCRIPTION
Expose PicksSelector#score_breakdown_for to return component
scores for a listing, then delegate from the rake task instead
of duplicating scoring math inline. Add task spec covering
runnable success path and missing-arg error.

Closes #101