### PR TITLE
feat(motion): Phase 5 — crate-as-container identity

### DIFF
--- a/app/frontend/components/crate_card.tsx
+++ b/app/frontend/components/crate_card.tsx
@@ -1,4 +1,6 @@
 import { motion } from "framer-motion"
+import { useTactileHover } from "@/hooks/use_tactile_hover"
+import { springTactile, springPress, SCALE_HOVER, SCALE_PRESS } from "@/lib/motion_tokens"
 import type { Crate } from "../types/inertia"
 
 interface Props {
@@ -10,12 +12,11 @@ interface Props {
 export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
   const isFeatured = variant === "featured"
   const nameClass = isFeatured ? "text-base font-semibold" : "text-sm font-semibold"
-
-  const cardClasses = `group flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden hover:border-mc-accent transition-colors cursor-pointer text-left`
+  const { isHovered, isPressed, handlers } = useTactileHover({ restingTilt: -0.5 })
 
   if (crate.records.length === 0) {
     return (
-      <div className={cardClasses}>
+      <div className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left">
         <div className="px-3 pt-3 pb-2">
           <div className="mc-section-header">
             <span className={`mc-section-name ${nameClass}`}>{crate.name}</span>
@@ -29,34 +30,56 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
   }
 
   return (
-    <button
+    <motion.button
       type="button"
       onClick={() => onSelectCrate(crate.slug)}
-      className={cardClasses}
+      className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden cursor-pointer text-left"
+      animate={{
+        borderColor: isHovered ? "var(--mc-accent)" : "var(--mc-border)",
+        scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
+        y: isHovered ? -3 : 0,
+        rotate: isHovered ? 0 : -0.5,
+      }}
+      transition={isPressed ? springPress : springTactile}
       aria-label={`Open ${crate.name}`}
+      {...handlers}
     >
-      <div className="px-3 pt-3 pb-1.5">
+      {/* Header row — lid lift on hover */}
+      <motion.div
+        className="px-3 pt-3 pb-1.5"
+        style={{ transformOrigin: "top" }}
+        animate={{ y: isHovered ? -2 : 0 }}
+        transition={springTactile}
+      >
         <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-1">
           <span className={`mc-section-name ${nameClass} truncate flex-1`}>{crate.name}</span>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <span className="text-[10px] text-mc-accent font-bold uppercase tracking-widest sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+            {/* DIG → label — slides in on hover */}
+            <motion.span
+              className="text-[10px] text-mc-accent font-bold uppercase tracking-widest"
+              animate={{ opacity: isHovered ? 1 : 0, x: isHovered ? 0 : -4 }}
+              transition={springTactile}
+            >
               DIG →
-            </span>
+            </motion.span>
             <span className="mc-section-count text-xs">{crate.count}</span>
           </div>
         </div>
-      </div>
+      </motion.div>
 
-      <div className="grid grid-cols-2 gap-1.5 px-3 pb-3 pt-1.5">
+      {/* Thumbnail grid — scale together as a group */}
+      <motion.div
+        className="grid grid-cols-2 gap-1.5 px-3 pb-3 pt-1.5"
+        animate={{ scale: isHovered ? SCALE_HOVER : 1 }}
+        transition={springTactile}
+      >
         {crate.records.slice(0, 4).map((record, i) => {
           const src = record.cover_image_url ?? record.thumbnail_url
           return (
-            <motion.button
+            <button
               key={record.id}
               type="button"
               className="aspect-square rounded-sm bg-mc-bg-raised overflow-hidden border border-mc-border/50 cursor-pointer"
-              whileHover={{ scale: 1.05, zIndex: 10 }}
-              transition={{ type: "spring", stiffness: 300, damping: 22 }}
               onClick={(e) => {
                 e.stopPropagation()
                 onSelectCrate(crate.slug, i)
@@ -74,10 +97,10 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
               ) : (
                 <div className="w-full h-full flex items-center justify-center mc-dim text-lg">♪</div>
               )}
-            </motion.button>
+            </button>
           )
         })}
-      </div>
-    </button>
+      </motion.div>
+    </motion.button>
   )
 }

--- a/app/frontend/hooks/use_tactile_hover.ts
+++ b/app/frontend/hooks/use_tactile_hover.ts
@@ -61,7 +61,8 @@ export function useTactileHover(
   // ── Proximity math ───────────────────────────────────────
 
   const updateProximity = useCallback((e: React.PointerEvent) => {
-    const el = e.currentTarget as HTMLElement
+    const el = e.currentTarget as HTMLElement | null
+    if (!el) return 0
     const rect = el.getBoundingClientRect()
 
     const cx = rect.left + rect.width / 2
@@ -102,7 +103,9 @@ export function useTactileHover(
 
       rafRef.current = requestAnimationFrame(() => {
         rafRef.current = null
-        setProximity(updateProximity(e))
+        if (e.currentTarget) {
+          setProximity(updateProximity(e))
+        }
       })
     },
     [reducedMotion, updateProximity],


### PR DESCRIPTION
## Summary

Phase 5 — the biggest visual-impact change. Crates go from plain CSS buttons with zero tactile identity to coordinated multi-element containers with lift, tilt, lid-opening header, and grouped thumbnails.

## What changed

`crate_card.tsx` now uses `useTactileHover` directly to drive coordinated animation from a single hover state:

- **Outer button** — tactile tilt (restingTilt -0.5°), lift (3px), scale (1.05), press-down (0.97). Border transitions to accent color on hover. Distinct from wall cards (positive alternating tilts).
- **Header "lid"** — translates up 2px on hover with `transformOrigin: "top"`, creating the lid-opening effect.
- **DIG → label** — slides in from -4px and fades in via framer-motion (was CSS `opacity` transition on `group-hover`).
- **Thumbnail grid** — scales as a group (1.05) tied to crate hover state. Individual thumbnails are now plain `<button>` elements — no per-thumbnail `motion.button` with independent hover.
- **Press-down** — `whileTap` equivalent via `isPressed` from the hook, using snappier `springPress`.

## Design decision

Used the hook directly instead of wrapping in `TactileCard` because the crate needs coordinated multi-element animation (lid, label, thumbnails) that a single wrapper can't express. The hook exposes `isHovered`/`isPressed` which drive `motion.div`/`motion.button`/`motion.span` children.

---

## Post-Deploy Monitoring & Validation

Verify visually: crate cards should tilt slightly at rest, lift and scale as cursor approaches, the header should "open" upward, the DIG → label should slide in, and all 4 thumbnails should scale together as a unit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/Gemini_3.1_Pro-4285F4?logo=googlegemini&logoColor=white)
