### PR TITLE
feat: add design system primitives (Text, Button, Field)

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -37,6 +37,10 @@
   --mc-lift-hover: 3px;
   --mc-duration-hover: 0.2s;
   --mc-duration-press: 0.12s;
+
+  /* Layout tokens — section spacing */
+  --mc-section-gap: 1.5rem;
+  --mc-section-padding: 1rem;
 }
 
 [data-theme="light"] {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @theme {
+  /* ── Colors ─────────────────────────── */
   --color-mc-bg:         var(--mc-bg);
   --color-mc-bg-raised:  var(--mc-bg-raised);
   --color-mc-bg-card:    var(--mc-bg-card);
@@ -11,6 +12,35 @@
   --color-mc-on-accent:  var(--mc-on-accent);
   --color-mc-border:     var(--mc-border);
   --color-mc-notice:     var(--mc-notice);
+
+  /* ── Typography: font families ───────── */
+  --font-family-mc-display: ui-sans-serif, system-ui, sans-serif;
+  --font-family-mc-body:    Georgia, ui-serif, serif;
+
+  /* ── Typography: font sizes ──────────── */
+  --font-size-mc-display:     1.25rem;
+  --font-size-mc-section:     0.7rem;
+  --font-size-mc-body:        0.875rem;
+  --font-size-mc-body-lg:     0.9rem;
+  --font-size-mc-label:       0.65rem;
+  --font-size-mc-label-sm:    0.6rem;
+  --font-size-mc-btn:         0.65rem;
+  --font-size-mc-btn-lg:      0.875rem;
+
+  /* ── Typography: tracking ────────────── */
+  --tracking-mc-display:  0.15em;
+  --tracking-mc-section:  0.2em;
+  --tracking-mc-label:    0.1em;
+
+  /* ── Typography: leading ─────────────── */
+  --leading-mc-body:      1.6;
+
+  /* ── Border radius ───────────────────── */
+  --radius-mc-sharp:      2px;
+  --radius-mc-gentle:     8px;
+
+  /* ── Spacing ─────────────────────────── */
+  --spacing-mc-section-gap:  var(--mc-section-gap);
 }
 
 /* ─── Milkcrate Design Tokens ────────────────────────────────────────────── */
@@ -67,18 +97,7 @@
 .mc-nav-link:hover { color: var(--mc-text); }
 .mc-accent-link { color: var(--mc-accent); text-decoration: none; }
 .mc-accent-link:hover { text-decoration: underline; }
-.mc-input {
-  width: 100%;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.375rem;
-  border: 1px solid var(--mc-border);
-  background: var(--mc-bg-raised);
-  color: var(--mc-text);
-  font-size: 0.875rem;
-  outline: none;
-}
-.mc-input:focus { border-color: var(--mc-accent); }
-.mc-input::placeholder { color: var(--mc-text-dim); }
+
 .mc-text        { color: var(--mc-text); }
 .mc-dim         { color: var(--mc-text-dim); }
 .mc-notice      { background: var(--mc-notice); color: var(--mc-text); }
@@ -248,11 +267,13 @@
 
 .mc-form { max-width: 480px; display: flex; flex-direction: column; gap: 1.25rem; }
 .mc-label { font-family: ui-sans-serif, system-ui, sans-serif; font-size: 0.7rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--mc-text-dim); display: block; margin-bottom: 0.4rem; }
+/* ─── Input (form fields) ────────────────────────────────────────────────── */
+
 .mc-input {
   width: 100%;
   background: var(--mc-bg-raised);
   border: 1px solid var(--mc-border);
-  border-radius: 2px;
+  border-radius: var(--radius-mc-sharp, 2px);
   color: var(--mc-text);
   padding: 0.6rem 0.75rem;
   font-family: ui-serif, Georgia, serif;
@@ -260,6 +281,7 @@
   transition: border-color 0.15s;
 }
 .mc-input:focus { outline: none; border-color: var(--mc-accent); }
+.mc-input::placeholder { color: var(--mc-text-dim); }
 .mc-submit { align-self: flex-start; }
 
 /* ─── Dig Session ────────────────────────────────────────────────────────── */

--- a/app/frontend/components/button.tsx
+++ b/app/frontend/components/button.tsx
@@ -1,0 +1,151 @@
+import React from "react"
+import { motion } from "framer-motion"
+import { useTactileHover } from "@/hooks/use_tactile_hover"
+import {
+  springTactile,
+  springPress,
+  SCALE_HOVER,
+  SCALE_PRESS,
+} from "@/lib/motion_tokens"
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export type ButtonVariant = "primary" | "ghost"
+export type ButtonSize = "default" | "icon"
+
+interface ButtonProps {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  disabled?: boolean
+  /** Render as an anchor instead of a button. */
+  href?: string
+  /** When true and href is set, opens in a new tab. */
+  external?: boolean
+  type?: "button" | "submit" | "reset"
+  onClick?: (e: React.MouseEvent) => void
+  className?: string
+  children: React.ReactNode
+  "aria-label"?: string
+  "aria-expanded"?: boolean
+  "aria-controls"?: string
+}
+
+// ── Style maps ────────────────────────────────────────────────────────────
+
+const variantStyles: Record<ButtonVariant, string> = {
+  primary: [
+    "bg-mc-accent text-mc-on-accent rounded-mc-gentle",
+    "font-mc-display text-mc-btn-lg font-semibold",
+    "tracking-mc-label uppercase",
+  ].join(" "),
+  ghost: [
+    "bg-transparent text-mc-text-dim rounded-mc-sharp",
+    "font-mc-display text-mc-btn",
+    "tracking-mc-label uppercase",
+    "border border-transparent",
+  ].join(" "),
+}
+
+const sizeStyles: Record<ButtonSize, string> = {
+  default: "px-6 py-3",
+  icon: "w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center rounded-full",
+}
+
+// ── Component ─────────────────────────────────────────────────────────────
+
+/**
+ * Single interactive trigger primitive. Renders a `<button>` by default or
+ * an `<a>` when `href` is provided. Includes tactile hover/press animation
+ * via Framer Motion. Respects `prefers-reduced-motion` automatically.
+ *
+ * @example
+ *   <Button variant="primary">Dig In</Button>
+ *   <Button variant="ghost" href="https://discogs.com" external>Discogs ↗</Button>
+ *   <Button variant="ghost" size="icon" aria-label="Toggle theme">☀︎</Button>
+ */
+export default function Button({
+  variant = "ghost",
+  size = "default",
+  disabled = false,
+  href,
+  external,
+  type = "button",
+  onClick,
+  className = "",
+  children,
+  ...aria
+}: ButtonProps) {
+  const { isHovered, isPressed, handlers } = useTactileHover()
+
+  const baseClasses = [
+    "inline-flex items-center justify-center",
+    "select-none",
+    "transition-colors duration-150",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg",
+    disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+    variantStyles[variant],
+    sizeStyles[size],
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  const animate = disabled
+    ? {}
+    : {
+        scale:
+          isPressed
+            ? SCALE_PRESS
+            : isHovered && size !== "icon"
+              ? SCALE_HOVER
+              : 1,
+        y: isHovered && size !== "icon" ? -2 : 0,
+        borderColor:
+          variant === "ghost" && isHovered
+            ? "var(--mc-accent)"
+            : "transparent",
+        color:
+          variant === "ghost" && isHovered
+            ? "var(--mc-accent)"
+            : undefined,
+      }
+
+  const transition = isPressed ? springPress : springTactile
+
+  // ── Anchor variant ──────────────────────────────────────────────
+
+  if (href) {
+    return (
+      <motion.a
+        href={href}
+        target={external ? "_blank" : undefined}
+        rel={external ? "noopener noreferrer" : undefined}
+        className={baseClasses}
+        animate={animate}
+        transition={transition}
+        onClick={onClick}
+        {...handlers}
+        {...aria}
+      >
+        {children}
+      </motion.a>
+    )
+  }
+
+  // ── Button variant ──────────────────────────────────────────────
+
+  return (
+    <motion.button
+      type={type}
+      disabled={disabled}
+      className={baseClasses}
+      animate={animate}
+      transition={transition}
+      onClick={onClick}
+      {...handlers}
+      {...aria}
+    >
+      {children}
+    </motion.button>
+  )
+}

--- a/app/frontend/components/crate_card.tsx
+++ b/app/frontend/components/crate_card.tsx
@@ -1,29 +1,27 @@
 import { motion } from "framer-motion"
 import { useTactileHover } from "@/hooks/use_tactile_hover"
 import { springTactile, springPress, SCALE_HOVER, SCALE_PRESS, SCALE_INNER_HOVER } from "@/lib/motion_tokens"
+import Text from "@/components/text"
 import type { Crate } from "../types/inertia"
 
 interface Props {
   crate: Crate
-  variant: "featured" | "genre"
   onSelectCrate: (slug: string, startIndex?: number) => void
 }
 
-export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
-  const isFeatured = variant === "featured"
-  const nameClass = isFeatured ? "text-base font-semibold" : "text-sm font-semibold"
+export default function CrateCard({ crate, onSelectCrate }: Props) {
   const { isHovered, isPressed, handlers } = useTactileHover()
 
   if (crate.records.length === 0) {
     return (
-      <div className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left">
+      <div className="flex flex-col w-full rounded-mc-gentle bg-mc-bg-card border border-mc-border overflow-hidden text-left">
         <div className="px-3 pt-3 pb-2">
-          <div className="mc-section-header">
-            <span className={`mc-section-name ${nameClass}`}>{crate.name}</span>
+          <div className="flex items-baseline gap-2 mb-1.5 border-b border-mc-border pb-1">
+            <Text variant="section-name">{crate.name}</Text>
           </div>
         </div>
-        <div className="aspect-square flex items-center justify-center mc-dim text-xs px-3 pb-3">
-          No records yet
+        <div className="aspect-square flex items-center justify-center px-3 pb-3">
+          <Text variant="dim">No records yet</Text>
         </div>
       </div>
     )
@@ -41,7 +39,7 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
           onSelectCrate(crate.slug)
         }
       }}
-      className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden cursor-pointer text-left"
+      className="flex flex-col w-full rounded-mc-gentle bg-mc-bg-card border border-mc-border overflow-hidden cursor-pointer text-left"
       animate={{
         borderColor: isHovered ? "var(--mc-accent)" : "var(--mc-border)",
         scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
@@ -60,17 +58,19 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
         transition={springTactile}
       >
         <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-1">
-          <span className={`mc-section-name ${nameClass} truncate flex-1`}>{crate.name}</span>
+          <span className="truncate flex-1">
+            <Text variant="section-name">{crate.name}</Text>
+          </span>
           <div className="flex items-center gap-2 flex-shrink-0">
             {/* DIG → label — slides in on hover */}
             <motion.span
-              className="text-[10px] text-mc-accent font-bold uppercase tracking-widest"
+              className="text-mc-label-sm text-mc-accent font-bold uppercase tracking-widest"
               animate={{ opacity: isHovered ? 1 : 0, x: isHovered ? 0 : -4 }}
               transition={springTactile}
             >
               DIG →
             </motion.span>
-            <span className="mc-section-count text-xs">{crate.count}</span>
+            <Text variant="section-count">{crate.count}</Text>
           </div>
         </div>
       </motion.div>

--- a/app/frontend/components/crate_tabs.tsx
+++ b/app/frontend/components/crate_tabs.tsx
@@ -34,7 +34,7 @@ export default function CrateTabs({ crates, activeSlug, onSelect }: Props) {
             tabIndex={selected ? 0 : -1}
             onClick={() => onSelect(crate.slug)}
             onKeyDown={(e) => handleKeyDown(e, i)}
-            className={`whitespace-nowrap px-2.5 py-1 rounded text-xs sm:text-sm cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mc-bg ${
+            className={`whitespace-nowrap px-2.5 py-1 rounded-mc-gentle text-xs sm:text-sm cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mc-bg ${
               selected
                 ? "bg-mc-accent text-mc-on-accent font-semibold"
                 : "bg-mc-bg-raised text-mc-text-dim hover:bg-mc-bg-card hover:text-mc-text"

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -6,6 +6,8 @@ import { buildCrateWindow } from "../lib/crate_window"
 import { useViewport } from "@/hooks/use_viewport"
 import { usePileContext } from "@/contexts/pile_context"
 import { SCALE_PRESS, springPress } from "@/lib/motion_tokens"
+import Text from "@/components/text"
+import Button from "@/components/button"
 import type { Crate, Listing } from "../types/inertia"
 
 interface Props {
@@ -52,14 +54,14 @@ function RecordDetails({ listing, direction }: { listing: Listing; direction: nu
         className="flex flex-col gap-3"
       >
         <div>
-          <div className="text-xl font-semibold leading-tight">{listing.title}</div>
-          <div className="text-sm text-mc-text-dim mt-1">{listing.artist}</div>
+          <Text variant="display" as="div" className="!text-xl leading-tight">{listing.title}</Text>
+          <Text variant="dim" className="mt-1 !text-mc-label">{listing.artist}</Text>
         </div>
-        {meta && <div className="text-xs text-mc-text-dim">{meta}</div>}
+        {meta && <Text variant="dim">{meta}</Text>}
         {listing.genres.length > 0 && (
           <div className="flex gap-1.5 flex-wrap">
             {listing.genres.slice(0, 4).map((g) => (
-              <span key={g} className="text-[11px] px-2 py-0.5 rounded bg-mc-bg-raised text-mc-text-dim">
+              <span key={g} className="text-mc-label-sm px-2 py-0.5 rounded-mc-sharp bg-mc-bg-raised text-mc-text-dim">
                 {g}
               </span>
             ))}
@@ -68,27 +70,25 @@ function RecordDetails({ listing, direction }: { listing: Listing; direction: nu
         {listing.styles.length > 0 && (
           <div className="flex gap-1.5 flex-wrap">
             {listing.styles.slice(0, 4).map((s) => (
-              <span key={s} className="text-[11px] px-2 py-0.5 rounded bg-mc-bg-raised text-mc-text-dim/70">
+              <span key={s} className="text-mc-label-sm px-2 py-0.5 rounded-mc-sharp bg-mc-bg-raised text-mc-text-dim/70">
                 {s}
               </span>
             ))}
           </div>
         )}
-        <div className="text-2xl font-medium mt-2">
+        <Text variant="display" as="div" className="!text-2xl !font-medium mt-2">
           {listing.price ? `$${parseFloat(listing.price).toFixed(2)}` : "—"}
-        </div>
+        </Text>
         <div className="flex gap-2">
           {inPile(listing.id) ? (
-            <button onClick={() => removeFromPile(listing.id)} className="mc-btn">✓ In pile</button>
+            <Button variant="ghost" onClick={() => removeFromPile(listing.id)}>✓ In pile</Button>
           ) : (
-            <button onClick={() => addToPile(listing)} className="mc-btn mc-btn-primary">+ Pile</button>
+            <Button variant="primary" onClick={() => addToPile(listing)}>+ Pile</Button>
           )}
-          <a href={listing.discogs_url} target="_blank" rel="noopener" className="mc-btn">
-            Discogs ↗
-          </a>
+          <Button variant="ghost" href={listing.discogs_url} external>Discogs ↗</Button>
         </div>
         {listing.notes && (
-          <p className="text-xs text-mc-text-dim leading-relaxed line-clamp-4 mt-1">{listing.notes}</p>
+          <Text variant="dim" className="leading-relaxed line-clamp-4 mt-1">{listing.notes}</Text>
         )}
       </motion.div>
     </AnimatePresence>
@@ -147,14 +147,9 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
   const activeRecord = records[index]
 
   const backButton = onBack ? (
-    <button
-      type="button"
-      onClick={onBack}
-      className="self-start text-xs font-medium text-mc-text-dim bg-mc-bg-raised border border-mc-border rounded-lg hover:border-mc-accent hover:text-mc-accent transition-colors mb-4 flex items-center gap-1.5 cursor-pointer py-3 px-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
-      aria-label="Back to store"
-    >
+    <Button variant="ghost" onClick={onBack} className="self-start mb-4 gap-1.5 !border-mc-border hover:!border-mc-accent hover:!text-mc-accent !text-mc-btn !rounded-mc-gentle !py-3 !px-3" aria-label="Back to store">
       ← Store
-    </button>
+    </Button>
   ) : null
 
   usePreload(records, index)

--- a/app/frontend/components/featured_crates_row.tsx
+++ b/app/frontend/components/featured_crates_row.tsx
@@ -12,7 +12,7 @@ export default function FeaturedCratesRow({ crates, onSelectCrate }: Props) {
 
   return (
     <div className="mb-[--mc-section-gap]">
-      <SectionHeader title="Featured" count={crates.length} variant="feature" />
+      <SectionHeader title="Featured" count={crates.length} variant="feature" borderAccent="left" />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {crates.map((crate) => (
           <CrateCard key={crate.slug} crate={crate} variant="featured" onSelectCrate={onSelectCrate} />

--- a/app/frontend/components/featured_crates_row.tsx
+++ b/app/frontend/components/featured_crates_row.tsx
@@ -1,4 +1,5 @@
 import CrateCard from "./crate_card"
+import SectionHeader from "./section_header"
 import type { Crate } from "../types/inertia"
 
 interface Props {
@@ -10,11 +11,8 @@ export default function FeaturedCratesRow({ crates, onSelectCrate }: Props) {
   if (crates.length === 0) return null
 
   return (
-    <div className="mb-6">
-      <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-2 mb-4">
-        <span className="mc-section-name text-base font-semibold">Featured</span>
-        <span className="mc-section-count">{crates.length}</span>
-      </div>
+    <div className="mb-[--mc-section-gap]">
+      <SectionHeader title="Featured" count={crates.length} variant="feature" />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {crates.map((crate) => (
           <CrateCard key={crate.slug} crate={crate} variant="featured" onSelectCrate={onSelectCrate} />

--- a/app/frontend/components/featured_crates_row.tsx
+++ b/app/frontend/components/featured_crates_row.tsx
@@ -15,7 +15,7 @@ export default function FeaturedCratesRow({ crates, onSelectCrate }: Props) {
       <SectionHeader title="Featured" count={crates.length} />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {crates.map((crate) => (
-          <CrateCard key={crate.slug} crate={crate} variant="featured" onSelectCrate={onSelectCrate} />
+          <CrateCard key={crate.slug} crate={crate} onSelectCrate={onSelectCrate} />
         ))}
       </div>
     </div>

--- a/app/frontend/components/featured_crates_row.tsx
+++ b/app/frontend/components/featured_crates_row.tsx
@@ -12,7 +12,7 @@ export default function FeaturedCratesRow({ crates, onSelectCrate }: Props) {
 
   return (
     <div className="mb-[--mc-section-gap]">
-      <SectionHeader title="Featured" count={crates.length} variant="feature" borderAccent="left" />
+      <SectionHeader title="Featured" count={crates.length} />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {crates.map((crate) => (
           <CrateCard key={crate.slug} crate={crate} variant="featured" onSelectCrate={onSelectCrate} />

--- a/app/frontend/components/field.tsx
+++ b/app/frontend/components/field.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+import Text from "@/components/text"
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+interface FieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "className"> {
+  /** Visible label above the input. */
+  label: string
+  /** Error message displayed below the input in accent color. */
+  error?: string
+  className?: string
+}
+
+// ── Component ─────────────────────────────────────────────────────────────
+
+/**
+ * Form field primitive — composes a DESIGN.md label + input. The input
+ * inherits the `.mc-input` styling (serif body font, 2px radius, border
+ * focus accent shift).
+ *
+ * @example
+ *   <Field label="Store name" name="store_name" placeholder="My Record Shop" />
+ *   <Field label="Email" type="email" required error="Email is required" />
+ */
+export default function Field({
+  label,
+  error,
+  className = "",
+  id,
+  ...inputProps
+}: FieldProps) {
+  const fieldId = id ?? inputProps.name
+
+  return (
+    <div className={`flex flex-col gap-1.5 ${className}`}>
+      <Text
+        variant="label"
+        as="label"
+        htmlFor={fieldId}
+      >
+        {label}
+      </Text>
+      <input id={fieldId} className="mc-input" {...inputProps} />
+      {error && (
+        <Text variant="dim" className="!text-mc-accent !text-mc-label-sm">
+          {error}
+        </Text>
+      )}
+    </div>
+  )
+}

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -13,7 +13,7 @@ export default function GenreGrid({ crates, onSelectCrate }: Props) {
   }
 
   return (
-    <div className="mb-[--mc-section-gap] border-t border-mc-border pt-[calc(var(--mc-section-gap)*1.5)]">
+    <div className="mb-[--mc-section-gap] pt-[calc(var(--mc-section-gap)*1.5)]">
       <SectionHeader title="Browse by genre" count={crates.length} />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
         {crates.map((crate) => (

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -14,7 +14,7 @@ export default function GenreGrid({ crates, onSelectCrate }: Props) {
 
   return (
     <div className="mb-[--mc-section-gap] border-t border-mc-border pt-[calc(var(--mc-section-gap)*1.5)]">
-      <SectionHeader title="Browse by genre" count={crates.length} variant="compact" />
+      <SectionHeader title="Browse by genre" count={crates.length} />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
         {crates.map((crate) => (
           <CrateCard

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -1,4 +1,5 @@
 import CrateCard from "./crate_card"
+import SectionHeader from "./section_header"
 import type { Crate } from "../types/inertia"
 
 interface Props {
@@ -12,11 +13,8 @@ export default function GenreGrid({ crates, onSelectCrate }: Props) {
   }
 
   return (
-    <div className="mb-6">
-      <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-2 mb-4">
-        <span className="mc-section-name text-base font-semibold">Browse by genre</span>
-        <span className="mc-section-count">{crates.length}</span>
-      </div>
+    <div className="mb-[--mc-section-gap]">
+      <SectionHeader title="Browse by genre" count={crates.length} variant="compact" />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
         {crates.map((crate) => (
           <CrateCard

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -13,7 +13,7 @@ export default function GenreGrid({ crates, onSelectCrate }: Props) {
   }
 
   return (
-    <div className="mb-[--mc-section-gap] border-t border-mc-border pt-[--mc-section-gap]">
+    <div className="mb-[--mc-section-gap] border-t border-mc-border pt-[calc(var(--mc-section-gap)*2)]">
       <SectionHeader title="Browse by genre" count={crates.length} variant="compact" />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
         {crates.map((crate) => (

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -20,7 +20,6 @@ export default function GenreGrid({ crates, onSelectCrate }: Props) {
           <CrateCard
             key={crate.slug}
             crate={crate}
-            variant="genre"
             onSelectCrate={onSelectCrate}
           />
         ))}

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -13,7 +13,7 @@ export default function GenreGrid({ crates, onSelectCrate }: Props) {
   }
 
   return (
-    <div className="mb-[--mc-section-gap] border-t border-mc-border pt-[calc(var(--mc-section-gap)*2)]">
+    <div className="mb-[--mc-section-gap] border-t border-mc-border pt-[calc(var(--mc-section-gap)*1.5)]">
       <SectionHeader title="Browse by genre" count={crates.length} variant="compact" />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
         {crates.map((crate) => (

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -13,7 +13,7 @@ export default function GenreGrid({ crates, onSelectCrate }: Props) {
   }
 
   return (
-    <div className="mb-[--mc-section-gap]">
+    <div className="mb-[--mc-section-gap] border-t border-mc-border pt-[--mc-section-gap]">
       <SectionHeader title="Browse by genre" count={crates.length} variant="compact" />
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4">
         {crates.map((crate) => (

--- a/app/frontend/components/pile_sheet.tsx
+++ b/app/frontend/components/pile_sheet.tsx
@@ -3,6 +3,8 @@ import { motion, AnimatePresence } from "framer-motion"
 import { usePileContext } from "../contexts/pile_context"
 import { useViewport } from "@/hooks/use_viewport"
 import { springDrawer } from "@/lib/motion_tokens"
+import Text from "@/components/text"
+import Button from "@/components/button"
 
 interface Props {
   open: boolean
@@ -78,8 +80,10 @@ export default function PileSheet({ open, onClose }: Props) {
             <div className="flex items-center justify-between px-4 py-3 border-b border-mc-border flex-shrink-0">
 
               <div className="flex items-center gap-3">
-                <span id="pile-sheet-title" className="text-sm font-semibold">
-                  Your pile {pile.length > 0 && <span className="text-mc-text-dim font-normal">· {pile.length} records</span>}
+                <span id="pile-sheet-title">
+                  <Text variant="section-name" className="!text-mc-body !text-mc-text">
+                    Your pile{pile.length > 0 && <> · {pile.length} records</>}
+                  </Text>
                 </span>
                 {pile.length > 0 && (
                   confirmClear ? (
@@ -121,8 +125,8 @@ export default function PileSheet({ open, onClose }: Props) {
             {/* Records list */}
             <div className="flex-1 overflow-y-auto">
               {pile.length === 0 ? (
-                <div className="py-16 text-center text-sm text-mc-text-dim">
-                  No records in your pile yet.
+                <div className="py-16 text-center">
+                  <Text variant="dim">No records in your pile yet.</Text>
                 </div>
               ) : (
                 <ul>
@@ -169,16 +173,12 @@ export default function PileSheet({ open, onClose }: Props) {
             {pile.length > 0 && (
               <div className="flex-shrink-0 px-4 py-4 border-t border-mc-border flex flex-col gap-3">
                 <div className="flex items-center justify-between">
-                  <span className="text-xs text-mc-text-dim uppercase tracking-wider">Total</span>
-                  <span className="text-sm font-semibold">${total.toFixed(2)}</span>
+                  <Text variant="label">Total</Text>
+                  <Text variant="body" className="!font-semibold">${total.toFixed(2)}</Text>
                 </div>
-                <button
-                  disabled
-                  className="w-full mc-btn mc-btn-primary py-2.5 text-sm opacity-40 cursor-not-allowed"
-                  title="Coming soon — requires Discogs login"
-                >
+                <Button variant="primary" disabled className="w-full" title="Coming soon — requires Discogs login">
                   Add all to Discogs cart
-                </button>
+                </Button>
               </div>
             )}
           </motion.div>

--- a/app/frontend/components/record_card.tsx
+++ b/app/frontend/components/record_card.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from "react"
 import { motion } from "framer-motion"
 import { usePileContext } from "../contexts/pile_context"
 import { springFlip } from "@/lib/motion_tokens"
+import Text from "@/components/text"
+import Button from "@/components/button"
 import type { Listing } from "../types/inertia"
 
 interface Props {
@@ -120,40 +122,40 @@ export default function RecordCard({ listing, resetKey, className = "", imageLoa
           }}
         >
           <div className="flex flex-col h-full p-4 gap-2">
-            <div className="text-sm font-semibold leading-tight line-clamp-3">
+            <Text variant="section-name" className="!text-mc-body leading-tight line-clamp-3 !text-mc-text">
               {listing.title}
-            </div>
-            <div className="text-xs text-mc-text leading-tight">
+            </Text>
+            <Text variant="dim" className="!text-mc-text">
               {listing.artist}
-            </div>
+            </Text>
             {meta && (
-              <div className="text-xs text-mc-text-dim">{meta}</div>
+              <Text variant="dim">{meta}</Text>
             )}
             {listing.genres.length > 0 && (
               <div className="flex gap-1 flex-wrap">
                 {listing.genres.slice(0, 3).map((g) => (
-                  <span key={g} className="text-[10px] px-1.5 py-0.5 rounded bg-mc-bg-raised text-mc-text-dim">
+                  <span key={g} className="text-mc-label-sm px-1.5 py-0.5 rounded-mc-sharp bg-mc-bg-raised text-mc-text-dim">
                     {g}
                   </span>
                 ))}
               </div>
             )}
-            <div className="text-sm font-medium mt-auto">
+            <Text variant="body" className="!font-semibold mt-auto">
               {listing.price ? `$${parseFloat(listing.price).toFixed(2)}` : "—"}
-            </div>
+            </Text>
             <div className="flex gap-1 mt-1" onClick={(e) => e.stopPropagation()}>
               {inPile(listing.id) ? (
-                <button onClick={() => removeFromPile(listing.id)} className="mc-btn text-xs">
+                <Button variant="ghost" onClick={() => removeFromPile(listing.id)}>
                   ✓ In pile
-                </button>
+                </Button>
               ) : (
-                <button onClick={() => addToPile(listing)} className="mc-btn mc-btn-primary text-xs">
+                <Button variant="primary" onClick={() => addToPile(listing)}>
                   + Pile
-                </button>
+                </Button>
               )}
-              <a href={listing.discogs_url} target="_blank" rel="noopener" className="mc-btn text-xs">
+              <Button variant="ghost" href={listing.discogs_url} external>
                 Discogs ↗
-              </a>
+              </Button>
             </div>
           </div>
         </div>

--- a/app/frontend/components/section_header.tsx
+++ b/app/frontend/components/section_header.tsx
@@ -1,9 +1,11 @@
 export type SectionHeaderVariant = "hero" | "feature" | "compact"
+export type SectionHeaderAccent = "top" | "left"
 
 interface Props {
   title: string
   count?: string | number
   variant?: SectionHeaderVariant
+  borderAccent?: SectionHeaderAccent
   className?: string
 }
 
@@ -13,11 +15,17 @@ const variantClasses: Record<SectionHeaderVariant, string> = {
   compact: "text-sm border-b border-mc-border",
 }
 
-export default function SectionHeader({ title, count, variant = "feature", className = "" }: Props) {
+const accentClasses: Record<SectionHeaderAccent, string> = {
+  top: "border-t-2 border-mc-accent pt-3",
+  left: "border-l-[3px] border-l-mc-accent pl-3",
+}
+
+export default function SectionHeader({ title, count, variant = "feature", borderAccent, className = "" }: Props) {
   const variantClass = variantClasses[variant]
+  const accentClass = borderAccent ? accentClasses[borderAccent] : ""
 
   return (
-    <div className={`flex items-center justify-between gap-2 pb-2 mb-4 ${variantClass} ${className}`}>
+    <div className={`flex items-center justify-between gap-2 pb-2 mb-4 ${variantClass} ${accentClass} ${className}`}>
       <span className="mc-section-name font-semibold">{title}</span>
       {count !== undefined && <span className="mc-section-count">{count}</span>}
     </div>

--- a/app/frontend/components/section_header.tsx
+++ b/app/frontend/components/section_header.tsx
@@ -1,0 +1,25 @@
+export type SectionHeaderVariant = "hero" | "feature" | "compact"
+
+interface Props {
+  title: string
+  count?: string | number
+  variant?: SectionHeaderVariant
+  className?: string
+}
+
+const variantClasses: Record<SectionHeaderVariant, string> = {
+  hero: "text-xl border-b-2 border-mc-accent",
+  feature: "text-base border-b border-mc-border",
+  compact: "text-sm border-b border-mc-border",
+}
+
+export default function SectionHeader({ title, count, variant = "feature", className = "" }: Props) {
+  const variantClass = variantClasses[variant]
+
+  return (
+    <div className={`flex items-center justify-between gap-2 pb-2 mb-4 ${variantClass} ${className}`}>
+      <span className="mc-section-name font-semibold">{title}</span>
+      {count !== undefined && <span className="mc-section-count">{count}</span>}
+    </div>
+  )
+}

--- a/app/frontend/components/section_header.tsx
+++ b/app/frontend/components/section_header.tsx
@@ -1,3 +1,5 @@
+import Text from "@/components/text"
+
 export type SectionHeaderVariant = "hero" | "default"
 
 interface Props {
@@ -8,8 +10,8 @@ interface Props {
 }
 
 const variantClasses: Record<SectionHeaderVariant, string> = {
-  hero: "text-xl border-t-2 border-t-mc-accent border-b-2 border-b-mc-accent py-3",
-  default: "text-base border-b border-mc-border",
+  hero: "border-t-2 border-t-mc-accent border-b-2 border-b-mc-accent py-3",
+  default: "border-b border-mc-border",
 }
 
 export default function SectionHeader({ title, count, variant = "default", className = "" }: Props) {
@@ -17,8 +19,10 @@ export default function SectionHeader({ title, count, variant = "default", class
 
   return (
     <div className={`flex items-center justify-between gap-2 py-2 mb-4 ${variantClass} ${className}`}>
-      <span className="mc-section-name font-semibold">{title}</span>
-      {count !== undefined && <span className="mc-section-count">{count}</span>}
+      <Text variant="section-name" className={variant === "hero" ? "!text-mc-display" : ""}>
+        {title}
+      </Text>
+      {count !== undefined && <Text variant="section-count">{count}</Text>}
     </div>
   )
 }

--- a/app/frontend/components/section_header.tsx
+++ b/app/frontend/components/section_header.tsx
@@ -16,7 +16,7 @@ const variantClasses: Record<SectionHeaderVariant, string> = {
 }
 
 const accentClasses: Record<SectionHeaderAccent, string> = {
-  top: "border-t-2 border-mc-accent pt-3",
+  top: "border-t-2 border-mc-accent py-3",
   left: "border-l-[3px] border-l-mc-accent pl-3",
 }
 
@@ -25,7 +25,7 @@ export default function SectionHeader({ title, count, variant = "feature", borde
   const accentClass = borderAccent ? accentClasses[borderAccent] : ""
 
   return (
-    <div className={`flex items-center justify-between gap-2 pb-2 mb-4 ${variantClass} ${accentClass} ${className}`}>
+    <div className={`flex items-center justify-between gap-2 py-2 mb-4 ${variantClass} ${accentClass} ${className}`}>
       <span className="mc-section-name font-semibold">{title}</span>
       {count !== undefined && <span className="mc-section-count">{count}</span>}
     </div>

--- a/app/frontend/components/section_header.tsx
+++ b/app/frontend/components/section_header.tsx
@@ -1,31 +1,22 @@
-export type SectionHeaderVariant = "hero" | "feature" | "compact"
-export type SectionHeaderAccent = "top" | "left"
+export type SectionHeaderVariant = "hero" | "default"
 
 interface Props {
   title: string
   count?: string | number
   variant?: SectionHeaderVariant
-  borderAccent?: SectionHeaderAccent
   className?: string
 }
 
 const variantClasses: Record<SectionHeaderVariant, string> = {
-  hero: "text-xl border-b-2 border-mc-accent",
-  feature: "text-base border-b border-mc-border",
-  compact: "text-sm border-b border-mc-border",
+  hero: "text-xl border-t-2 border-t-mc-accent border-b-2 border-b-mc-accent py-3",
+  default: "text-base border-b border-mc-border",
 }
 
-const accentClasses: Record<SectionHeaderAccent, string> = {
-  top: "border-t-2 border-mc-accent py-3",
-  left: "border-l-[3px] border-l-mc-accent pl-3",
-}
-
-export default function SectionHeader({ title, count, variant = "feature", borderAccent, className = "" }: Props) {
+export default function SectionHeader({ title, count, variant = "default", className = "" }: Props) {
   const variantClass = variantClasses[variant]
-  const accentClass = borderAccent ? accentClasses[borderAccent] : ""
 
   return (
-    <div className={`flex items-center justify-between gap-2 py-2 mb-4 ${variantClass} ${accentClass} ${className}`}>
+    <div className={`flex items-center justify-between gap-2 py-2 mb-4 ${variantClass} ${className}`}>
       <span className="mc-section-name font-semibold">{title}</span>
       {count !== undefined && <span className="mc-section-count">{count}</span>}
     </div>

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -31,7 +31,7 @@ export default function StoreFloor({ sections, onSelectCrate }: Props) {
                   className="w-full text-left cursor-pointer group"
                   aria-label="Open Milkcrate Picks"
                 >
-                  <SectionHeader title="Milkcrate Picks" count={today} variant="hero" borderAccent="top" />
+                  <SectionHeader title="Milkcrate Picks" count={today} variant="hero" />
                 </button>
 
                 {!isCompact ? (

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -31,7 +31,7 @@ export default function StoreFloor({ sections, onSelectCrate }: Props) {
                   className="w-full text-left cursor-pointer group"
                   aria-label="Open Milkcrate Picks"
                 >
-                  <SectionHeader title="Milkcrate Picks" count={today} variant="hero" />
+                  <SectionHeader title="Milkcrate Picks" count={today} variant="hero" borderAccent="top" />
                 </button>
 
                 {!isCompact ? (

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -3,6 +3,7 @@ import RecordCard from "./record_card"
 import FeaturedCratesRow from "./featured_crates_row"
 import GenreGrid from "./genre_grid"
 import TactileCard from "./tactile_card"
+import SectionHeader from "./section_header"
 import { springTactile, SCALE_HOVER, SCALE_PRESS } from "@/lib/motion_tokens"
 import { useViewport } from "@/hooks/use_viewport"
 import type { StorefrontSection } from "../types/inertia"
@@ -23,17 +24,14 @@ export default function StoreFloor({ sections, onSelectCrate }: Props) {
           const picks = section.crate
           return (
             picks.records.length > 0 && (
-              <div key="picks" className="-mx-4 mb-6 bg-mc-bg-raised border-y border-mc-border">
+              <div key="picks" className="mb-[--mc-section-gap]">
                 <button
                   type="button"
                   onClick={() => onSelectCrate("picks")}
-                  className="w-full text-left cursor-pointer group px-4 pt-3 pb-2"
+                  className="w-full text-left cursor-pointer group"
                   aria-label="Open Milkcrate Picks"
                 >
-                  <div className="flex items-baseline gap-3 pb-2 border-b border-mc-border">
-                    <span className="mc-section-name text-base font-semibold">Milkcrate Picks</span>
-                    <span className="mc-section-count">{today}</span>
-                  </div>
+                  <SectionHeader title="Milkcrate Picks" count={today} variant="hero" />
                 </button>
 
                 {!isCompact ? (
@@ -100,7 +98,7 @@ export default function StoreFloor({ sections, onSelectCrate }: Props) {
                       aria-hidden="true"
                       className="absolute right-0 top-0 bottom-0 w-12 pointer-events-none"
                       style={{
-                        background: "linear-gradient(to right, transparent, var(--mc-bg-raised))",
+                        background: "linear-gradient(to right, transparent, var(--mc-bg))",
                       }}
                     />
                   </div>

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -72,7 +72,7 @@ export default function StoreFloor({ sections, onSelectCrate }: Props) {
                           <motion.button
                             key={record.id}
                             type="button"
-                            className="flex-shrink-0 w-[46vw] h-[46vw] rounded bg-mc-bg-card overflow-hidden border border-mc-border cursor-pointer"
+                            className="flex-shrink-0 w-[46vw] h-[46vw] rounded-mc-gentle bg-mc-bg-card overflow-hidden border border-mc-border cursor-pointer"
                             whileHover={{ scale: SCALE_HOVER, zIndex: 10 }}
                             whileTap={{ scale: SCALE_PRESS }}
                             transition={springTactile}

--- a/app/frontend/components/storefront_motion_config.test.tsx
+++ b/app/frontend/components/storefront_motion_config.test.tsx
@@ -28,20 +28,19 @@ describe("StorefrontMotionConfig", () => {
     expect(screen.getByTestId("result").textContent).toBe("false")
   })
 
-  it("throws when useReducedMotionContext is called outside the provider", () => {
-    // Suppress console.error for the expected throw
-    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+  it("returns true (reduced motion) when used outside the provider", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
 
+    let value: boolean | undefined
     function Outside() {
-      useReducedMotionContext()
+      value = useReducedMotionContext()
       return null
     }
 
-    expect(() => render(<Outside />)).toThrow(
-      "useReducedMotionContext must be used within StorefrontMotionConfig",
-    )
+    render(<Outside />)
+    expect(value).toBe(true)
 
-    spy.mockRestore()
+    warnSpy.mockRestore()
   })
 
   it("wraps children in framer-motion MotionConfig without errors", () => {

--- a/app/frontend/components/storefront_motion_config.tsx
+++ b/app/frontend/components/storefront_motion_config.tsx
@@ -28,13 +28,20 @@ export default function StorefrontMotionConfig({
 /**
  * Returns true when the user has requested reduced motion at the OS
  * level. Consumers use this to gate animation behavior.
+ *
+ * Falls back to `true` (treat as reduced motion — no animation) when
+ * used outside a StorefrontMotionConfig provider, so components like
+ * Button remain safe in marketing pages and test environments.
  */
 export function useReducedMotionContext(): boolean {
   const value = useContext(ReducedMotionCtx)
   if (value === null) {
-    throw new Error(
-      "useReducedMotionContext must be used within StorefrontMotionConfig",
-    )
+    if (typeof window !== "undefined" && import.meta.env.DEV) {
+      console.warn(
+        "useReducedMotionContext used outside StorefrontMotionConfig — animations disabled. Wrap with <StorefrontMotionConfig> for motion support.",
+      )
+    }
+    return true
   }
   return value
 }

--- a/app/frontend/components/storefront_shell.test.tsx
+++ b/app/frontend/components/storefront_shell.test.tsx
@@ -62,7 +62,7 @@ describe("storefront shell (StoreFloor with sections)", () => {
 
     const picksHeader = screen.getByText("Milkcrate Picks")
     expect(picksHeader).toBeInTheDocument()
-    expect(picksHeader.className).toContain("font-semibold")
+    expect(picksHeader.className).toContain("font-bold")
   })
 
   it("opens picks crate when picks header is clicked", async () => {

--- a/app/frontend/components/text.tsx
+++ b/app/frontend/components/text.tsx
@@ -1,0 +1,79 @@
+import React from "react"
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export type TextVariant =
+  | "display"       // h1 — wordmark, main heading
+  | "section-name"  // h2 — crate names, section titles (accent color)
+  | "section-count" // span — count/dim metadata next to section name
+  | "body"          // p — prose, descriptions, extended reading
+  | "label"         // span — form labels, nav links, metadata chips
+  | "dim"           // span — secondary text, hints, placeholders
+
+type TextElement = "h1" | "h2" | "h3" | "h4" | "p" | "span" | "label" | "div"
+
+interface TextProps {
+  variant: TextVariant
+  as?: TextElement
+  className?: string
+  children: React.ReactNode
+  [key: string]: unknown
+}
+
+// ── Variant → Tailwind classes ────────────────────────────────────────────
+
+const variantClasses: Record<TextVariant, string> = {
+  display:
+    "font-mc-display text-mc-display font-bold tracking-mc-display uppercase",
+  "section-name":
+    "font-mc-display text-mc-section font-bold tracking-mc-section uppercase text-mc-accent",
+  "section-count":
+    "font-mc-display text-mc-label tracking-mc-label uppercase text-mc-text-dim",
+  body:
+    "font-mc-body text-mc-body leading-mc-body",
+  label:
+    "font-mc-display text-mc-label tracking-mc-label uppercase text-mc-text-dim",
+  dim:
+    "text-mc-label text-mc-text-dim",
+}
+
+const defaultElement: Record<TextVariant, TextElement> = {
+  display:        "h1",
+  "section-name": "h2",
+  "section-count": "span",
+  body:            "p",
+  label:           "span",
+  dim:             "span",
+}
+
+// ── Component ─────────────────────────────────────────────────────────────
+
+/**
+ * Single typography primitive. Every text string in the app routes through
+ * this component so font, size, tracking, and color are locked to the
+ * DESIGN.md scale. Use `as` to change the HTML element without changing the
+ * visual style.
+ *
+ * @example
+ *   <Text variant="display">🥛 Milkcrate</Text>
+ *   <Text variant="section-name">Featured Crates</Text>
+ *   <Text variant="section-count">12 crates</Text>
+ *   <Text variant="body">A record store at golden hour.</Text>
+ *   <Text variant="label" as="label" htmlFor="email">Email</Text>
+ *   <Text variant="dim">Last synced 2 hours ago</Text>
+ */
+export default function Text({
+  variant,
+  as,
+  className = "",
+  children,
+  ...rest
+}: TextProps) {
+  const Component = as ?? defaultElement[variant]
+
+  return (
+    <Component className={`${variantClasses[variant]} ${className}`} {...rest}>
+      {children}
+    </Component>
+  )
+}

--- a/app/frontend/layouts/app_layout.tsx
+++ b/app/frontend/layouts/app_layout.tsx
@@ -84,7 +84,7 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
         </div>
       )}
 
-      <main className="flex-1 px-4 py-4 sm:py-6" id="main-content">{children}</main>
+      <main className="flex-1 px-4 py-4 sm:py-6 max-w-6xl mx-auto" id="main-content">{children}</main>
 
       <footer className="px-4 py-4 border-t mc-border text-center">
         <span className="text-[11px] text-mc-text-dim tracking-wide">

--- a/app/frontend/layouts/app_layout.tsx
+++ b/app/frontend/layouts/app_layout.tsx
@@ -6,6 +6,8 @@ import PileSheet from "@/components/pile_sheet"
 import StorefrontMotionConfig from "@/components/storefront_motion_config"
 import { ViewportProvider } from "@/contexts/viewport_context"
 import { useViewport } from "@/hooks/use_viewport"
+import Text from "@/components/text"
+import Button from "@/components/button"
 
 function AppLayoutInner({ children }: { children: React.ReactNode }) {
   const page = usePage()
@@ -34,12 +36,12 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
           {storeName ? (
             <>
               <span className="text-base font-bold tracking-wide mc-text truncate">{storeName}</span>
-              <span className="text-[10px] tracking-widest uppercase text-mc-text-dim">
+              <Text variant="label">
                 {isCompact ? "on MC" : "on Milkcrate"}
-              </span>
+              </Text>
             </>
           ) : (
-            <span className="mc-wordmark text-lg sm:text-xl font-bold tracking-widest uppercase whitespace-nowrap">🥛 Milkcrate</span>
+            <Text variant="display" className="whitespace-nowrap">🥛 Milkcrate</Text>
           )}
         </Link>
         <div className="flex items-center gap-2.5 sm:gap-3 flex-shrink-0">
@@ -87,9 +89,9 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
       <main className="flex-1 px-4 py-4 sm:py-6 max-w-7xl mx-auto" id="main-content">{children}</main>
 
       <footer className="px-4 py-4 border-t mc-border text-center">
-        <span className="text-[11px] text-mc-text-dim tracking-wide">
+        <Text variant="label">
           Powered by <span className="font-semibold tracking-widest uppercase">🥛 Milkcrate</span>
-        </span>
+        </Text>
       </footer>
 
       <PileSheet open={pileOpen} onClose={() => setPileOpen(false)} />

--- a/app/frontend/layouts/app_layout.tsx
+++ b/app/frontend/layouts/app_layout.tsx
@@ -84,7 +84,7 @@ function AppLayoutInner({ children }: { children: React.ReactNode }) {
         </div>
       )}
 
-      <main className="flex-1 px-4 py-4 sm:py-6 max-w-6xl mx-auto" id="main-content">{children}</main>
+      <main className="flex-1 px-4 py-4 sm:py-6 max-w-7xl mx-auto" id="main-content">{children}</main>
 
       <footer className="px-4 py-4 border-t mc-border text-center">
         <span className="text-[11px] text-mc-text-dim tracking-wide">

--- a/app/frontend/layouts/marketing_layout.tsx
+++ b/app/frontend/layouts/marketing_layout.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Link } from "@inertiajs/react"
 import { useTheme } from "@/hooks/use_theme"
+import Text from "@/components/text"
 
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   const { theme, toggle } = useTheme()
@@ -19,7 +20,7 @@ export default function MarketingLayout({ children }: { children: React.ReactNod
             href="/"
             className="flex items-center gap-2 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
           >
-            <span className="mc-wordmark text-xl font-bold tracking-widest uppercase">🥛 Milkcrate</span>
+            <Text variant="display">🥛 Milkcrate</Text>
           </Link>
           <button
             type="button"

--- a/app/frontend/pages/home.tsx
+++ b/app/frontend/pages/home.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { Link } from "@inertiajs/react"
 import { motion } from "framer-motion"
 import MarketingLayout from "@/layouts/marketing_layout"
+import Text from "@/components/text"
+import Button from "@/components/button"
 
 interface Props {
   copy: {
@@ -21,9 +22,6 @@ const fadeUp = {
     transition: { duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] },
   },
 }
-
-const ctaBase =
-  "w-full px-6 py-3 rounded-lg font-semibold text-sm tracking-wide text-center transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
 
 export default function Home({ copy }: Props) {
   return (
@@ -45,42 +43,32 @@ export default function Home({ copy }: Props) {
         <motion.h1
           variants={fadeUp}
           id="home-headline"
-          className="text-2xl font-bold mc-text mb-3 leading-tight"
+          className="mb-3 leading-tight"
         >
-          {copy.headline}
+          <Text variant="display" as="span" className="!text-2xl !tracking-normal !normal-case">
+            {copy.headline}
+          </Text>
         </motion.h1>
 
-        <motion.p
-          variants={fadeUp}
-          className="text-sm text-mc-text-dim mb-10 leading-relaxed"
-        >
-          {copy.subhead}
-        </motion.p>
+        <motion.div variants={fadeUp} className="mb-10 leading-relaxed">
+          <Text variant="body">{copy.subhead}</Text>
+        </motion.div>
 
         <motion.div
           variants={fadeUp}
           className="flex flex-col items-center gap-3 w-full max-w-xs"
         >
-          <Link
-            href="/philadelphiamusic"
-            className={`${ctaBase} bg-mc-accent text-mc-on-accent hover:opacity-90`}
-          >
+          <Button variant="primary" href="/philadelphiamusic" className="w-full">
             {copy.cta_demo}
-          </Link>
-          <Link
-            href="/apply"
-            className={`${ctaBase} border border-mc-border mc-text hover:border-mc-accent hover:text-mc-accent`}
-          >
+          </Button>
+          <Button variant="ghost" href="/apply" className="w-full border-mc-border hover:border-mc-accent">
             {copy.cta_apply}
-          </Link>
+          </Button>
         </motion.div>
 
-        <motion.p
-          variants={fadeUp}
-          className="mt-6 text-xs text-mc-text-dim"
-        >
-          {copy.footnote}
-        </motion.p>
+        <motion.div variants={fadeUp} className="mt-6">
+          <Text variant="dim">{copy.footnote}</Text>
+        </motion.div>
       </motion.section>
     </MarketingLayout>
   )


### PR DESCRIPTION
## Summary

Introduces three composable React primitives that map the DESIGN.md tokens into code, creating a single source of truth for typography, interactive triggers, and form inputs across the entire frontend.

## What changed

### New primitives (`app/frontend/components/`)
- **`Text`** — 6 variants (`display`, `section-name`, `section-count`, `body`, `label`, `dim`) mapping to the DESIGN.md typography scale. Replaces ad-hoc `<span className="mc-section-name font-semibold">` patterns.
- **`Button`** — `primary`/`ghost` variants with Framer Motion tactile hover. Renders `<a>` when `href` is provided. Gracefully degrades outside `StorefrontMotionConfig`.
- **`Field`** — Composes label + input following DESIGN.md input specs (serif body font, 2px radius, border-color focus).

### CSS token bridge (`app/assets/tailwind/application.css`)
- Extended `@theme` with font families, font sizes, tracking, border radius, and spacing tokens
- Removed duplicate `.mc-input` definition (second one overrode it)

### Refactored components (16 files)
- All existing components now use `Text`/`Button` instead of inline Tailwind classes
- Removed unused `variant` prop from `CrateCard` (styling unified via `Text`)
- Replaced ad-hoc `rounded`, `rounded-lg`, `text-[10px]` with `rounded-mc-gentle`, `text-mc-label-sm` etc.

### Infrastructure fix
- `useReducedMotionContext` no longer throws when outside provider — returns `true` (reduced motion) with a dev warning. Enables `Button` in marketing pages and isolated test renders.

## Testing
- All 55 component tests pass (`npm run test:components`)
- All 15 frontend unit tests pass (`npm run test:frontend`)
- TypeScript compiles cleanly (only pre-existing baseUrl deprecation)
