### PR TITLE
fix(crate-view): correct card entry animation direction

### DIFF
--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -36,8 +36,8 @@ const activeLayerStyle: React.CSSProperties = {
 
 function RecordDetails({ listing, direction }: { listing: Listing; direction: number }) {
   const meta = [listing.format, listing.label, listing.year, listing.condition].filter(Boolean).join(" · ")
-  const enterY = direction >= 0 ? -16 : 16
-  const exitY = direction >= 0 ? 16 : -16
+  const enterY = direction >= 0 ? 16 : -16
+  const exitY = direction >= 0 ? -16 : 16
   const { inPile, addToPile, removeFromPile } = usePileContext()
 
   const currencySymbol = listing.currency === "GBP" ? "£" : listing.currency === "EUR" ? "€" : "$"
@@ -312,18 +312,18 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
                   variants={{
                     initial: (d: number) => (
                       prefersReducedMotion
-                        ? { opacity: 0, y: d >= 0 ? -42 : 42, scale: 0.98 }
+                        ? { opacity: 0, y: d >= 0 ? 42 : -42, scale: 0.98 }
                         : d >= 0
-                          ? { opacity: 0, y: -78, rotate: -3 }
-                          : { opacity: 0, y: 78, rotate: 3 }
+                          ? { opacity: 0, y: 78, rotate: 3 }
+                          : { opacity: 0, y: -78, rotate: -3 }
                     ),
                     animate: { opacity: 1, y: 0, rotate: 0, scale: 1 },
                     exit: (d: number) => (
                       prefersReducedMotion
-                        ? { opacity: 0, y: d >= 0 ? 54 : -54, scale: 0.96 }
+                        ? { opacity: 0, y: d >= 0 ? -54 : 54, scale: 0.96 }
                         : d >= 0
-                          ? { opacity: 0, y: 66, rotate: 4 }
-                          : { opacity: 0, y: -66, rotate: -4 }
+                          ? { opacity: 0, y: -66, rotate: -4 }
+                          : { opacity: 0, y: 66, rotate: 4 }
                     ),
                   }}
                   initial="initial"


### PR DESCRIPTION
## Summary

Fixes the card entry animation direction in the crate view. Forward/next records now enter from BELOW (rising from the stack) and backward/prev records enter from ABOVE (descending from the front) — matching the crate physical metaphor.

## What changed

`app/frontend/components/crate_view.tsx` — 2 targeted edits:

1. **Animation variants**: Swapped entry/exit y values so forward (`direction >= 0`) enters from below (`y: 78`) and backward enters from above (`y: -78`).

2. **RecordDetails**: Synced to match the card's new direction.

## What didn't change

Gesture mapping is unchanged: **swipe DOWN = forward**, **swipe UP = backward**.

## Behavior

| Interaction | Before | After |
|---|---|---|
| Swipe DOWN / ↓ button | Forward record enters from above | Forward record enters from below ✓ |
| Swipe UP / ↑ button | Backward record enters from below | Backward record enters from above ✓ |

All 21 crate view tests pass.