### PR TITLE
Add real mailer flow for seller onboarding

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,6 +9,7 @@ class PagesController < ApplicationController
 
   def apply
     render inertia: "apply", props: {
+      submitted: flash[:submitted] || false,
       copy: t("pages.apply").to_h,
       turnstile: {
         enabled: TurnstileVerifier.enabled?,

--- a/app/controllers/waitlists_controller.rb
+++ b/app/controllers/waitlists_controller.rb
@@ -13,7 +13,7 @@ class WaitlistsController < ApplicationController
 
     if entry.save
       SellerMailer.confirmation(entry).deliver_later
-      render inertia: "apply", props: apply_props.merge(submitted: true)
+      redirect_to apply_path, flash: { notice: "You're on the list! We'll be in touch.", submitted: true }
     else
       render inertia: "apply", props: apply_props.merge(
         submitted: false,

--- a/app/controllers/waitlists_controller.rb
+++ b/app/controllers/waitlists_controller.rb
@@ -12,6 +12,7 @@ class WaitlistsController < ApplicationController
     entry = Waitlist.new(waitlist_params)
 
     if entry.save
+      SellerMailer.confirmation(entry).deliver_later
       render inertia: "apply", props: apply_props.merge(submitted: true)
     else
       render inertia: "apply", props: apply_props.merge(

--- a/app/mailers/seller_mailer.rb
+++ b/app/mailers/seller_mailer.rb
@@ -1,0 +1,6 @@
+class SellerMailer < ApplicationMailer
+  def confirmation(waitlist)
+    @waitlist = waitlist
+    mail to: waitlist.email, subject: "Welcome to Milkcrate — we're reviewing your store"
+  end
+end

--- a/app/views/seller_mailer/confirmation.html.erb
+++ b/app/views/seller_mailer/confirmation.html.erb
@@ -16,6 +16,6 @@
 <hr style="border: none; border-top: 1px solid #eee; margin: 2rem 0;">
 
 <p style="color: #999; font-size: 0.8rem;">
-  The Milkcrate Team<br>
-  <a href="https://milkcrate.com" style="color: #999;">milkcrate.com</a>
+  Patrick<br>
+  <a href="https://milkcrate.fm" style="color: #999;">milkcrate.fm</a>
 </p>

--- a/app/views/seller_mailer/confirmation.html.erb
+++ b/app/views/seller_mailer/confirmation.html.erb
@@ -1,0 +1,21 @@
+<h1 style="font-size: 1.25rem; margin-bottom: 0.5rem;">Hi <%= @waitlist.name %>,</h1>
+
+<p style="color: #555; line-height: 1.6;">
+  Thanks for your interest in Milkcrate. We've received your application and will review your store shortly.
+</p>
+
+<p style="color: #555; line-height: 1.6;">
+  <strong>Discogs username:</strong> <%= @waitlist.discogs_username %><br>
+  <strong>Email:</strong> <%= @waitlist.email %>
+</p>
+
+<p style="color: #555; line-height: 1.6;">
+  We'll reach out to you directly at this email once we've completed our review.
+</p>
+
+<hr style="border: none; border-top: 1px solid #eee; margin: 2rem 0;">
+
+<p style="color: #999; font-size: 0.8rem;">
+  The Milkcrate Team<br>
+  <a href="https://milkcrate.com" style="color: #999;">milkcrate.com</a>
+</p>

--- a/app/views/seller_mailer/confirmation.text.erb
+++ b/app/views/seller_mailer/confirmation.text.erb
@@ -1,0 +1,11 @@
+Hi <%= @waitlist.name %>,
+
+Thanks for your interest in Milkcrate. We've received your application
+and will review your store shortly.
+
+Discogs username: <%= @waitlist.discogs_username %>
+Email: <%= @waitlist.email %>
+
+We'll reach out to you directly at this email once we've completed our review.
+
+— The Milkcrate Team

--- a/spec/mailers/seller_mailer_spec.rb
+++ b/spec/mailers/seller_mailer_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe SellerMailer, type: :mailer do
+  describe "#confirmation" do
+    let(:waitlist) { create(:waitlist, name: "Test Store", email: "store@example.com", discogs_username: "teststore") }
+    let(:mail) { described_class.confirmation(waitlist) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Welcome to Milkcrate — we're reviewing your store")
+      expect(mail.to).to eq(["store@example.com"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body with seller name" do
+      expect(mail.text_part.body).to include("Test Store")
+      expect(mail.html_part.body).to include("Test Store")
+    end
+
+    it "includes the Discogs username" do
+      expect(mail.text_part.body).to include("teststore")
+      expect(mail.html_part.body).to include("teststore")
+    end
+  end
+end

--- a/spec/mailers/seller_mailer_spec.rb
+++ b/spec/mailers/seller_mailer_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe SellerMailer, type: :mailer do
 
     it "renders the headers" do
       expect(mail.subject).to eq("Welcome to Milkcrate — we're reviewing your store")
-      expect(mail.to).to eq(["store@example.com"])
-      expect(mail.from).to eq(["from@example.com"])
+      expect(mail.to).to eq([ "store@example.com" ])
+      expect(mail.from).to eq([ "from@example.com" ])
     end
 
     it "renders the body with seller name" do

--- a/spec/requests/waitlists_spec.rb
+++ b/spec/requests/waitlists_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe "Waitlists", type: :request do
         }.to change(Waitlist, :count).by(1)
       end
 
+      it "sends a confirmation email" do
+        expect {
+          post "/waitlist", params: valid_params
+        }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
+          "SellerMailer", "confirmation", "deliver_now", any_args
+        )
+      end
+
       it "renders the apply page with submitted: true" do
         post "/waitlist", params: valid_params
         expect(response).to have_http_status(:ok)

--- a/spec/requests/waitlists_spec.rb
+++ b/spec/requests/waitlists_spec.rb
@@ -29,10 +29,22 @@ RSpec.describe "Waitlists", type: :request do
         )
       end
 
-      it "renders the apply page with submitted: true" do
+      it "redirects to the apply page" do
         post "/waitlist", params: valid_params
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(apply_path)
+      end
+
+      it "renders the apply page with submitted: true after redirect" do
+        post "/waitlist", params: valid_params
+        follow_redirect!
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("submitted")
+      end
+
+      it "is refresh-safe: redirect prevents form resubmission on refresh" do
+        post "/waitlist", params: valid_params
+        expect(response).to have_http_status(:found)
       end
     end
 


### PR DESCRIPTION
Create SellerMailer with confirmation email sent after successful
waitlist signup. Add HTML and text mailer views with seller name
and Discogs username. Email is delivered asynchronously via
deliver_later. Add mailer and request specs.

Closes #107