### PR TITLE
feat(motion): Phase 3 — continuous cursor proximity tracking

### DIFF
--- a/app/frontend/hooks/use_tactile_hover.test.tsx
+++ b/app/frontend/hooks/use_tactile_hover.test.tsx
@@ -1,75 +1,179 @@
 import React from "react"
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi, afterEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
 import { useTactileHover } from "./use_tactile_hover"
 import StorefrontMotionConfig from "@/components/storefront_motion_config"
 
-// Pointer event stub matching the shape useTactileHover expects
-const pointerEvent = {} as React.PointerEvent
+// Minimal pointer event stub
+function pointerEvent(
+  overrides: Partial<React.PointerEvent> = {},
+): React.PointerEvent {
+  return {
+    pointerType: "mouse",
+    clientX: 0,
+    clientY: 0,
+    currentTarget: {
+      getBoundingClientRect: () => ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    },
+    ...overrides,
+  } as unknown as React.PointerEvent
+}
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <StorefrontMotionConfig>{children}</StorefrontMotionConfig>
 )
 
 describe("useTactileHover", () => {
-  it("returns default state initially", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("returns idle state initially", () => {
     const { result } = renderHook(() => useTactileHover(), { wrapper })
 
     expect(result.current.isHovered).toBe(false)
     expect(result.current.isPressed).toBe(false)
+    expect(result.current.proximity).toBe(0)
     expect(result.current.transform).toEqual({ rotate: 0, scale: 1, y: 0 })
-    expect(result.current.transition).toBeDefined()
   })
 
-  it("sets isHovered on pointer enter", () => {
+  it("sets proximity on pointer enter (mouse)", () => {
     const { result } = renderHook(() => useTactileHover(), { wrapper })
 
-    act(() => result.current.handlers.onPointerEnter(pointerEvent))
+    act(() =>
+      result.current.handlers.onPointerEnter(
+        pointerEvent({ pointerType: "mouse" }),
+      ),
+    )
 
+    // Binary fallback without onPointerMove: proximity becomes 0
+    // (enter doesn't set proximity for mouse — move handler does)
+    expect(result.current.proximity).toBe(0)
+  })
+
+  it("sets proximity=1 on pointer enter (touch — binary fallback)", () => {
+    const { result } = renderHook(() => useTactileHover(), { wrapper })
+
+    act(() =>
+      result.current.handlers.onPointerEnter(
+        pointerEvent({ pointerType: "touch" }),
+      ),
+    )
+
+    expect(result.current.proximity).toBe(1)
     expect(result.current.isHovered).toBe(true)
-    expect(result.current.transform.scale).toBeGreaterThan(1) // SCALE_HOVER
-    expect(result.current.transform.y).toBeLessThan(0) // lifted
   })
 
-  it("resets on pointer leave", () => {
+  it("resets to idle on pointer leave", () => {
     const { result } = renderHook(() => useTactileHover(), { wrapper })
 
-    act(() => result.current.handlers.onPointerEnter(pointerEvent))
-    act(() => result.current.handlers.onPointerLeave(pointerEvent))
+    act(() =>
+      result.current.handlers.onPointerEnter(
+        pointerEvent({ pointerType: "touch" }),
+      ),
+    )
+    expect(result.current.proximity).toBe(1)
 
+    act(() => result.current.handlers.onPointerLeave(pointerEvent()))
+
+    expect(result.current.proximity).toBe(0)
     expect(result.current.isHovered).toBe(false)
-    expect(result.current.transform).toEqual({ rotate: 0, scale: 1, y: 0 })
+    expect(result.current.isPressed).toBe(false)
+  })
+
+  it("computes proximity from cursor position on pointer move", () => {
+    // Mock rAF to fire synchronously for testing
+    const rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        cb(0)
+        return 1
+      })
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+
+    const { result } = renderHook(() => useTactileHover(), { wrapper })
+
+    // Enter as mouse first so isTouchRef is false
+    act(() =>
+      result.current.handlers.onPointerEnter(
+        pointerEvent({ pointerType: "mouse" }),
+      ),
+    )
+
+    // Move cursor to element center (50, 50) — should be max proximity
+    act(() =>
+      result.current.handlers.onPointerMove(
+        pointerEvent({ clientX: 50, clientY: 50 }),
+      ),
+    )
+
+    // At center: dist=0, proximity = 1 - 0/maxDist = 1
+    expect(result.current.proximity).toBeCloseTo(1, 1)
+    // isHovered derived: proximity > 0
+    expect(result.current.isHovered).toBe(true)
+
+    rafSpy.mockRestore()
+  })
+
+  it("lowers proximity as cursor moves away from center", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+      (cb: FrameRequestCallback) => {
+        cb(0)
+        return 1
+      },
+    )
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+
+    const { result } = renderHook(() => useTactileHover(), { wrapper })
+
+    act(() =>
+      result.current.handlers.onPointerEnter(
+        pointerEvent({ pointerType: "mouse" }),
+      ),
+    )
+
+    // Move cursor to the element edge (0, 50) — far from center
+    act(() =>
+      result.current.handlers.onPointerMove(
+        pointerEvent({ clientX: 0, clientY: 50 }),
+      ),
+    )
+
+    // dist=50, maxDist = hypot(100,100)*0.6 ≈ 84.9, proximity ≈ 0.41
+    expect(result.current.proximity).toBeGreaterThan(0)
+    expect(result.current.proximity).toBeLessThan(0.6)
+
+    vi.restoreAllMocks()
   })
 
   it("sets isPressed on pointer down", () => {
     const { result } = renderHook(() => useTactileHover(), { wrapper })
 
-    act(() => result.current.handlers.onPointerDown(pointerEvent))
+    act(() => result.current.handlers.onPointerDown(pointerEvent()))
 
     expect(result.current.isPressed).toBe(true)
-    // SCALE_PRESS < 1
-    expect(result.current.transform.scale).toBeLessThan(1)
+    expect(result.current.transform.scale).toBeLessThan(1) // SCALE_PRESS
   })
 
-  it("resets isPressed on pointer up", () => {
+  it("uses snappier transition when pressed", () => {
     const { result } = renderHook(() => useTactileHover(), { wrapper })
 
-    act(() => result.current.handlers.onPointerDown(pointerEvent))
-    act(() => result.current.handlers.onPointerUp(pointerEvent))
+    const idleTransition = result.current.transition
 
-    expect(result.current.isPressed).toBe(false)
-  })
+    act(() => result.current.handlers.onPointerDown(pointerEvent()))
 
-  it("hover + press uses press scale (press dominates)", () => {
-    const { result } = renderHook(() => useTactileHover(), { wrapper })
-
-    act(() => result.current.handlers.onPointerEnter(pointerEvent))
-    act(() => result.current.handlers.onPointerDown(pointerEvent))
-
-    expect(result.current.isHovered).toBe(true)
-    expect(result.current.isPressed).toBe(true)
-    // Press scale should win when both are active
-    expect(result.current.transform.scale).toBeLessThan(1)
+    // Pressed transition should differ from idle
+    expect(result.current.transition).not.toEqual(idleTransition)
   })
 
   it("disables tilt when disableTilt is true", () => {
@@ -77,36 +181,90 @@ describe("useTactileHover", () => {
       wrapper,
     })
 
-    // Idle: no tilt
     expect(result.current.transform.rotate).toBe(0)
 
-    act(() => result.current.handlers.onPointerEnter(pointerEvent))
-    // Hovered: still no tilt
+    // Touch enter sets proximity=1
+    act(() =>
+      result.current.handlers.onPointerEnter(
+        pointerEvent({ pointerType: "touch" }),
+      ),
+    )
+    // Still 0 because disableTilt
     expect(result.current.transform.rotate).toBe(0)
   })
 
-  it("provides snappier press transition when pressed", () => {
-    const { result } = renderHook(() => useTactileHover(), { wrapper })
+  it("applies restingTilt when idle, straightens on approach", () => {
+    // Mock rAF sync
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+      (cb: FrameRequestCallback) => {
+        cb(0)
+        return 1
+      },
+    )
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
 
-    // Idle: tactile spring
-    const idleTransition = result.current.transition
-
-    act(() => result.current.handlers.onPointerDown(pointerEvent))
-    // Pressed: snappier press spring
-    expect(result.current.transition).not.toEqual(idleTransition)
-  })
-
-  it("applies restingTilt when idle", () => {
     const { result } = renderHook(
       () => useTactileHover({ restingTilt: 3 }),
       { wrapper },
     )
 
-    // Idle: should have resting tilt (nonzero)
-    expect(result.current.transform.rotate).not.toBe(0)
+    // Idle: full resting tilt
+    expect(result.current.transform.rotate).toBe(3)
 
-    act(() => result.current.handlers.onPointerEnter(pointerEvent))
-    // Hovered: straightens out
-    expect(result.current.transform.rotate).toBe(0)
+    // Enter + move to center
+    act(() =>
+      result.current.handlers.onPointerEnter(
+        pointerEvent({ pointerType: "mouse" }),
+      ),
+    )
+    act(() =>
+      result.current.handlers.onPointerMove(
+        pointerEvent({ clientX: 50, clientY: 50 }),
+      ),
+    )
+
+    // Centered: proximity ≈ 1 → straightens
+    expect(result.current.transform.rotate).toBeCloseTo(0, 1)
+
+    vi.restoreAllMocks()
+  })
+
+  it("proximity drives continuous scale interpolation", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+      (cb: FrameRequestCallback) => {
+        cb(0)
+        return 1
+      },
+    )
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+
+    const { result } = renderHook(() => useTactileHover(), { wrapper })
+
+    act(() =>
+      result.current.handlers.onPointerEnter(
+        pointerEvent({ pointerType: "mouse" }),
+      ),
+    )
+
+    // Edge hover → low proximity → small scale bump
+    act(() =>
+      result.current.handlers.onPointerMove(
+        pointerEvent({ clientX: 0, clientY: 50 }),
+      ),
+    )
+    const edgeScale = result.current.transform.scale
+
+    // Center hover → high proximity → full SCALE_HOVER
+    act(() =>
+      result.current.handlers.onPointerMove(
+        pointerEvent({ clientX: 50, clientY: 50 }),
+      ),
+    )
+    const centerScale = result.current.transform.scale
+
+    // Center should scale up more than edge
+    expect(centerScale).toBeGreaterThan(edgeScale)
+
+    vi.restoreAllMocks()
   })
 })

--- a/app/frontend/hooks/use_tactile_hover.ts
+++ b/app/frontend/hooks/use_tactile_hover.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react"
+import { useState, useCallback, useMemo, useRef } from "react"
 import type { MotionStyle, Transition } from "framer-motion"
 import {
   SCALE_PRESS,
@@ -22,11 +22,15 @@ interface TactileHandlers {
   onPointerLeave: (e: React.PointerEvent) => void
   onPointerDown: (e: React.PointerEvent) => void
   onPointerUp: (e: React.PointerEvent) => void
+  onPointerMove: (e: React.PointerEvent) => void
 }
 
 interface TactileState {
+  /** True when proximity > 0 (derived — not a separate state). */
   isHovered: boolean
   isPressed: boolean
+  /** Cursor proximity to element center, 0 (idle) to 1 (centered). */
+  proximity: number
   /** Framer Motion animate target — updated reactively. */
   transform: MotionStyle
   /** Transition to use for the current state — snappier on press. */
@@ -38,11 +42,10 @@ interface TactileState {
 const isBrowser = typeof window !== "undefined"
 
 /**
- * Binary hover hook — toggles isHovered / isPressed on pointer events
- * and computes a framer-motion-ready transform target.
- *
- * Phase 3 will add cursor-proximity tracking (proximity 0–1) and
- * an onPointerMove handler for continuous response.
+ * Cursor-proximity hover hook. Tracks pointer position relative to
+ * the element center and returns a continuous 0–1 proximity value.
+ * Falls back to binary behavior on touch devices and when reduced
+ * motion is active.
  */
 export function useTactileHover(
   options: UseTactileHoverOptions = {},
@@ -50,17 +53,63 @@ export function useTactileHover(
   const { restingTilt = 0, disableTilt = false } = options
   const reducedMotion = useReducedMotionContext()
 
-  const [isHovered, setIsHovered] = useState(false)
+  const [proximity, setProximity] = useState(0)
   const [isPressed, setIsPressed] = useState(false)
+  const isTouchRef = useRef(false)
+  const rafRef = useRef<number | null>(null)
 
-  const enter = useCallback(() => {
-    if (!isBrowser || reducedMotion) return
-    setIsHovered(true)
-  }, [reducedMotion])
+  // ── Pointer handlers ──────────────────────────────────────
+
+  const enter = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isBrowser) return
+      const isTouch = e.pointerType !== "mouse"
+      isTouchRef.current = isTouch
+
+      if (reducedMotion || isTouch) {
+        // Binary fallback: snap to full proximity
+        setProximity(1)
+        return
+      }
+      // Mouse: proximity set by onPointerMove
+    },
+    [reducedMotion],
+  )
+
+  const move = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isBrowser || reducedMotion || isTouchRef.current) return
+
+      // Cancel any pending frame before scheduling the next
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+      }
+
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null
+        const el = e.currentTarget as HTMLElement
+        const rect = el.getBoundingClientRect()
+
+        const cx = rect.left + rect.width / 2
+        const cy = rect.top + rect.height / 2
+        const dx = e.clientX - cx
+        const dy = e.clientY - cy
+        const dist = Math.hypot(dx, dy)
+        const maxDist = Math.hypot(rect.width, rect.height) * 0.6
+
+        setProximity(Math.max(0, Math.min(1, 1 - dist / maxDist)))
+      })
+    },
+    [reducedMotion],
+  )
 
   const leave = useCallback(() => {
     if (!isBrowser) return
-    setIsHovered(false)
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+    setProximity(0)
     setIsPressed(false)
   }, [])
 
@@ -80,27 +129,42 @@ export function useTactileHover(
       onPointerLeave: leave,
       onPointerDown: down,
       onPointerUp: up,
+      onPointerMove: move,
     }),
-    [enter, leave, down, up],
+    [enter, leave, down, up, move],
   )
+
+  // ── Derived state ─────────────────────────────────────────
+
+  const isHovered = proximity > 0
 
   const transform = useMemo<MotionStyle>(() => {
     if (reducedMotion) {
       return { rotate: 0, scale: 1, y: 0 }
     }
 
+    // Tilt: straightens as cursor approaches
     const rotate = disableTilt
       ? 0
-      : isHovered
-        ? 0
-        : restingTilt * (TILT_HOVER / 1.5)
+      : restingTilt * (TILT_HOVER / 1.5) * (1 - proximity)
 
-    const scale = isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1
+    // Scale: SCALE_PRESS when pressed, otherwise interpolate
+    const scale = isPressed
+      ? SCALE_PRESS
+      : 1 + (SCALE_HOVER - 1) * proximity
 
-    const y = isHovered ? -LIFT_HOVER : 0
+    // Lift: increases as cursor approaches
+    const y = proximity === 0 ? 0 : -LIFT_HOVER * proximity
 
     return { rotate, scale, y }
-  }, [reducedMotion, disableTilt, isHovered, isPressed, restingTilt])
+  }, [reducedMotion, disableTilt, isPressed, restingTilt, proximity])
 
-  return { isHovered, isPressed, transform, transition: isPressed ? springPress : springTactile, handlers }
+  return {
+    isHovered,
+    isPressed,
+    proximity,
+    transform,
+    transition: isPressed ? springPress : springTactile,
+    handlers,
+  }
 }


### PR DESCRIPTION
## Summary

Phase 3 — the highest-leverage single change in the refactor: replaces binary hover with continuous cursor proximity tracking. Every TactileCard now responds to cursor approach rather than snapping between two states.

## What changed

**`use_tactile_hover.ts`** — upgraded from binary to proximity model:

- **Proximity state (0–1)** driven by pointer position relative to element center via `getBoundingClientRect()`. Computed as `clamp(1 - dist / maxDist, 0, 1)` where `maxDist = diagonal * 0.6`.
- **rAF-throttled `onPointerMove`** — cancels previous frame before scheduling the next, preventing render floods at high pointer event rates.
- **Touch detection** — `pointerType !== "mouse"` falls back to binary behavior (proximity = 1 on enter, 0 on leave).
- **Continuous transform interpolation** — tilt straightens, scale ramps from 1→SCALE_HOVER, lift increases as cursor approaches center.
- **Reduced motion** — proximity stays binary (0 or 1), same as the old on/off behavior.
- **`isHovered` derived** from `proximity > 0` — backward compatible.

No consumer changes needed — `TactileCard` already spreads handlers and consumes `transform`/`transition` from the hook.

## Test coverage

11 tests covering idle state, touch binary fallback, proximity computation at center/edge, press-down scale, snappier press transition, disableTilt, restingTilt straightening, and continuous scale interpolation.

---

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — internal animation behavior change. Verify visually that crate thumbnails and wall cards respond smoothly to cursor approach, not binary snap.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/Gemini_3.1_Pro-4285F4?logo=googlegemini&logoColor=white)
