### PR TITLE
Make Turnstile failures observable and bounded

### DIFF
--- a/app/services/turnstile_verifier.rb
+++ b/app/services/turnstile_verifier.rb
@@ -1,5 +1,8 @@
 class TurnstileVerifier
   SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+  OPEN_TIMEOUT = 2
+  READ_TIMEOUT = 5
+  WRITE_TIMEOUT = 5
 
   def self.enabled?
     ActiveModel::Type::Boolean.new.cast(ENV.fetch("TURNSTILE_ENABLED", "false"))
@@ -21,7 +24,14 @@ class TurnstileVerifier
     end
 
     response.body["success"] == true
-  rescue Faraday::Error
+  rescue Faraday::ConnectionFailed => e
+    Rails.logger.warn "[TurnstileVerifier] Upstream connection failed: #{e.message}"
+    false
+  rescue Faraday::TimeoutError => e
+    Rails.logger.warn "[TurnstileVerifier] Upstream timeout: #{e.message}"
+    false
+  rescue Faraday::Error => e
+    Rails.logger.warn "[TurnstileVerifier] Upstream error: #{e.message}"
     false
   end
 
@@ -34,6 +44,9 @@ class TurnstileVerifier
     Faraday.new(url: SITEVERIFY_URL) do |faraday|
       faraday.request :url_encoded
       faraday.response :json
+      faraday.options.open_timeout = OPEN_TIMEOUT
+      faraday.options.timeout = READ_TIMEOUT
+      faraday.options.write_timeout = WRITE_TIMEOUT
     end
   end
   private_class_method :connection

--- a/spec/requests/waitlists_spec.rb
+++ b/spec/requests/waitlists_spec.rb
@@ -58,6 +58,33 @@ RSpec.describe "Waitlists", type: :request do
         }.not_to change(Waitlist, :count)
       end
 
+      it "re-renders the apply page with a Turnstile error when verification fails" do
+        allow(TurnstileVerifier).to receive(:verify).with(
+          token: "bad-token",
+          remote_ip: "127.0.0.1"
+        ).and_return(false)
+
+        post "/waitlist", params: valid_params.merge(turnstile_token: "bad-token")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Please confirm you are human.")
+      end
+
+      it "re-renders the apply page when upstream verification fails closed" do
+        allow(TurnstileVerifier).to receive(:verify).with(
+          token: "timeout-token",
+          remote_ip: "127.0.0.1"
+        ).and_return(false)
+
+        expect {
+          post "/waitlist", params: valid_params.merge(turnstile_token: "timeout-token")
+        }.not_to change(Waitlist, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("turnstile")
+        expect(response.body).to include("submitted")
+      end
+
       it "creates an entry when Turnstile verification succeeds" do
         allow(TurnstileVerifier).to receive(:verify).with(
           token: "good-token",

--- a/spec/services/turnstile_verifier_spec.rb
+++ b/spec/services/turnstile_verifier_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe TurnstileVerifier do
     end
   end
 
+  describe "timeout configuration" do
+    it "uses explicit open/read/write timeouts" do
+      faraday = Faraday.new do |f|
+        f.request :url_encoded
+      end
+
+      expect(described_class::OPEN_TIMEOUT).to eq(2)
+      expect(described_class::READ_TIMEOUT).to eq(5)
+      expect(described_class::WRITE_TIMEOUT).to eq(5)
+    end
+  end
+
   describe ".verify" do
     it "returns false without a token" do
       ENV["TURNSTILE_SECRET_KEY"] = "secret"
@@ -60,6 +72,32 @@ RSpec.describe TurnstileVerifier do
       stub_turnstile_response("success" => false)
 
       expect(described_class.verify(token: "token", remote_ip: "127.0.0.1")).to eq(false)
+    end
+
+    it "returns false and logs on connection failure" do
+      ENV["TURNSTILE_SECRET_KEY"] = "secret"
+      connection = instance_double(Faraday::Connection)
+      allow(connection).to receive(:post).and_raise(Faraday::ConnectionFailed, "connection refused")
+      allow(described_class).to receive(:connection).and_return(connection)
+      allow(Rails.logger).to receive(:warn)
+
+      result = described_class.verify(token: "token", remote_ip: "127.0.0.1")
+
+      expect(result).to eq(false)
+      expect(Rails.logger).to have_received(:warn).with(/Upstream connection failed/)
+    end
+
+    it "returns false and logs on timeout" do
+      ENV["TURNSTILE_SECRET_KEY"] = "secret"
+      connection = instance_double(Faraday::Connection)
+      allow(connection).to receive(:post).and_raise(Faraday::TimeoutError, "timeout")
+      allow(described_class).to receive(:connection).and_return(connection)
+      allow(Rails.logger).to receive(:warn)
+
+      result = described_class.verify(token: "token", remote_ip: "127.0.0.1")
+
+      expect(result).to eq(false)
+      expect(Rails.logger).to have_received(:warn).with(/Upstream timeout/)
     end
   end
 

--- a/spec/services/turnstile_verifier_spec.rb
+++ b/spec/services/turnstile_verifier_spec.rb
@@ -35,18 +35,6 @@ RSpec.describe TurnstileVerifier do
     end
   end
 
-  describe "timeout configuration" do
-    it "uses explicit open/read/write timeouts" do
-      faraday = Faraday.new do |f|
-        f.request :url_encoded
-      end
-
-      expect(described_class::OPEN_TIMEOUT).to eq(2)
-      expect(described_class::READ_TIMEOUT).to eq(5)
-      expect(described_class::WRITE_TIMEOUT).to eq(5)
-    end
-  end
-
   describe ".verify" do
     it "returns false without a token" do
       ENV["TURNSTILE_SECRET_KEY"] = "secret"


### PR DESCRIPTION
Add explicit connection/read/write timeouts to Turnstile HTTP
client. Distinguish and log upstream connection failures and
timeouts separately from invalid-token rejections while keeping
conservative false return for all failure modes.

Closes #105