### PR TITLE
feat(motion): Phase 2 foundation — CSS motion tokens, springPress wiring

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -25,6 +25,16 @@
   --mc-accent-dim:  #8a3020;
   --mc-border:      #352a20;
   --mc-notice:      #352020;
+
+  /* Motion tokens — inspectable in DevTools, usable by non-React CSS */
+  --mc-spring-stiffness: 300;
+  --mc-spring-damping: 26;
+  --mc-scale-press: 0.97;
+  --mc-scale-hover: 1.05;
+  --mc-tilt-hover: 1.5deg;
+  --mc-lift-hover: 3px;
+  --mc-duration-hover: 0.2s;
+  --mc-duration-press: 0.12s;
 }
 
 [data-theme="light"] {

--- a/app/frontend/components/tactile_card.tsx
+++ b/app/frontend/components/tactile_card.tsx
@@ -1,6 +1,5 @@
 import { motion } from "framer-motion"
 import { useTactileHover } from "@/hooks/use_tactile_hover"
-import { springTactile } from "@/lib/motion_tokens"
 
 interface Props {
   /** Resting rotation in degrees when not hovered. */
@@ -27,12 +26,12 @@ export default function TactileCard({
   className,
   style,
 }: Props) {
-  const { transform, handlers } = useTactileHover({ restingTilt, disableTilt })
+  const { transform, transition, handlers } = useTactileHover({ restingTilt, disableTilt })
 
   return (
     <motion.div
       animate={transform}
-      transition={springTactile}
+      transition={transition}
       className={className}
       style={style}
       {...handlers}

--- a/app/frontend/hooks/use_tactile_hover.test.tsx
+++ b/app/frontend/hooks/use_tactile_hover.test.tsx
@@ -18,6 +18,7 @@ describe("useTactileHover", () => {
     expect(result.current.isHovered).toBe(false)
     expect(result.current.isPressed).toBe(false)
     expect(result.current.transform).toEqual({ rotate: 0, scale: 1, y: 0 })
+    expect(result.current.transition).toBeDefined()
   })
 
   it("sets isHovered on pointer enter", () => {
@@ -82,6 +83,17 @@ describe("useTactileHover", () => {
     act(() => result.current.handlers.onPointerEnter(pointerEvent))
     // Hovered: still no tilt
     expect(result.current.transform.rotate).toBe(0)
+  })
+
+  it("provides snappier press transition when pressed", () => {
+    const { result } = renderHook(() => useTactileHover(), { wrapper })
+
+    // Idle: tactile spring
+    const idleTransition = result.current.transition
+
+    act(() => result.current.handlers.onPointerDown(pointerEvent))
+    // Pressed: snappier press spring
+    expect(result.current.transition).not.toEqual(idleTransition)
   })
 
   it("applies restingTilt when idle", () => {

--- a/app/frontend/hooks/use_tactile_hover.ts
+++ b/app/frontend/hooks/use_tactile_hover.ts
@@ -1,10 +1,12 @@
 import { useState, useCallback, useMemo } from "react"
-import type { MotionStyle } from "framer-motion"
+import type { MotionStyle, Transition } from "framer-motion"
 import {
   SCALE_PRESS,
   SCALE_HOVER,
   LIFT_HOVER,
   TILT_HOVER,
+  springTactile,
+  springPress,
 } from "@/lib/motion_tokens"
 import { useReducedMotionContext } from "@/components/storefront_motion_config"
 
@@ -27,6 +29,8 @@ interface TactileState {
   isPressed: boolean
   /** Framer Motion animate target — updated reactively. */
   transform: MotionStyle
+  /** Transition to use for the current state — snappier on press. */
+  transition: Transition
   /** Pointer event handlers to spread onto a motion element. */
   handlers: TactileHandlers
 }
@@ -98,5 +102,5 @@ export function useTactileHover(
     return { rotate, scale, y }
   }, [reducedMotion, disableTilt, isHovered, isPressed, restingTilt])
 
-  return { isHovered, isPressed, transform, handlers }
+  return { isHovered, isPressed, transform, transition: isPressed ? springPress : springTactile, handlers }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the storefront animation refactor: add CSS custom properties for DevTools inspectability and wire the previously-unused `springPress` token so press interactions feel snappier than hover.

## What changed

- **CSS motion tokens** — Added `--mc-spring-stiffness`, `--mc-scale-press`, `--mc-duration-hover`, etc. to `:root` in `application.css`. These mirror the TypeScript constants in `motion_tokens.ts` for DevTools visibility and CSS-only consumers.

- **springPress wired into useTactileHover** — The hook now returns a state-dependent `transition` field: `springTactile` (300/26) for idle/hover, `springPress` (400/28) when pressed. TactileCard consumes this instead of hardcoding `springTactile` for all states.

## Design decision

The hook computes `transition` alongside `transform` — both are state-derived and belong together. This avoids duplicating the press-vs-hover logic in every consumer.

---

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — internal wiring change with no new user-facing behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/Gemini_3.1_Pro-4285F4?logo=googlegemini&logoColor=white)
