### PR TITLE
Fix form failure URL: use /apply instead of /waitlist

### DIFF
--- a/app/frontend/pages/apply.tsx
+++ b/app/frontend/pages/apply.tsx
@@ -179,7 +179,7 @@ export default function Apply({ submitted = false, errors = {}, turnstile, copy 
         <form
           onSubmit={(e) => {
             e.preventDefault()
-            post("/waitlist")
+            post("/apply")
           }}
           className="flex flex-col gap-6"
           noValidate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   root "pages#home"
 
   get  "/apply",   to: "pages#apply"
-  post "/waitlist", to: "waitlists#create"
+  post "/apply", to: "waitlists#create"
 
   get "/:slug", to: "stores#show", as: :store
 end

--- a/spec/requests/waitlists_spec.rb
+++ b/spec/requests/waitlists_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe "Waitlists", type: :request do
     context "with valid params" do
       it "creates a waitlist entry" do
         expect {
-          post "/waitlist", params: valid_params
+          post "/apply", params: valid_params
         }.to change(Waitlist, :count).by(1)
       end
 
       it "sends a confirmation email" do
         expect {
-          post "/waitlist", params: valid_params
+          post "/apply", params: valid_params
         }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           "SellerMailer", "confirmation", "deliver_now", any_args
         )
@@ -31,27 +31,27 @@ RSpec.describe "Waitlists", type: :request do
 
       it "sends an admin notification email" do
         expect {
-          post "/waitlist", params: valid_params
+          post "/apply", params: valid_params
         }.to have_enqueued_job(ActionMailer::MailDeliveryJob).with(
           "SellerMailer", "admin_notification", "deliver_now", any_args
         )
       end
 
       it "redirects to the apply page" do
-        post "/waitlist", params: valid_params
+        post "/apply", params: valid_params
         expect(response).to have_http_status(:found)
         expect(response).to redirect_to(apply_path)
       end
 
       it "renders the apply page with submitted: true after redirect" do
-        post "/waitlist", params: valid_params
+        post "/apply", params: valid_params
         follow_redirect!
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("submitted")
       end
 
       it "is refresh-safe: redirect prevents form resubmission on refresh" do
-        post "/waitlist", params: valid_params
+        post "/apply", params: valid_params
         expect(response).to have_http_status(:found)
       end
     end
@@ -63,12 +63,12 @@ RSpec.describe "Waitlists", type: :request do
 
       it "does not create an entry without a Turnstile token" do
         expect {
-          post "/waitlist", params: valid_params
+          post "/apply", params: valid_params
         }.not_to change(Waitlist, :count)
       end
 
       it "renders the apply page with submitted: false without a Turnstile token" do
-        post "/waitlist", params: valid_params
+        post "/apply", params: valid_params
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("submitted")
@@ -82,7 +82,7 @@ RSpec.describe "Waitlists", type: :request do
         ).and_return(false)
 
         expect {
-          post "/waitlist", params: valid_params.merge(turnstile_token: "bad-token")
+          post "/apply", params: valid_params.merge(turnstile_token: "bad-token")
         }.not_to change(Waitlist, :count)
       end
 
@@ -92,7 +92,7 @@ RSpec.describe "Waitlists", type: :request do
           remote_ip: "127.0.0.1"
         ).and_return(false)
 
-        post "/waitlist", params: valid_params.merge(turnstile_token: "bad-token")
+        post "/apply", params: valid_params.merge(turnstile_token: "bad-token")
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Please confirm you are human.")
@@ -105,7 +105,7 @@ RSpec.describe "Waitlists", type: :request do
         ).and_return(false)
 
         expect {
-          post "/waitlist", params: valid_params.merge(turnstile_token: "timeout-token")
+          post "/apply", params: valid_params.merge(turnstile_token: "timeout-token")
         }.not_to change(Waitlist, :count)
 
         expect(response).to have_http_status(:ok)
@@ -120,7 +120,7 @@ RSpec.describe "Waitlists", type: :request do
         ).and_return(true)
 
         expect {
-          post "/waitlist", params: valid_params.merge(turnstile_token: "good-token")
+          post "/apply", params: valid_params.merge(turnstile_token: "good-token")
         }.to change(Waitlist, :count).by(1)
       end
     end
@@ -129,20 +129,20 @@ RSpec.describe "Waitlists", type: :request do
       it "does not create an entry" do
         params = valid_params.deep_merge(waitlist: { name: "" })
         expect {
-          post "/waitlist", params: params
+          post "/apply", params: params
         }.not_to change(Waitlist, :count)
       end
 
       it "renders the apply page with submitted: false" do
         params = valid_params.deep_merge(waitlist: { name: "" })
-        post "/waitlist", params: params
+        post "/apply", params: params
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("submitted")
       end
 
       it "returns validation errors in the frontend-expected format" do
         params = valid_params.deep_merge(waitlist: { name: "" })
-        post "/waitlist", params: params
+        post "/apply", params: params
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include('"error":"can\'t be blank"')
@@ -154,7 +154,7 @@ RSpec.describe "Waitlists", type: :request do
       it "does not create an entry" do
         params = valid_params.deep_merge(waitlist: { email: "notvalid" })
         expect {
-          post "/waitlist", params: params
+          post "/apply", params: params
         }.not_to change(Waitlist, :count)
       end
     end
@@ -163,7 +163,7 @@ RSpec.describe "Waitlists", type: :request do
       it "does not create an entry" do
         params = valid_params.deep_merge(waitlist: { discogs_username: "" })
         expect {
-          post "/waitlist", params: params
+          post "/apply", params: params
         }.not_to change(Waitlist, :count)
       end
     end


### PR DESCRIPTION
The apply form at `/apply` was posting to `/waitlist`, a separate POST-only route. On validation failure, Inertia preserves the POST target URL, leaving the user at `/waitlist` — which has no GET handler and would produce a 404 on refresh.

**Fix**: Changed the form to post to `/apply` (its own page URL) and routed `POST /apply` to `waitlists#create`. Removed the `/waitlist` route entirely.

- On success: redirect to `GET /apply` (unchanged) ✅
- On failure: `render inertia: "apply"` keeps URL at `/apply` ✅
- The /waitlist route is gone — it was only used by this form