### PR TITLE
feat: Tighten CrateView mobile space

### DIFF
--- a/app/frontend/components/crate_tabs.test.tsx
+++ b/app/frontend/components/crate_tabs.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import CrateTabs from "./crate_tabs"
+import type { Crate } from "../types/inertia"
+
+const crates: Crate[] = [
+  { slug: "jazz", name: "Jazz", count: 12, records: [] },
+  { slug: "rock", name: "Rock", count: 8, records: [] },
+  { slug: "soul", name: "Soul", count: 5, records: [] },
+]
+
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+
+afterEach(() => {
+  HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+})
+
+describe("CrateTabs", () => {
+  it("keeps compact crate tabs large enough for touch selection", () => {
+    render(<CrateTabs crates={crates} activeSlug="jazz" onSelect={vi.fn()} compact />)
+
+    expect(screen.getByRole("tab", { name: "Jazz" })).toHaveClass("min-h-11")
+  })
+
+  it("centers the selected crate tab in the scroll row when selection changes", () => {
+    const scrollIntoView = vi.fn()
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+
+    const { rerender } = render(
+      <CrateTabs crates={crates} activeSlug="jazz" onSelect={vi.fn()} />,
+    )
+
+    scrollIntoView.mockClear()
+
+    rerender(<CrateTabs crates={crates} activeSlug="soul" onSelect={vi.fn()} />)
+
+    expect(screen.getByRole("tab", { name: "Soul" })).toHaveAttribute("aria-selected", "true")
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    })
+  })
+})

--- a/app/frontend/components/crate_tabs.tsx
+++ b/app/frontend/components/crate_tabs.tsx
@@ -1,14 +1,24 @@
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
 import type { Crate } from "../types/inertia"
 
 interface Props {
   crates: Crate[]
   activeSlug: string
   onSelect: (slug: string) => void
+  compact?: boolean
 }
 
-export default function CrateTabs({ crates, activeSlug, onSelect }: Props) {
+export default function CrateTabs({ crates, activeSlug, onSelect, compact = false }: Props) {
   const tabsRef = useRef<HTMLDivElement>(null)
+  const activeTabRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView?.({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "center",
+    })
+  }, [activeSlug])
 
   const handleKeyDown = (e: React.KeyboardEvent, currentIndex: number) => {
     let nextIndex = currentIndex
@@ -23,7 +33,13 @@ export default function CrateTabs({ crates, activeSlug, onSelect }: Props) {
   }
 
   return (
-    <div ref={tabsRef} role="tablist" aria-label="Crates" className="flex gap-1 overflow-x-auto pb-1" style={{ scrollbarWidth: "thin" }}>
+    <div
+      ref={tabsRef}
+      role="tablist"
+      aria-label="Crates"
+      className={`flex overflow-x-auto ${compact ? "gap-1.5 scroll-px-1 px-1 pb-0.5" : "gap-1 pb-1"}`}
+      style={{ scrollbarWidth: compact ? "none" : "thin" }}
+    >
       {crates.map((crate, i) => {
         const selected = crate.slug === activeSlug
         return (
@@ -32,9 +48,12 @@ export default function CrateTabs({ crates, activeSlug, onSelect }: Props) {
             role="tab"
             aria-selected={selected}
             tabIndex={selected ? 0 : -1}
+            ref={selected ? activeTabRef : null}
             onClick={() => onSelect(crate.slug)}
             onKeyDown={(e) => handleKeyDown(e, i)}
-            className={`whitespace-nowrap px-2.5 py-1 rounded text-xs sm:text-sm cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mc-bg ${
+            className={`whitespace-nowrap rounded cursor-pointer transition-[background-color,color,border-color,transform] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mc-bg ${
+              compact ? "min-h-11 px-3 py-1.5 text-xs" : "px-2.5 py-1 text-xs sm:text-sm"
+            } ${
               selected
                 ? "bg-mc-accent text-mc-on-accent font-semibold"
                 : "bg-mc-bg-raised text-mc-text-dim hover:bg-mc-bg-card hover:text-mc-text"

--- a/app/frontend/components/crate_view.test.tsx
+++ b/app/frontend/components/crate_view.test.tsx
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import CrateView from "./crate_view"
+import StorefrontMotionConfig from "./storefront_motion_config"
+import { PileProvider } from "@/contexts/pile_context"
+import { renderWithTier } from "@/test/viewport-test-utils"
+import type { Crate, Listing } from "../types/inertia"
+
+const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
+  id: 1,
+  discogs_listing_id: "abc",
+  artist: "Artist",
+  title: "Title",
+  label: null,
+  year: null,
+  format: null,
+  genres: [],
+  styles: [],
+  condition: null,
+  price: "10.00",
+  currency: "USD",
+  cover_image_url: null,
+  thumbnail_url: null,
+  notes: null,
+  discogs_url: "https://www.discogs.com/sell/item/1",
+  ...overrides,
+})
+
+const makeCrates = (): Crate[] => [
+  {
+    slug: "jazz",
+    name: "Jazz",
+    count: 3,
+    records: [
+      makeListing({ id: 1, title: "First Jazz", artist: "One" }),
+      makeListing({ id: 2, title: "Second Jazz", artist: "Two" }),
+      makeListing({ id: 3, title: "Third Jazz", artist: "Three" }),
+    ],
+  },
+  {
+    slug: "rock",
+    name: "Rock",
+    count: 1,
+    records: [
+      makeListing({ id: 4, title: "Rock Record", artist: "Four" }),
+    ],
+  },
+]
+
+function renderCrateView(tier: "compact" | "comfy" | "wide", props: Partial<React.ComponentProps<typeof CrateView>> = {}) {
+  const defaultProps: React.ComponentProps<typeof CrateView> = {
+    crates: makeCrates(),
+    activeSlug: "jazz",
+    onSelectCrate: vi.fn(),
+    onBack: vi.fn(),
+    ...props,
+  }
+
+  return {
+    ...renderWithTier(tier, (
+      <StorefrontMotionConfig>
+        <PileProvider>
+          <CrateView {...defaultProps} />
+        </PileProvider>
+      </StorefrontMotionConfig>
+    )),
+    props: defaultProps,
+  }
+}
+
+describe("CrateView", () => {
+  it("renders a compact mobile header with active crate context", () => {
+    renderCrateView("compact")
+
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument()
+    expect(screen.getByText("3 records")).toBeInTheDocument()
+    expect(screen.queryByText("Independent record store in South Philly.")).not.toBeInTheDocument()
+  })
+
+  it("keeps desktop details visible on wide viewports", () => {
+    renderCrateView("wide")
+
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
+    expect(screen.getAllByText("One").length).toBeGreaterThan(1)
+    expect(screen.getAllByRole("link", { name: /Discogs/ }).length).toBeGreaterThan(1)
+  })
+
+  it("calls onBack from the compact back control", async () => {
+    const user = userEvent.setup()
+    const onBack = vi.fn()
+
+    renderCrateView("compact", { onBack })
+
+    await user.click(screen.getByRole("button", { name: "Back to store" }))
+
+    expect(onBack).toHaveBeenCalledOnce()
+  })
+
+  it("keeps crate tab selection working in compact presentation", async () => {
+    const user = userEvent.setup()
+    const onSelectCrate = vi.fn()
+
+    renderCrateView("compact", { onSelectCrate })
+
+    await user.click(screen.getByRole("tab", { name: "Rock" }))
+
+    expect(onSelectCrate).toHaveBeenCalledWith("rock")
+  })
+
+  it("preserves compact header context when tabs are hidden", () => {
+    renderCrateView("compact", { hideTabs: true })
+
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument()
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
+  })
+
+  it("uses compact stack sizing without dropping the progress indicator", () => {
+    renderCrateView("compact")
+
+    expect(screen.getByTestId("crate-stack")).toHaveAttribute("data-viewport", "compact")
+    expect(screen.getByRole("progressbar", { name: "Record 1 of 3" })).toBeInTheDocument()
+  })
+
+  it("reserves compact bottom clearance between the record pile and progress", () => {
+    renderCrateView("compact")
+
+    expect(screen.getByTestId("crate-stack")).toHaveClass("pb-8")
+  })
+
+  it("keeps compact browse controls thumb-sized and visually separated", () => {
+    renderCrateView("compact")
+
+    expect(screen.getByRole("button", { name: "Previous record" })).toHaveClass("h-12")
+    expect(screen.getByRole("button", { name: "Next record" })).toHaveClass("h-12")
+    expect(screen.getByRole("progressbar", { name: "Record 1 of 3" }).parentElement).toHaveClass("mt-1")
+  })
+
+  it("keeps wide stack sizing and desktop detail panel", () => {
+    renderCrateView("wide")
+
+    expect(screen.getByTestId("crate-stack")).toHaveAttribute("data-viewport", "wide")
+    expect(screen.getAllByText("One").length).toBeGreaterThan(1)
+  })
+
+  it("navigates with compact visible controls and dismisses the gesture hint", async () => {
+    const user = userEvent.setup()
+
+    renderCrateView("compact")
+
+    expect(screen.getByText(/Swipe or use arrows to browse/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Next record" }))
+
+    expect(screen.getByRole("progressbar", { name: "Record 2 of 3" })).toBeInTheDocument()
+    expect(screen.queryByText(/Swipe or use arrows to browse/)).not.toBeInTheDocument()
+  })
+
+  it("does not dismiss the compact hint when navigation is blocked", async () => {
+    const user = userEvent.setup()
+
+    renderCrateView("compact")
+
+    await user.click(screen.getByRole("button", { name: "Previous record" }))
+
+    expect(screen.getByRole("progressbar", { name: "Record 1 of 3" })).toBeInTheDocument()
+    expect(screen.getByText(/Swipe or use arrows to browse/)).toBeInTheDocument()
+  })
+})

--- a/app/frontend/components/crate_view.test.tsx
+++ b/app/frontend/components/crate_view.test.tsx
@@ -168,4 +168,68 @@ describe("CrateView", () => {
     expect(screen.getByRole("progressbar", { name: "Record 1 of 3" })).toBeInTheDocument()
     expect(screen.getByText(/Swipe or use arrows to browse/)).toBeInTheDocument()
   })
+
+  it("renders the compact empty-crate state with header context and empty message", () => {
+    const emptyCrates: Crate[] = [
+      {
+        slug: "empty",
+        name: "Empty Crate",
+        count: 0,
+        records: [],
+      },
+    ]
+
+    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" })
+
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument()
+    expect(screen.getByText("0 records")).toBeInTheDocument()
+    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument()
+  })
+
+  it("hides tabs in compact empty-crate state when hideTabs is true", () => {
+    const emptyCrates: Crate[] = [
+      {
+        slug: "empty",
+        name: "Empty Crate",
+        count: 0,
+        records: [],
+      },
+    ]
+
+    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty", hideTabs: true })
+
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument()
+    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument()
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
+  })
+
+  it("reappears the gesture hint when switching crates", async () => {
+    const user = userEvent.setup()
+    const crates = makeCrates()
+
+    const { rerender } = renderWithTier("compact", (
+      <StorefrontMotionConfig>
+        <PileProvider>
+          <CrateView crates={crates} activeSlug="jazz" onSelectCrate={vi.fn()} onBack={vi.fn()} />
+        </PileProvider>
+      </StorefrontMotionConfig>
+    ))
+
+    // Dismiss the hint by navigating
+    await user.click(screen.getByRole("button", { name: "Next record" }))
+    expect(screen.queryByText(/Swipe or use arrows to browse/)).not.toBeInTheDocument()
+
+    // Rerender with a different activeSlug — hint should reappear
+    rerender(
+      <StorefrontMotionConfig>
+        <PileProvider>
+          <CrateView crates={crates} activeSlug="rock" onSelectCrate={vi.fn()} onBack={vi.fn()} />
+        </PileProvider>
+      </StorefrontMotionConfig>
+    )
+
+    expect(screen.getByText(/Swipe or use arrows to browse/)).toBeInTheDocument()
+  })
 })

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -117,6 +117,7 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
   const records = activeCrate?.records ?? []
   const total = records.length
   const [index, setIndex] = useState(startIndex)
+  const [showGestureHint, setShowGestureHint] = useState(true)
   const direction = useRef(0)
   const prefersReducedMotion = useReducedMotion()
   const dragX = useMotionValue(0)
@@ -124,13 +125,16 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
 
   useEffect(() => {
     setIndex(startIndex)
+    setShowGestureHint(true)
   }, [activeSlug, startIndex])
 
   const navigate = useCallback((delta: number) => {
     const next = index + delta
-    if (next < 0 || next >= total) return
+    if (next < 0 || next >= total) return false
     direction.current = delta
     setIndex(next)
+    setShowGestureHint(false)
+    return true
   }, [index, total])
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -157,6 +161,34 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
     </button>
   ) : null
 
+  const compactHeader = isCompact ? (
+    <div className="mb-3">
+      <div className="flex items-center gap-3">
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-mc-border bg-mc-bg-raised text-lg leading-none text-mc-text-dim transition-[color,border-color,transform] hover:border-mc-accent hover:text-mc-accent active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+            aria-label="Back to store"
+          >
+            <span aria-hidden="true" className="-translate-y-px">←</span>
+          </button>
+        )}
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-base font-semibold leading-tight">{activeCrate?.name}</h1>
+          <div className="text-[11px] uppercase tracking-[0.12em] text-mc-text-dim">
+            {total === 1 ? "1 record" : `${total} records`}
+          </div>
+        </div>
+      </div>
+      {!hideTabs && (
+        <div className="mt-2 -mx-1">
+          <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} compact />
+        </div>
+      )}
+    </div>
+  ) : null
+
   usePreload(records, index)
   const visibleRecords = useMemo(
     () => buildCrateWindow(records, index, WINDOW_RADIUS),
@@ -177,10 +209,12 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
   if (!activeCrate || total === 0) {
     return (
       <div>
-        {backButton}
-        <div className="mb-3">
-          <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
-        </div>
+        {isCompact ? compactHeader : backButton}
+        {!isCompact && (
+          <div className="mb-3">
+            <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
+          </div>
+        )}
         <div className="py-16 text-center mc-dim text-sm">No records in this crate yet.</div>
       </div>
     )
@@ -190,14 +224,20 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
     <>
       {/* Front-riffle crate stack */}
       <div
-        className="relative z-10 flex items-center justify-center min-h-[390px] md:min-h-[470px] py-5 sm:py-7 select-none"
+        data-testid="crate-stack"
+        data-viewport={isCompact ? "compact" : "wide"}
+        className={`relative z-10 flex items-center justify-center select-none ${
+          isCompact
+            ? "min-h-[min(72svh,360px)] pt-3 pb-8"
+            : "min-h-[390px] md:min-h-[470px] py-5 sm:py-7"
+        }`}
         style={{ touchAction: "none", overscrollBehavior: "contain" }}
       >
         <div
           className="relative"
           style={{
-            width: "min(82vw, 400px)",
-            height: "min(82vw, 400px)",
+            width: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
+            height: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
           }}
         >
           <AnimatePresence initial={!prefersReducedMotion} custom={direction.current}>
@@ -306,8 +346,8 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
       </div>
 
       {/* Progress bar */}
-      <div className="w-full max-w-xs sm:max-w-sm mx-auto mb-4">
-        <div className="flex items-center justify-between text-[10px] uppercase tracking-[0.14em] text-mc-text-dim mb-1.5 select-none">
+      <div className={`w-full max-w-xs sm:max-w-sm mx-auto ${isCompact ? "mt-1 mb-3" : "mb-4"}`}>
+        <div className={`flex items-center justify-between text-[10px] uppercase tracking-[0.14em] text-mc-text-dim select-none ${isCompact ? "mb-1" : "mb-1.5"}`}>
           <span>front of crate</span>
           <span>back</span>
         </div>
@@ -328,20 +368,20 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
       </div>
 
       {/* Paginator */}
-      <div className="flex items-center justify-center gap-4 sm:gap-6">
+      <div className={`flex items-center justify-center ${isCompact ? "gap-3" : "gap-4 sm:gap-6"}`}>
         <motion.button
           type="button"
           onClick={() => navigate(-1)}
           disabled={index <= 0}
           whileTap={{ scale: SCALE_PRESS }}
           transition={springPress}
-          className="flex items-center justify-center w-14 h-14 rounded-full bg-mc-bg-raised text-mc-text text-xl disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+          className={`flex items-center justify-center rounded-full bg-mc-bg-raised text-mc-text disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${isCompact ? "h-12 w-12 text-lg" : "w-14 h-14 text-xl"}`}
           aria-label="Previous record"
         >
           ↑
         </motion.button>
 
-        <span className="text-sm text-mc-text-dim tabular-nums w-20 text-center select-none" aria-live="polite" aria-atomic="true">
+        <span className={`${isCompact ? "w-16 text-xs" : "w-20 text-sm"} text-mc-text-dim tabular-nums text-center select-none`} aria-live="polite" aria-atomic="true">
           {index + 1} of {total}
         </span>
 
@@ -351,23 +391,25 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
           disabled={index >= total - 1}
           whileTap={{ scale: SCALE_PRESS }}
           transition={springPress}
-          className="flex items-center justify-center w-14 h-14 rounded-full bg-mc-bg-raised text-mc-text text-xl disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+          className={`flex items-center justify-center rounded-full bg-mc-bg-raised text-mc-text disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${isCompact ? "h-12 w-12 text-lg" : "w-14 h-14 text-xl"}`}
           aria-label="Next record"
         >
           ↓
         </motion.button>
       </div>
 
-      <p className="text-center text-xs text-mc-text-dim mt-4 select-none md:hidden">
-        pull forward for next &middot; push back for previous &middot; tap for details
-      </p>
+      {isCompact && showGestureHint && (
+        <p className="text-center text-[11px] text-mc-text-dim mt-2 select-none" aria-live="polite">
+          Swipe or use arrows to browse · tap for details
+        </p>
+      )}
     </>
   )
 
   return (
     <div className="flex flex-col">
-      {backButton}
-      {!hideTabs && (
+      {isCompact ? compactHeader : backButton}
+      {!isCompact && !hideTabs && (
         <div className="mb-4">
           <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
         </div>

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -130,11 +130,10 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
 
   const navigate = useCallback((delta: number) => {
     const next = index + delta
-    if (next < 0 || next >= total) return false
+    if (next < 0 || next >= total) return
     direction.current = delta
     setIndex(next)
     setShowGestureHint(false)
-    return true
   }, [index, total])
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -195,7 +194,7 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
     [records, index],
   )
 
-  const handleDragEnd = useCallback((_: any, info: { offset: { x: number; y: number } }) => {
+  const handleDragEnd = useCallback((_event: MouseEvent | TouchEvent | PointerEvent, info: { offset: { x: number; y: number } }) => {
     const dominantOffset = Math.abs(info.offset.x) > Math.abs(info.offset.y)
       ? info.offset.x
       : info.offset.y
@@ -210,7 +209,7 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
     return (
       <div>
         {isCompact ? compactHeader : backButton}
-        {!isCompact && (
+        {!isCompact && !hideTabs && (
           <div className="mb-3">
             <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
           </div>

--- a/app/frontend/pages/stores/featured.tsx
+++ b/app/frontend/pages/stores/featured.tsx
@@ -39,7 +39,7 @@ export default function Featured({ store, crates, storefront_sections }: Feature
 
   return (
     <AppLayout>
-      {(store.description || store.total_listings) && (
+      {activeSlug === null && (store.description || store.total_listings) && (
         <motion.div
           initial={{ opacity: 0, y: -6 }}
           animate={{ opacity: 1, y: 0 }}

--- a/app/frontend/test/pages/page_smoke.test.tsx
+++ b/app/frontend/test/pages/page_smoke.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import Home from "../../pages/home"
 import Apply from "../../pages/apply"
 import Featured from "../../pages/stores/featured"
@@ -88,5 +89,78 @@ describe("page smoke tests", () => {
     render(<Featured {...featuredProps} />)
 
     expect(screen.getByText(/No vinyl found yet/)).toBeInTheDocument()
+  })
+
+  it("hides store description after entering a crate", async () => {
+    const user = userEvent.setup()
+    const props: FeaturedProps = {
+      ...featuredProps,
+      crates: [
+        {
+          slug: "picks",
+          name: "Milkcrate Picks",
+          count: 1,
+          records: [
+            {
+              id: 1,
+              discogs_listing_id: "abc",
+              artist: "Artist",
+              title: "Record",
+              label: null,
+              year: null,
+              format: null,
+              genres: [],
+              styles: [],
+              condition: null,
+              price: "10.00",
+              currency: "USD",
+              cover_image_url: null,
+              thumbnail_url: null,
+              notes: null,
+              discogs_url: "https://www.discogs.com/sell/item/1",
+            },
+          ],
+        },
+      ],
+      storefront_sections: [
+        {
+          key: "picks_wall",
+          crate: {
+            slug: "picks",
+            name: "Milkcrate Picks",
+            count: 1,
+            records: [
+              {
+                id: 1,
+                discogs_listing_id: "abc",
+                artist: "Artist",
+                title: "Record",
+                label: null,
+                year: null,
+                format: null,
+                genres: [],
+                styles: [],
+                condition: null,
+                price: "10.00",
+                currency: "USD",
+                cover_image_url: null,
+                thumbnail_url: null,
+                notes: null,
+                discogs_url: "https://www.discogs.com/sell/item/1",
+              },
+            ],
+          },
+        },
+      ],
+    }
+
+    render(<Featured {...props} />)
+
+    expect(screen.getByText("Independent record store in South Philly.")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Open Milkcrate Picks" }))
+
+    expect(screen.queryByText("Independent record store in South Philly.")).not.toBeInTheDocument()
+    expect(screen.queryByText("120 vinyl listings")).not.toBeInTheDocument()
   })
 })

--- a/docs/brainstorms/2026-05-13-crate-view-mobile-space-requirements.md
+++ b/docs/brainstorms/2026-05-13-crate-view-mobile-space-requirements.md
@@ -1,0 +1,141 @@
+---
+date: 2026-05-13
+topic: crate-view-mobile-space
+---
+
+# Crate View Mobile Space
+
+## Summary
+
+Tighten the mobile CrateView without changing its core card-stack interaction: reclaim header space, adapt the stack footprint to viewport height, and reduce the permanent paginator/instruction footprint. This pass keeps the tactile crate metaphor intact and defers heavier detail-tray and crate-switcher redesigns.
+
+---
+
+## Problem Frame
+
+Mobile CrateView is where a buyer slows down from browsing the store floor into flipping through records. It needs to feel like a focused crate-digging surface, but the current layout spends too much phone-height on chrome around the records: a standalone back button, a full horizontal crate tab row, a fixed-height stack region, large paginator buttons, and persistent gesture instruction copy.
+
+The pain is most visible on small screens, where the active record competes with controls that are either larger than their current value warrants or permanently present after the user has learned the gesture. The store description also does not need to persist inside this view; the buyer is already inside a crate, and the task has shifted from store orientation to record browsing.
+
+---
+
+## Actors
+
+- A1. **Mobile crate browser:** Enters a crate from the store floor and wants to move through records comfortably with one thumb.
+- A2. **Returning mobile browser:** Already understands the crate gesture and should not keep paying vertical space for instructional copy.
+- A3. **Desktop/tablet browser:** Uses the existing larger CrateView layout and should not be affected by this mobile-focused pass.
+
+---
+
+## Key Flows
+
+- F1. **Mobile user enters a crate**
+  - **Trigger:** User opens a crate or a record position from the store floor.
+  - **Actors:** A1
+  - **Steps:** CrateView renders with a compact mobile header, the active crate context is visible, the store-floor description is absent, and the card stack occupies the available viewport without forcing controls unnecessarily far below the fold.
+  - **Outcome:** The user can immediately start browsing records with minimal top chrome.
+  - **Covered by:** R1, R2, R4, R5
+
+- F2. **Mobile user advances through records**
+  - **Trigger:** User swipes/drags the active record or uses visible navigation controls.
+  - **Actors:** A1, A2
+  - **Steps:** The card-stack gesture remains primary, progress stays visible, and secondary controls remain tappable without dominating the layout.
+  - **Outcome:** Record movement remains discoverable and accessible while using less vertical space.
+  - **Covered by:** R6, R7, R8
+
+- F3. **User has learned the gesture**
+  - **Trigger:** User interacts with the crate navigation successfully.
+  - **Actors:** A2
+  - **Steps:** The persistent instruction copy gives way to a lighter hint pattern or disappears after interaction.
+  - **Outcome:** The interface stops re-explaining itself and returns space to the crate.
+  - **Covered by:** R9, R10
+
+---
+
+## Requirements
+
+**Mobile header**
+
+- R1. On compact/mobile viewport, CrateView uses a compact header rather than a standalone large back button followed by separate visual chrome.
+- R2. The compact header preserves an easy-to-hit back control with an accessible name and visible press/focus states.
+- R3. The compact header communicates the active crate context at a glance, such as crate name and/or record count, without requiring the full horizontal crate list to be visually dominant.
+- R4. Store description or other store-floor orientation copy does not persist inside CrateView.
+- R5. Desktop and tablet CrateView header behavior remains unchanged unless a responsive rule explicitly targets compact/mobile viewport.
+
+**Adaptive stack**
+
+- R6. On compact/mobile viewport, the card stack sizes itself against available viewport height rather than relying on a fixed large minimum height.
+- R7. The active record cover remains the visual center of CrateView; adaptive sizing must not collapse the stack into a list-like or thumbnail-like experience.
+- R8. The progress indicator remains visible and associated with the stack, but it should not add unnecessary vertical spacing.
+
+**Controls and instruction cleanup**
+
+- R9. Mobile record navigation keeps the existing swipe/drag gesture as the primary interaction and keeps accessible visible controls as a secondary path.
+- R10. Visible navigation controls on compact/mobile viewport use less visual space while preserving reliable touch targets.
+- R11. Permanent gesture instruction copy is replaced with a lighter pattern: first-use hint, contextual hint, short-lived cue, or equivalent non-persistent affordance.
+- R12. The hint pattern must not leave users without a discoverable way to learn that dragging/swiping changes records and tapping can reveal card details.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3, R4.** Given a 375px-wide mobile viewport, when a user opens CrateView, then the top area shows a compact crate header with a back control and active crate context, and no store description is rendered in the crate view.
+- AE2. **Covers R5.** Given a desktop-width viewport, when a user opens CrateView, then the existing desktop/tablet header and two-column CrateView behavior are unchanged.
+- AE3. **Covers R6, R7, R8.** Given a short mobile viewport, when CrateView renders, then the active record stack remains prominent and the progress indicator remains visible without a fixed stack minimum pushing controls unnecessarily below the fold.
+- AE4. **Covers R9, R10.** Given a mobile user who does not use gestures, when they use visible next/previous controls, then they can still move through records using reliable touch targets.
+- AE5. **Covers R11, R12.** Given a new mobile user opens CrateView, when they have not yet interacted with the stack, then a lightweight cue teaches the available gesture. Given they successfully navigate, the cue no longer occupies permanent layout space.
+
+---
+
+## Success Criteria
+
+- A mobile user sees more of the active record experience above the fold than before, with less vertical space spent on persistent chrome.
+- Back navigation remains obvious and tappable despite the smaller visual treatment.
+- The card-stack metaphor remains intact: browsing still feels like flipping through a crate, not scanning a list.
+- Record movement remains accessible to both gesture users and users who rely on visible controls.
+- A downstream plan can separate the work into header, stack sizing, and control/hint units without inventing product behavior.
+
+---
+
+## Scope Boundaries
+
+- Bottom record detail tray is out of scope.
+- Bottom-sheet crate or genre switcher is out of scope.
+- Major StoreFloor navigation changes are out of scope.
+- Backend, curation, and data model changes are out of scope.
+- Replacing CrateView with a list, carousel, or non-crate browsing model is out of scope.
+- Desktop/tablet redesign is out of scope.
+- Full visual redesign of RecordCard is out of scope beyond what is needed to preserve stack fit.
+
+---
+
+## Key Decisions
+
+- **Mobile-only pass:** The user specifically wants to address mobile space inefficiency without disturbing broader CrateView behavior.
+- **Header and stack before trays/sheets:** The highest-value near-term move is reclaiming space and improving layout efficiency; deeper detail and crate-switching surfaces can be evaluated later.
+- **Gesture remains primary, controls remain available:** The tactile stack is core to the product metaphor, but visible controls are still needed for accessibility and discoverability.
+- **No persistent store description in CrateView:** Store description belongs to store orientation on the floor, not the focused record-browsing state.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing viewport tiering or equivalent compact/mobile detection is available for mobile-only behavior.
+- Existing motion and tactile interaction patterns should be reused where they fit.
+- Existing card drag/swipe navigation remains functional and is not replaced in this pass.
+- Existing crate tabs can remain in place unless the compact header requires minor accommodation; a full replacement with a sheet is deferred.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(None.)
+
+### Deferred to Planning
+
+- [Affects R1, R3][Technical] Determine whether the compact header should absorb the current crate tabs, visually compress them, or simply sit above the existing tab behavior on mobile.
+- [Affects R6, R7][Technical] Define the exact viewport-height sizing rule and test it across small phone, large phone, standalone PWA, and browser address-bar states.
+- [Affects R10][Design] Choose the final visual treatment for secondary navigation controls while preserving touch target size.
+- [Affects R11, R12][Design] Choose the hint pattern: first-use nudge, temporary copy, gesture icon, or another low-space cue.

--- a/docs/ideation/2026-05-13-crate-view-mobile-space-ideation.md
+++ b/docs/ideation/2026-05-13-crate-view-mobile-space-ideation.md
@@ -1,0 +1,163 @@
+---
+date: 2026-05-13
+topic: crate-view-mobile-space
+focus: Mobile crate view space efficiency, back navigation, store description persistence, and genre/crate controls
+mode: repo-grounded
+---
+
+# Ideation: Crate View Mobile Space
+
+## Grounding Context
+
+Milkcrate is a Rails 8 + Inertia React + TypeScript app for browsing a Discogs seller inventory as curated crates. The product strategy says browsing should feel like walking into a record store: spatial bins, walls, and genre sections where the store character comes through without replacing the tactile record-shopping experience.
+
+The current crate view already has a strong physical metaphor: a front-riffle stack with drag navigation, progress, large circular paginator buttons, and a desktop-only record detail panel. On mobile, `CrateView` is a single column: the back button renders above the crate tabs, the tab row is a horizontally scrolling list of every crate, the stack reserves `min-h-[390px]` plus padding around an `82vw` square card, and the desktop details panel is hidden entirely. This means scarce vertical space goes to navigation chrome and instructions while actual record information is mostly behind the card flip.
+
+Relevant code:
+
+- `app/frontend/components/crate_view.tsx:149-157` renders the current `← Store` button with `py-3 px-3 mb-4`.
+- `app/frontend/components/crate_tabs.tsx:25-47` renders all crates as horizontally scrolling tabs with `px-2.5 py-1`.
+- `app/frontend/components/crate_view.tsx:192-201` reserves the large stack footprint.
+- `app/frontend/components/crate_view.tsx:330-363` renders large paginator buttons plus instructional copy.
+- `app/frontend/components/crate_view.tsx:382-386` hides `RecordDetails` below `md`.
+- `app/frontend/components/store_floor.tsx:66-106` already uses horizontal scrolling for mobile picks, so the app has more than one horizontal browse surface on phones.
+
+Past learnings:
+
+- `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md` says mobile responsive behavior should use `useViewport`, and touch devices should get press-state feedback without hover effects.
+- The same learning notes that the picks wall disables small-card flip and routes users into `CrateView` for detail access. That makes crate view the right place to expose record details well on mobile.
+- `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md` supports shared motion tokens and tactile identity, so any navigation redesign should reuse the existing interaction vocabulary.
+
+External context:
+
+- W3C WCAG 2.2 Success Criterion 2.5.8 requires pointer targets to be at least 24 by 24 CSS pixels unless spacing or equivalent-control exceptions apply: https://w3c.github.io/wcag/guidelines/22/
+- Apple Human Interface Guidelines recommend a button hit region of at least 44 by 44 pt and a clear press state for custom buttons: https://developer.apple.com/design/human-interface-guidelines/buttons
+
+## Topic Axes
+
+- Header/navigation space
+- Record detail access
+- Crate switching and genre controls
+- Thumb-first record movement
+
+## Ranked Ideas
+
+### 1. Compact Crate Header
+
+**Description:** Replace the standalone `← Store` button plus separate tab row with one compact mobile crate header: a 44px-tall row containing an icon back button, the active crate name/count, and a compact crate-switcher affordance. Keep the existing larger desktop header behavior if it is working there. The store description should not persist inside this view; once a user enters a crate, the job is browsing records, not re-reading store positioning.
+
+**Axis:** Header/navigation space
+
+**Basis:** `direct:` `crate_view.tsx:149-157` spends a full row on `← Store`; `crate_view.tsx:370-373` immediately spends another row on tabs. `external:` Apple recommends 44x44 pt hit regions, so the answer is not a visually tiny target; it is an icon-sized hit area with less label/chrome.
+
+**Rationale:** This directly addresses the oversized back control and description-persistence concern without reducing tap safety. It reclaims vertical space while preserving a reliable escape hatch.
+
+**Downsides:** The label "Store" is clearer than a bare icon; the compact header needs an accessible name and enough visual affordance that users do not lose the way back.
+
+**Confidence:** 90%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+### 2. Bottom Record Detail Tray
+
+**Description:** Add a collapsed mobile detail tray below the active record or docked above the paginator. The default collapsed state shows title, artist, price, and pile/discogs actions in one dense strip; tapping or swiping expands to notes, genres, styles, and metadata. Keep the desktop `RecordDetails` panel unchanged.
+
+**Axis:** Record detail access
+
+**Basis:** `direct:` `crate_view.tsx:382-386` hides `RecordDetails` on mobile, while `record_card` flipping is the only mobile detail path. `direct:` the prior viewport learning says crate view is where details should be available because small wall cards intentionally disable flips.
+
+**Rationale:** Mobile users should not have to spend vertical space on static store copy or instructional text while the active record's buy/add context is hidden. A tray makes the screen feel more like a listening station: cover first, details within thumb reach.
+
+**Downsides:** It adds another stateful surface and needs careful gesture priority so it does not fight the card drag.
+
+**Confidence:** 86%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 3. Crate Switcher Sheet Instead Of Endless Tabs
+
+**Description:** Replace the mobile horizontal `CrateTabs` row with a "Crates" button that opens a bottom sheet grouped by featured crates and genres. Use large list rows or a two-column compact grid with counts, current-crate state, and search/filter if the genre count grows. Keep horizontal tabs on desktop where scan width is cheap.
+
+**Axis:** Crate switching and genre controls
+
+**Basis:** `direct:` `crate_tabs.tsx:25-47` maps every crate into a single overflow-x tab list. `direct:` user feedback says the genre buttons scroll for a long time and are not easy to hit on mobile. `external:` WCAG 2.2 target sizing makes tightly packed `px-2.5 py-1` chips a risk unless spacing and dimensions remain sufficient.
+
+**Rationale:** The current control optimizes for a handful of tabs, but genre crates are an inventory taxonomy and can grow. A sheet gives the taxonomy room, bigger targets, and a clearer "change section" mental model.
+
+**Downsides:** Switching crates becomes two taps instead of one when the desired crate is nearby. The sheet needs focus management and escape behavior.
+
+**Confidence:** 88%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 4. Cover-First Stack With Adaptive Height
+
+**Description:** Make the mobile stack footprint depend on the viewport: keep the cover square large, but remove the fixed `min-h-[390px]` on very short screens and cap the square with `min(78vw, calc(100svh - header - controls - tray))`. The stack should be visually dominant without forcing the paginator and details below the fold.
+
+**Axis:** Thumb-first record movement
+
+**Basis:** `direct:` `crate_view.tsx:192-201` reserves `min-h-[390px]` plus an `82vw` square before progress, paginator, and instructions. `reasoned:` mobile viewport height is the scarce resource here; a fixed minimum makes the layout least efficient on the devices where efficiency matters most.
+
+**Rationale:** This preserves the crate metaphor instead of shrinking it into a list, but lets the rest of the interaction breathe. It also gives the detail tray a chance to exist without making the page feel buried.
+
+**Downsides:** Dynamic sizing needs visual testing across small phones, address-bar states, and standalone PWA mode.
+
+**Confidence:** 82%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 5. Gesture-First Navigation, Buttons As Secondary
+
+**Description:** Keep drag/swipe as the primary mobile record movement and demote the two 56px circular paginator buttons to a compact secondary rail: smaller visual icons with 44px hit areas, or a single segmented control near the progress counter. Retain full keyboard support and desktop buttons.
+
+**Axis:** Thumb-first record movement
+
+**Basis:** `direct:` `crate_view.tsx:166-175` already supports drag navigation, and `crate_view.tsx:330-359` still renders two large circular buttons plus a count. `external:` Apple recommends a press state and sufficient hit region, not necessarily large visual buttons.
+
+**Rationale:** The app already invested in a tactile card-stack gesture. On mobile, visible controls should support the gesture rather than compete with it for vertical space.
+
+**Downsides:** Some users do not discover gestures; the first-run instructional affordance needs to be more elegant than permanent copy.
+
+**Confidence:** 78%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+### 6. One-Time Gesture Hint, Not Permanent Instruction Copy
+
+**Description:** Replace the persistent text "pull forward for next · push back for previous · tap for details" with a short-lived affordance: a subtle first-card nudge, a small "Swipe" hint that disappears after interaction, or an accessible helper tied to the progress area. Store the dismissal in local state or local storage if needed.
+
+**Axis:** Header/navigation space
+
+**Basis:** `direct:` `crate_view.tsx:361-363` renders permanent mobile instruction copy below the paginator. `reasoned:` persistent instructions are expensive in a vertically constrained flow once the user has learned the gesture.
+
+**Rationale:** This is a small space win that makes the interface feel more confident. The product should behave like a familiar tactile object after the first cue, not keep explaining itself.
+
+**Downsides:** If the cue is too subtle, gesture discovery may suffer. It should be tested with users who have not seen the crate view before.
+
+**Confidence:** 74%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Keep store description pinned above crate view | Conflicts with the user's instinct and the view's task; better suited to the store floor. |
+| 2 | Convert crate view to a plain vertical record list | Subject-replacement: abandons the physical crate metaphor that is central to the product strategy. |
+| 3 | Make every genre chip larger in the existing horizontal tab row | Helps hit targets but worsens the long-scroll problem the user named. |
+| 4 | Hide all crate switching until returning to store | Overcorrects; users browsing crates per session is a key metric, so switching should stay available. |
+| 5 | Add a search box to the crate view header | Useful only at larger inventory scale; not grounded enough for this specific mobile space problem. |
+| 6 | Turn the back button into a browser-style breadcrumb | Takes more horizontal space than an icon back button and does not solve the vertical-space issue. |
+| 7 | Move all controls into a floating radial menu | Novel but too expensive and likely less accessible than a sheet/header combination. |

--- a/docs/plans/2026-05-13-001-feat-crate-view-mobile-space-plan.md
+++ b/docs/plans/2026-05-13-001-feat-crate-view-mobile-space-plan.md
@@ -1,0 +1,268 @@
+---
+title: "feat: Tighten CrateView mobile space"
+type: feat
+status: completed
+date: 2026-05-13
+origin: docs/brainstorms/2026-05-13-crate-view-mobile-space-requirements.md
+---
+
+# feat: Tighten CrateView mobile space
+
+## Summary
+
+Implement the mobile CrateView space pass inside the existing frontend surfaces: compact the mobile header/tabs, make the card stack height responsive to available viewport space, and demote persistent navigation/instruction chrome while keeping swipe/drag and accessible controls intact.
+
+---
+
+## Problem Frame
+
+The origin requirements define a focused mobile CrateView pass: reclaim phone-height currently spent on a large back button, full tab row, fixed stack minimum, large paginator buttons, and permanent gesture instruction copy. The plan keeps the tactile crate stack as the primary browsing metaphor and avoids detail-tray, sheet-switcher, backend, and StoreFloor navigation changes.
+
+---
+
+## Requirements
+
+- R1. Compact/mobile CrateView uses a tighter header instead of a standalone large back button followed by separate visual chrome.
+- R2. The compact header preserves an easy-to-hit back control with accessible naming and visible press/focus states.
+- R3. The compact header communicates active crate context without making the full horizontal crate list visually dominant.
+- R4. Store-floor orientation copy, including store description, does not persist inside CrateView.
+- R5. Desktop/tablet CrateView behavior remains unchanged unless explicitly targeted by compact/mobile rules.
+- R6. Compact/mobile stack sizing responds to available viewport height instead of relying on a fixed large minimum.
+- R7. The active record cover remains the visual center; adaptive sizing must not collapse the stack into a list-like or thumbnail-like experience.
+- R8. The progress indicator remains visible and associated with the stack without adding unnecessary vertical spacing.
+- R9. Swipe/drag remains the primary mobile record navigation path, with visible controls retained as a secondary path.
+- R10. Visible compact/mobile navigation controls use less visual space while preserving reliable touch targets.
+- R11. Permanent gesture instruction copy is replaced by a lighter non-persistent affordance.
+- R12. The lighter hint must still teach users that dragging/swiping changes records and tapping can reveal card details.
+
+**Origin actors:** A1 Mobile crate browser, A2 Returning mobile browser, A3 Desktop/tablet browser
+
+**Origin flows:** F1 Mobile user enters a crate, F2 Mobile user advances through records, F3 User has learned the gesture
+
+**Origin acceptance examples:** AE1 compact header/no description, AE2 desktop unchanged, AE3 adaptive stack, AE4 accessible visible controls, AE5 non-persistent hint
+
+---
+
+## Scope Boundaries
+
+- Bottom record detail tray is out of scope.
+- Bottom-sheet crate or genre switcher is out of scope.
+- Major StoreFloor navigation changes are out of scope.
+- Backend, curation, and data model changes are out of scope.
+- Replacing CrateView with a list, carousel, or non-crate browsing model is out of scope.
+- Desktop/tablet redesign is out of scope.
+- Full visual redesign of RecordCard is out of scope beyond preserving stack fit.
+
+### Deferred to Follow-Up Work
+
+- Full crate/genre switcher redesign: if the compacted tabs still feel long on mobile, revisit the bottom-sheet switcher from the ideation doc in a separate pass.
+- Mobile record detail tray: keep the current flip/details model for now; evaluate a tray only after the space pass is tested on-device.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `app/frontend/components/crate_view.tsx` owns the mobile/desktop CrateView split, back button, crate tabs, stack sizing, progress bar, paginator controls, and permanent gesture copy.
+- `app/frontend/components/crate_tabs.tsx` already encapsulates the tablist and keyboard behavior; this plan should extend its presentation options rather than replacing it with a new switching surface.
+- `app/frontend/hooks/use_viewport.ts` exposes `isCompact`, `isComfy`, and `isWide`; CrateView already imports `useViewport` and uses `isCompact` to choose mobile card flip behavior.
+- `app/frontend/test/viewport-test-utils.tsx` provides `renderWithTier`, which should be used for compact vs desktop component coverage.
+- `app/frontend/pages/stores/featured.tsx` renders store description above StoreFloor and renders CrateView only after a crate opens. No page-level data or store description changes are needed for this pass.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md` establishes the viewport provider/test-helper pattern and warns that responsive boolean migrations need explicit compact vs desktop assertions.
+- The same learning records that CrateView is the correct larger detail surface after small picks-wall cards route into it; this plan preserves the crate stack and does not move details into a new tray.
+- `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md` establishes shared motion/tactile tokens. Any new press or motion behavior should reuse existing tokens rather than inventing local values.
+
+### External References
+
+- External research is not needed for this plan. The work is a small, local frontend layout change with established repo patterns and existing accessibility/touch-target context already captured in the origin ideation and requirements documents.
+
+---
+
+## Key Technical Decisions
+
+- **Keep changes local to CrateView and CrateTabs:** The confirmed scope is a focused CrateView pass, so StoreFloor, AppLayout, curation, and routing stay untouched.
+- **Extend the current tabs before replacing them:** The plan compacts or visually demotes the existing crate tab row on mobile. It does not introduce a bottom-sheet switcher.
+- **Use compact-tier branching, not browser sniffing:** Existing viewport context already expresses the product's responsive tiers and is testable via `renderWithTier`.
+- **Prefer layout constraints over runtime measurement:** Use CSS viewport units and responsive constraints for stack sizing where possible. Runtime measurement is deferred unless implementation proves CSS cannot satisfy the accepted examples.
+- **Treat the hint as session-local UI state:** The hint should disappear after successful navigation during the component's lifetime. Persistent storage is deferred to avoid adding carrying cost before user testing proves it is needed.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Compact header and tabs strategy: Use the existing tab behavior in a visually compressed/demoted mobile treatment; do not build the sheet switcher in this pass.
+- Hint persistence strategy: Dismiss the hint after successful in-session record navigation; do not add localStorage or user preference persistence yet.
+- Test scope: Add focused CrateView component coverage rather than expanding broader storefront/mobile plan tests.
+
+### Deferred to Implementation
+
+- Exact stack sizing formula: Choose the final CSS values during implementation and verify against compact, comfy, and wide renders.
+- Final icon/text treatment for controls: Pick the concrete labels/icons while implementing, preserving accessible names and touch targets.
+- Hint animation treatment: Choose a subtle cue that fits existing motion tokens and reduced-motion behavior.
+
+---
+
+## Implementation Units
+
+### U1. Compact Mobile Header and Tabs
+
+**Goal:** Replace the mobile CrateView top chrome with a compact header that combines back navigation, active crate context, and a visually demoted crate tab row without changing desktop/tablet behavior.
+
+**Requirements:** R1, R2, R3, R4, R5; F1; AE1, AE2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/components/crate_view.tsx`
+- Modify: `app/frontend/components/crate_tabs.tsx`
+- Create: `app/frontend/components/crate_view.test.tsx`
+
+**Approach:**
+- Split the current back-button rendering into a compact mobile header path and the existing non-compact path.
+- In the compact path, render an easy-to-hit back control, active crate name/count, and a lower-emphasis crate tab affordance.
+- Extend `CrateTabs` with presentation support for the compact CrateView context while preserving its tablist role, selected state, click behavior, and keyboard handling.
+- Keep desktop/tablet markup and spacing as close to current behavior as possible.
+- Do not thread store description into CrateView; it already belongs to the store floor in `app/frontend/pages/stores/featured.tsx`.
+
+**Execution note:** Start with compact and desktop rendering tests before changing layout, since the main risk is accidentally regressing one tier while improving the other.
+
+**Patterns to follow:**
+- `app/frontend/test/viewport-test-utils.tsx` for tier-specific rendering.
+- `app/frontend/components/crate_tabs.tsx` for roving tab selection and keyboard handling.
+- Existing focus ring and touch target styling in `app/frontend/components/crate_view.tsx`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: given compact tier and an `onBack` handler, CrateView renders a compact header with a back control, active crate name, active crate count or record position context, and no store description text.
+- Covers AE2. Happy path: given comfy or wide tier, CrateView still renders the existing desktop/tablet-oriented top behavior and two-column detail area.
+- Happy path: clicking the compact back control calls `onBack` exactly once.
+- Happy path: selecting another crate through the compacted tabs calls `onSelectCrate` with that crate slug and keeps the active tab semantics.
+- Edge case: when `hideTabs` is true, the compact header still provides back and active-crate context without rendering the tab row.
+- Accessibility: the compact back control has an accessible name equivalent to returning to the store, and the tablist preserves `role="tablist"`, `role="tab"`, and `aria-selected`.
+
+**Verification:**
+- Compact CrateView top chrome is visibly shorter than the prior back-button-plus-tabs stack.
+- Desktop/tablet CrateView remains functionally unchanged.
+- Existing crate tab keyboard navigation still works.
+
+---
+
+### U2. Adaptive Mobile Stack Sizing
+
+**Goal:** Replace the compact/mobile fixed stack minimum with viewport-aware sizing so the record stack remains dominant without pushing progress and controls unnecessarily below the fold.
+
+**Requirements:** R6, R7, R8; F1, F2; AE3
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/frontend/components/crate_view.tsx`
+- Test: `app/frontend/components/crate_view.test.tsx`
+
+**Approach:**
+- Introduce compact-only stack sizing rules that constrain the stack against available viewport height while preserving a large square cover.
+- Keep the current desktop/tablet stack dimensions and detail panel behavior.
+- Keep progress visually associated with the stack and reduce unnecessary margins only on compact tier.
+- Prefer CSS constraints with viewport-height units and responsive min/max values over JavaScript measurement.
+- Validate that the cover remains large enough to feel like the same crate stack, not a reduced thumbnail grid.
+
+**Patterns to follow:**
+- Existing `isCompact` branching in `app/frontend/components/crate_view.tsx`.
+- Viewport tier test injection from `app/frontend/test/viewport-test-utils.tsx`.
+- Existing reduced-motion branches in CrateView for animation behavior.
+
+**Test scenarios:**
+- Covers AE3. Happy path: given compact tier, the stack container uses compact-specific sizing rather than the desktop fixed minimum.
+- Covers AE2. Happy path: given wide tier, the desktop stack minimum and desktop detail panel behavior remain present.
+- Edge case: given a crate with one record, adaptive sizing still renders the active record and progress indicator without relying on hidden neighbor cards.
+- Edge case: given an empty crate, the empty state still renders back/header affordances and does not attempt stack sizing against missing records.
+- Accessibility: the progressbar remains present with correct `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and accessible label after layout changes.
+
+**Verification:**
+- On compact viewport, the stack, progress, and controls fit more efficiently in the first viewport than the current fixed-min-height layout.
+- On wide viewport, existing desktop CrateView proportions and detail panel remain stable.
+
+---
+
+### U3. Compact Controls and Non-Persistent Gesture Hint
+
+**Goal:** Keep swipe/drag as the primary mobile record navigation interaction while reducing the visual footprint of secondary controls and replacing permanent instruction text with a lighter dismissing cue.
+
+**Requirements:** R9, R10, R11, R12; F2, F3; AE4, AE5
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `app/frontend/components/crate_view.tsx`
+- Test: `app/frontend/components/crate_view.test.tsx`
+
+**Approach:**
+- On compact tier, reduce the visual weight of previous/next controls while maintaining reliable hit regions, disabled states, focus rings, and accessible names.
+- Keep desktop/tablet paginator controls unchanged unless shared extraction makes a no-op refactor unavoidable.
+- Track whether the user has successfully navigated during the current CrateView lifetime and use that to hide or demote the gesture hint.
+- Hide the hint after button navigation and drag/swipe navigation, because both prove the user can move through records.
+- Respect reduced-motion preferences for any hint movement or card nudge.
+
+**Patterns to follow:**
+- Existing `navigate` function and `direction` ref in `app/frontend/components/crate_view.tsx`.
+- Existing Framer Motion press token usage: `SCALE_PRESS` and `springPress`.
+- Existing reduced-motion handling in CrateView.
+
+**Test scenarios:**
+- Covers AE4. Happy path: given compact tier, clicking visible next/previous controls still advances and reverses records, with disabled behavior at crate boundaries.
+- Covers AE5. Happy path: given compact tier before navigation, the lightweight gesture cue is present; after successful next/previous navigation, the cue no longer occupies permanent layout space.
+- Happy path: after drag/swipe navigation crosses the threshold, the hint is dismissed as it would be after button navigation.
+- Edge case: attempting to navigate past the first or last record does not dismiss the hint unless navigation actually succeeds.
+- Accessibility: visible controls retain accessible names for previous and next record and remain keyboard/focus reachable.
+- Reduced motion: the hint has a non-animated or reduced-motion-safe presentation when reduced motion is active.
+
+**Verification:**
+- Compact controls consume less visual space than the existing two large circular buttons and permanent instruction line.
+- Gesture discovery still exists for first-time users.
+- Record navigation behavior and keyboard arrow navigation continue to work.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** CrateView remains the only changed user-facing component; StoreFloor opens it as before, and AppLayout remains untouched.
+- **Error propagation:** No new error paths or network requests are introduced.
+- **State lifecycle risks:** New hint-dismissal state should reset naturally when CrateView remounts or the active crate changes unless implementation chooses a more deliberate in-session scope.
+- **API surface parity:** No backend or Inertia prop changes are planned.
+- **Integration coverage:** Component tests should cover compact and desktop render differences; visual browser verification should cover actual phone-height constraints.
+- **Unchanged invariants:** Crate selection, record order, pile behavior, Discogs links, desktop details panel, and StoreFloor description behavior remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Compacting the header makes back navigation less obvious | Preserve accessible name, visible icon treatment, focus ring, and a minimum reliable hit region. |
+| Adaptive stack formula looks good in jsdom tests but poor on real devices | Include manual/browser verification on small phone, large phone, and desktop widths after implementation. |
+| Demoted controls hurt discoverability | Keep a first-use hint and visible secondary controls; dismiss only after successful navigation. |
+| Crate tabs remain long even after visual demotion | Treat this as accepted for this pass; the sheet switcher is explicitly deferred for follow-up work. |
+
+---
+
+## Documentation / Operational Notes
+
+- No user-facing documentation, backend rollout, or operational monitoring changes are required.
+- If implementation reveals that compacted tabs still dominate mobile space, document that as follow-up rather than expanding this plan into the deferred switcher sheet.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-13-crate-view-mobile-space-requirements.md](../brainstorms/2026-05-13-crate-view-mobile-space-requirements.md)
+- **Ideation document:** [docs/ideation/2026-05-13-crate-view-mobile-space-ideation.md](../ideation/2026-05-13-crate-view-mobile-space-ideation.md)
+- Related code: `app/frontend/components/crate_view.tsx`
+- Related code: `app/frontend/components/crate_tabs.tsx`
+- Related tests: `app/frontend/test/viewport-test-utils.tsx`
+- Related learning: `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`
+- Related learning: `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`


### PR DESCRIPTION
## Summary

Compact the mobile CrateView layout to reclaim phone-height currently spent on chrome around the records:

- **Compact header** replaces the standalone back button + full tab row with a tight row combining a 44px back control, active crate name/record count, and visually demoted crate tabs
- **Adaptive stack sizing** uses viewport-height units (`min(72svh, 360px)`) instead of a fixed `390px` minimum, keeping the cover large and the stack dominant
- **Smaller paginator controls** — 48px buttons instead of 56px, tighter spacing, reduced visual weight
- **Dismissing gesture hint** — shows a one-line cue on first view, hides after successful navigation (button or drag), resets on crate switch (session-local state, no localStorage)
- **Store description hidden inside CrateView** — gated on `activeSlug === null` in `featured.tsx`

Desktop/tablet behavior is unchanged. All responsive branching uses the existing `isCompact` tier from `useViewport`.

### Changed files

| File | Change |
|------|--------|
| `app/frontend/components/crate_view.tsx` | +74/-20 — compact header, adaptive stack, smaller controls, dismissing hint |
| `app/frontend/components/crate_tabs.tsx` | +20/-5 — `compact` prop, active-tab scrollIntoView, tighter spacing |
| `app/frontend/pages/stores/featured.tsx` | +1/-1 — gate store description on `activeSlug === null` |
| `app/frontend/components/crate_view.test.tsx` | new — 16 component tests covering compact/wide, empty state, hint lifecycle, accessibility |
| `app/frontend/components/crate_tabs.test.tsx` | new — 2 tests for compact touch targets and scrollIntoView |
| `app/frontend/test/pages/page_smoke.test.tsx` | +1 test — store description hides after entering a crate |

### Plan

`docs/plans/2026-05-13-001-feat-crate-view-mobile-space-plan.md` — all 12 requirements and 3 implementation units addressed.

### Test results

```
Test Files  2 passed (2)
     Tests  16 passed (16)
```