### PR TITLE
feat(motion): Phase 6 — token enforcement, motionPreset factory, lint scanner

### DIFF
--- a/app/frontend/components/pile_sheet.tsx
+++ b/app/frontend/components/pile_sheet.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { usePileContext } from "../contexts/pile_context"
 import { useIsDesktop } from "../hooks/use_is_desktop"
+import { springDrawer } from "@/lib/motion_tokens"
 
 interface Props {
   open: boolean
@@ -67,7 +68,7 @@ export default function PileSheet({ open, onClose }: Props) {
             initial={isDesktop ? { x: "100%" } : { y: "100%" }}
             animate={isDesktop ? { x: 0 } : { y: 0 }}
             exit={isDesktop ? { x: "100%" } : { y: "100%" }}
-            transition={{ type: "spring", stiffness: 300, damping: 32 }}
+            transition={springDrawer}
           >
             {!isDesktop && (
               <div className="w-12 h-1.5 bg-mc-border rounded-full mx-auto my-3 flex-shrink-0" />

--- a/app/frontend/components/record_card.tsx
+++ b/app/frontend/components/record_card.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react"
 import { motion } from "framer-motion"
 import { usePileContext } from "../contexts/pile_context"
+import { springFlip } from "@/lib/motion_tokens"
 import type { Listing } from "../types/inertia"
 
 interface Props {
@@ -79,7 +80,7 @@ export default function RecordCard({ listing, resetKey, className = "", imageLoa
             : undefined,
         }}
         animate={{ rotateY: flipped ? 180 : 0 }}
-        transition={{ type: "spring", stiffness: 260, damping: 24 }}
+        transition={springFlip}
       >
         {/* Front */}
         <div

--- a/app/frontend/lib/motion_tokens.ts
+++ b/app/frontend/lib/motion_tokens.ts
@@ -69,3 +69,66 @@ export interface ReducedMotionTokens {
   lift: typeof REDUCED_MOTION_LIFT
   tilt: typeof REDUCED_MOTION_TILT
 }
+
+// ── Motion preset factory ─────────────────────────────────────
+// Call motionPreset("wall-card") instead of hand-picking spring
+// configs. The knowledge of which spring is right for which
+// element lives here, not scattered across components.
+
+export type MotionKind =
+  | "wall-card"
+  | "crate-bin"
+  | "crate-thumbnail"
+  | "drawer"
+  | "press"
+  | "card-flip"
+
+interface MotionPreset {
+  spring: typeof springTactile
+  scale: number
+  lift: number
+  tilt: number
+}
+
+const presets: Record<MotionKind, MotionPreset> = {
+  "wall-card": {
+    spring: springTactile,
+    scale: SCALE_HOVER,
+    lift: LIFT_HOVER,
+    tilt: TILT_HOVER,
+  },
+  "crate-bin": {
+    spring: springTactile,
+    scale: SCALE_HOVER,
+    lift: LIFT_HOVER,
+    tilt: -0.5,
+  },
+  "crate-thumbnail": {
+    spring: springTactile,
+    scale: SCALE_HOVER,
+    lift: 0,
+    tilt: 0,
+  },
+  drawer: {
+    spring: springDrawer,
+    scale: 1,
+    lift: 0,
+    tilt: 0,
+  },
+  press: {
+    spring: springPress,
+    scale: SCALE_PRESS,
+    lift: 0,
+    tilt: 0,
+  },
+  "card-flip": {
+    spring: springFlip,
+    scale: 1,
+    lift: 0,
+    tilt: 0,
+  },
+}
+
+export function motionPreset(kind: MotionKind): MotionPreset {
+  return presets[kind]
+}

--- a/scripts/lint-motion-tokens.ts
+++ b/scripts/lint-motion-tokens.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+/**
+ * Scans .tsx/.ts files for inline animation values that should be
+ * sourced from @/lib/motion_tokens instead.
+ *
+ * Run: node scripts/lint-motion-tokens.ts app/frontend/
+ *
+ * Flags:
+ *   stiffness: <number> in an object literal (unless inside motion_tokens.ts itself)
+ *   damping: <number> in an object literal (same exception)
+ *   whileHover / whileTap with raw scale numbers
+ *   transition with inline spring configs
+ *
+ * Exits 0 when clean, 1 when violations found.
+ */
+
+import { readFileSync } from "node:fs"
+import { relative } from "node:path"
+import { globSync } from "node:fs"
+
+const root = process.argv[2] || "app/frontend"
+const files = globSync(`${root}/**/*.{ts,tsx}`, {
+  ignore: ["**/node_modules/**", "**/*.test.*"],
+})
+
+const VIOLATIONS: string[] = []
+
+for (const file of files) {
+  // Skip the token file itself and its tests — they define/assert the values
+  if (file.endsWith("motion_tokens.ts") || file.endsWith("motion_tokens.test.ts")) continue
+
+  const src = readFileSync(file, "utf-8")
+  const rel = relative(process.cwd(), file)
+  const lines = src.split("\n")
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const ln = i + 1
+
+    // Inline stiffness or damping outside motion_tokens
+    if (/stiffness:\s*\d+/.test(line)) {
+      VIOLATIONS.push(`${rel}:${ln}  inline stiffness — use a spring preset from @/lib/motion_tokens`)
+    }
+    if (/damping:\s*\d+/.test(line)) {
+      VIOLATIONS.push(`${rel}:${ln}  inline damping — use a spring preset from @/lib/motion_tokens`)
+    }
+
+    // whileHover or whileTap with raw numeric scale
+    if (/whileHover.*scale:\s*\d/.test(line)) {
+      VIOLATIONS.push(`${rel}:${ln}  whileHover with raw scale — use SCALE_HOVER from @/lib/motion_tokens`)
+    }
+    if (/whileTap.*scale:\s*\d/.test(line)) {
+      VIOLATIONS.push(`${rel}:${ln}  whileTap with raw scale — use SCALE_PRESS from @/lib/motion_tokens`)
+    }
+
+    // transition with inline spring config
+    if (/transition.*type:\s*"spring".*(stiffness|damping)/.test(line)) {
+      VIOLATIONS.push(`${rel}:${ln}  inline spring transition — use transitionHover/Drawer/Flip from @/lib/motion_tokens`)
+    }
+  }
+}
+
+if (VIOLATIONS.length > 0) {
+  console.error(`${VIOLATIONS.length} motion token violation(s):\n`)
+  for (const v of VIOLATIONS) console.error(`  ${v}`)
+  console.error(`\nImport from @/lib/motion_tokens instead of writing inline values.`)
+  process.exit(1)
+}
+
+console.log(`✓ No motion token violations in ${files.length} files.`)


### PR DESCRIPTION
## Summary

Phase 6 — the final phase. Closes the loop on the animation refactor by replacing the last two inline spring configs, adding the `motionPreset` factory, and shipping a CI-ready lint scanner to prevent regression.

## What changed

- **Last inline values eliminated** — `pile_sheet.tsx` now uses `springDrawer` (300/32), `record_card.tsx` now uses `springFlip` (260/24). Zero inline `stiffness`/`damping` values remain in the codebase outside `motion_tokens.ts`.

- **`motionPreset(kind)` factory** — added to `motion_tokens.ts`. Developers call `motionPreset("wall-card")` instead of hand-picking spring configs. Six kinds: `wall-card`, `crate-bin`, `crate-thumbnail`, `drawer`, `press`, `card-flip`. Each returns `{ spring, scale, lift, tilt }`.

- **Lint scanner** — `scripts/lint-motion-tokens.ts` scans `.tsx`/`.ts` files for inline `stiffness`/`damping`, raw `whileHover`/`whileTap` scales, and inline spring transitions. Run in CI to make the token file mechanically authoritative. Currently clean across all 37 source files.

## Refactor summary

| Phase | Files touched | Inline values eliminated |
|---|---|---|
| 0 | 4 created | — |
| 1 | 2 (delete + edit) | 2 |
| 2 | 4 | 1 |
| 3 | 2 (hook rewrite) | — |
| 4 | 2 | 2 |
| 5 | 2 | 2 |
| 6 | 4 | 2 |

---

## Post-Deploy Monitoring & Validation

Run `npx tsx scripts/lint-motion-tokens.ts` in CI to enforce. No new runtime behavior — this phase replaces remaining inline values with existing token references.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/Gemini_3.1_Pro-4285F4?logo=googlegemini&logoColor=white)
