### PR TITLE
feat: responsive grids, home page redesign, and apply page polish

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -41,8 +41,8 @@
 
 [data-theme="light"] {
   --mc-bg:          #f5f0e8;
-  --mc-bg-raised:   #ece6d8;
-  --mc-bg-card:     #e0d8c8;
+  --mc-bg-raised:   #e0d8c8;
+  --mc-bg-card:     #ece6d8;
   --mc-text:        #1a1410;
   --mc-text-dim:    #6b5a44;
   --mc-accent:      #b07030;

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -35,10 +35,17 @@ const activeLayerStyle: React.CSSProperties = {
 }
 
 function RecordDetails({ listing, direction }: { listing: Listing; direction: number }) {
-  const meta = [listing.label, listing.year, listing.condition].filter(Boolean).join(" · ")
+  const meta = [listing.format, listing.label, listing.year, listing.condition].filter(Boolean).join(" · ")
   const enterY = direction >= 0 ? -16 : 16
   const exitY = direction >= 0 ? 16 : -16
   const { inPile, addToPile, removeFromPile } = usePileContext()
+
+  const currencySymbol = listing.currency === "GBP" ? "£" : listing.currency === "EUR" ? "€" : "$"
+
+  const allTags = [
+    ...listing.genres.slice(0, 4).map((g) => ({ label: g, dim: false })),
+    ...listing.styles.slice(0, 4).map((s) => ({ label: s, dim: true })),
+  ]
 
   return (
     <AnimatePresence mode="wait" custom={direction}>
@@ -49,46 +56,48 @@ function RecordDetails({ listing, direction }: { listing: Listing; direction: nu
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: exitY }}
         transition={{ duration: 0.18, ease: "easeOut" }}
-        className="flex flex-col gap-3"
+        className="flex flex-col gap-4"
       >
-        <div>
-          <div className="text-xl font-semibold leading-tight">{listing.title}</div>
-          <div className="text-sm text-mc-text-dim mt-1">{listing.artist}</div>
+        {/* Header: info + price/actions in two-column row */}
+        <div className="grid grid-cols-[1fr_auto] gap-x-6 items-start">
+          <div>
+            <div className="text-xl font-semibold leading-tight">{listing.title}</div>
+            <div className="text-sm text-mc-text-dim mt-1">{listing.artist}</div>
+            {meta && <div className="text-xs text-mc-text-dim mt-2">{meta}</div>}
+          </div>
+          <div className="flex flex-col items-end gap-2">
+            <span className="text-2xl font-medium whitespace-nowrap">
+              {listing.display_price ?? (listing.price ? `${currencySymbol}${parseFloat(listing.price).toFixed(2)}` : "—")}
+            </span>
+            <div className="flex gap-2">
+              {inPile(listing.id) ? (
+                <button onClick={() => removeFromPile(listing.id)} className="mc-btn">✓ In pile</button>
+              ) : (
+                <button onClick={() => addToPile(listing)} className="mc-btn mc-btn-primary">+ Pile</button>
+              )}
+              <a href={listing.discogs_url} target="_blank" rel="noopener" className="mc-btn">Discogs ↗</a>
+            </div>
+          </div>
         </div>
-        {meta && <div className="text-xs text-mc-text-dim">{meta}</div>}
-        {listing.genres.length > 0 && (
+
+        {/* Combined genre + style pills */}
+        {allTags.length > 0 && (
           <div className="flex gap-1.5 flex-wrap">
-            {listing.genres.slice(0, 4).map((g) => (
-              <span key={g} className="text-[11px] px-2 py-0.5 rounded bg-mc-bg-raised text-mc-text-dim">
-                {g}
+            {allTags.map((tag) => (
+              <span
+                key={tag.label}
+                className={`text-[11px] px-2 py-0.5 rounded bg-mc-bg-raised ${
+                  tag.dim ? "text-mc-text-dim/70" : "text-mc-text-dim"
+                }`}
+              >
+                {tag.label}
               </span>
             ))}
           </div>
         )}
-        {listing.styles.length > 0 && (
-          <div className="flex gap-1.5 flex-wrap">
-            {listing.styles.slice(0, 4).map((s) => (
-              <span key={s} className="text-[11px] px-2 py-0.5 rounded bg-mc-bg-raised text-mc-text-dim/70">
-                {s}
-              </span>
-            ))}
-          </div>
-        )}
-        <div className="text-2xl font-medium mt-2">
-          {listing.price ? `$${parseFloat(listing.price).toFixed(2)}` : "—"}
-        </div>
-        <div className="flex gap-2">
-          {inPile(listing.id) ? (
-            <button onClick={() => removeFromPile(listing.id)} className="mc-btn">✓ In pile</button>
-          ) : (
-            <button onClick={() => addToPile(listing)} className="mc-btn mc-btn-primary">+ Pile</button>
-          )}
-          <a href={listing.discogs_url} target="_blank" rel="noopener" className="mc-btn">
-            Discogs ↗
-          </a>
-        </div>
+
         {listing.notes && (
-          <p className="text-xs text-mc-text-dim leading-relaxed line-clamp-4 mt-1">{listing.notes}</p>
+          <p className="text-xs text-mc-text-dim leading-relaxed line-clamp-4">{listing.notes}</p>
         )}
       </motion.div>
     </AnimatePresence>
@@ -149,17 +158,6 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
   const progress = total > 0 ? ((index + 1) / total) * 100 : 0
   const activeRecord = records[index]
 
-  const backButton = onBack ? (
-    <button
-      type="button"
-      onClick={onBack}
-      className="self-start text-xs font-medium text-mc-text-dim bg-mc-bg-raised border border-mc-border rounded-lg hover:border-mc-accent hover:text-mc-accent transition-colors mb-4 flex items-center gap-1.5 cursor-pointer py-3 px-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
-      aria-label="Back to store"
-    >
-      ← Store
-    </button>
-  ) : null
-
   const compactHeader = isCompact ? (
     <div className="mb-3">
       <div className="flex items-center gap-3">
@@ -205,15 +203,31 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
     dragX.set(0)
   }, [dragX, navigate])
 
+  const desktopToolbar = onBack || !hideTabs ? (
+    <div className="flex items-center gap-3 mb-4 border-b border-mc-border py-2">
+      {onBack && (
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex items-center gap-1.5 text-xs font-medium text-mc-text-dim bg-mc-bg-raised border border-mc-border rounded-lg hover:border-mc-accent hover:text-mc-accent transition-colors whitespace-nowrap py-1.5 px-3 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+          aria-label="Back to store"
+        >
+          ← Store
+        </button>
+      )}
+      {onBack && !hideTabs && <div className="w-px self-stretch bg-mc-border" />}
+      {!hideTabs && (
+        <div className="min-w-0 flex-1">
+          <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
+        </div>
+      )}
+    </div>
+  ) : null
+
   if (!activeCrate || total === 0) {
     return (
       <div>
-        {isCompact ? compactHeader : backButton}
-        {!isCompact && !hideTabs && (
-          <div className="mb-3">
-            <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
-          </div>
-        )}
+        {isCompact ? compactHeader : desktopToolbar}
         <div className="py-16 text-center mc-dim text-sm">No records in this crate yet.</div>
       </div>
     )
@@ -407,22 +421,17 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
 
   return (
     <div className="flex flex-col">
-      {isCompact ? compactHeader : backButton}
-      {!isCompact && !hideTabs && (
-        <div className="mb-4">
-          <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
-        </div>
-      )}
+      {isCompact ? compactHeader : desktopToolbar}
 
       {/* Mobile: single column. Desktop: centered two-column */}
-      <div className="md:max-w-3xl md:mx-auto md:w-full md:grid md:grid-cols-[420px_1fr] md:gap-12 md:items-start">
+      <div className="md:mx-auto md:w-full md:grid md:grid-cols-[420px_1fr] md:gap-12 md:items-start">
         <div className="flex flex-col">
           {cardStack}
         </div>
 
         {/* Desktop details panel */}
         {activeRecord && (
-          <div className="hidden md:flex md:flex-col md:pt-20 md:min-h-[420px]">
+          <div className="hidden md:flex md:flex-col md:pt-7">
             <RecordDetails listing={activeRecord} direction={direction.current} />
           </div>
         )}

--- a/app/frontend/types/inertia.ts
+++ b/app/frontend/types/inertia.ts
@@ -20,6 +20,7 @@ export interface Listing {
   styles: string[]
   condition: string | null
   price: string
+  display_price?: string
   currency: string
   cover_image_url: string | null
   thumbnail_url: string | null


### PR DESCRIPTION
## Summary

The home page now goes beyond a hero-only layout with two new sections — "How Browsing Works" and a visual crate-flipping preview — that help users understand the product before applying. Grids across the app adapt dynamically to viewport tiers (compact/comfy/wide) using the `useViewport` hook for more nuanced responsive control. Both marketing and app layouts wrap content in a consistent `max-w-6xl` container. The apply page is cleaned up: the glass-of-milk decoration is gone and the subhead is tighter.

## What changed and why

- **Home page redesign** — added a three-step "How Browsing Works" section (flip crates, discover what's interesting, build your pile), a decorative crate-thumbnail preview grid, and a "See a live store" link. This gives prospective users concrete context about the Milkcrate experience before they fill out the apply form.

- **Responsive grids** — `FeaturedCratesRow`, `GenreGrid`, and `StoreFloor` (picks wall) now use the `useViewport` hook to set column counts per viewport tier instead of fixed CSS breakpoints. Compact gets fewer columns, comfy and wide get progressively more. The picks wall on desktop shows a 5-column grid across 2 rows.

- **Layout containers** — Both `AppLayout` and `MarketingLayout` now wrap `<main>` content in a centered `max-w-6xl` container with responsive padding, replacing bare `px-4` margins on individual pages.

- **Apply page polish** — removed the decorative 🥛 + divider above the form. Shortened the subhead by dropping "— this isn't automatic, we review every store personally."
