### PR TITLE
fix(store): keep onboarding spinner until enrichment is complete

### DIFF
--- a/app/frontend/pages/stores/featured.tsx
+++ b/app/frontend/pages/stores/featured.tsx
@@ -76,7 +76,7 @@ export default function Featured({ store, crates, storefront_sections }: Feature
         </div>
       )}
 
-      {store.sync_status === "syncing" ? (
+      {(store.sync_status === "syncing" || store.enrichment_status === "enriching") ? (
         <div
           role="status"
           aria-live="polite"
@@ -104,7 +104,9 @@ export default function Featured({ store, crates, storefront_sections }: Feature
             />
           </svg>
           <p className="text-sm mc-dim">
-            Syncing inventory… check back in a moment.
+            {store.sync_status === "syncing"
+              ? "Syncing inventory… check back in a moment."
+              : "Setting up your store… check back in a moment."}
           </p>
         </div>
       ) : crates.length === 0 ? (

--- a/app/frontend/types/inertia.ts
+++ b/app/frontend/types/inertia.ts
@@ -6,6 +6,8 @@ export interface Store {
   total_listings: number | null
   sync_status: string
   last_sync_error_at: string | null
+  enrichment_status: string
+  last_enriched_at: string | null
 }
 
 export interface Listing {

--- a/app/jobs/enrichment_job.rb
+++ b/app/jobs/enrichment_job.rb
@@ -3,9 +3,18 @@ class EnrichmentJob < ApplicationJob
 
   def perform(store_id, listing_ids: nil)
     store = Store.find(store_id)
-    service = EnrichmentService.new
+    store.update!(enrichment_status: "enriching")
 
+    service = EnrichmentService.new
     service.enrich_releases(store, listing_ids:)
     service.enrich_music_brainz_images(store)
+
+    store.update!(enrichment_status: "idle", last_enriched_at: Time.current)
+  rescue StandardError => error
+    Rails.logger.error(
+      "[EnrichmentJob] store=#{store&.discogs_username || store_id} job_id=#{job_id} failed\n#{error.full_message(highlight: false, order: :top)}"
+    )
+    store&.update!(enrichment_status: "failed")
+    raise
   end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -8,13 +8,19 @@ class Store < ApplicationRecord
     idle: "idle",
     syncing: "syncing",
     failed: "failed"
-  }, default: "idle"
+  }, default: "idle", prefix: "sync"
 
   enum :catalog_coverage, {
     unknown: "unknown",
     near_complete: "near_complete",
     partial: "partial"
   }, default: "unknown"
+
+  enum :enrichment_status, {
+    idle: "idle",
+    enriching: "enriching",
+    failed: "failed"
+  }, default: "idle", prefix: "enrichment"
 
   def stale?
     last_synced_at.nil? || last_synced_at < 23.hours.ago

--- a/app/presenters/crate_presenter.rb
+++ b/app/presenters/crate_presenter.rb
@@ -11,7 +11,9 @@ class CratePresenter
       description: @store.description,
       total_listings: @store.total_listings,
       sync_status: @store.sync_status,
-      last_sync_error_at: @store.last_sync_error_at
+      last_sync_error_at: @store.last_sync_error_at,
+      enrichment_status: @store.enrichment_status,
+      last_enriched_at: @store.last_enriched_at
     }
   end
 

--- a/db/migrate/20260515221108_add_enrichment_status_to_stores.rb
+++ b/db/migrate/20260515221108_add_enrichment_status_to_stores.rb
@@ -1,0 +1,6 @@
+class AddEnrichmentStatusToStores < ActiveRecord::Migration[8.1]
+  def change
+    add_column :stores, :enrichment_status, :string, default: "idle", null: false
+    add_column :stores, :last_enriched_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,6 @@
 ActiveRecord::Schema[8.1].define(version: 2026_05_15_221108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
-  enable_extension "vector"
 
   create_table "daily_selections", force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_025358) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_15_221108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "vector"
 
   create_table "daily_selections", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -220,7 +221,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_025358) do
     t.datetime "created_at", null: false
     t.text "description"
     t.string "discogs_username"
+    t.string "enrichment_status", default: "idle", null: false
     t.integer "inventory_page_count", default: 0, null: false
+    t.datetime "last_enriched_at"
     t.text "last_sync_error"
     t.datetime "last_sync_error_at"
     t.datetime "last_synced_at"

--- a/spec/factories/stores.rb
+++ b/spec/factories/stores.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:discogs_username) { |n| "recordstore#{n}" }
     description { "A great record store." }
     sync_status { "idle" }
+    enrichment_status { "idle" }
     catalog_coverage { "near_complete" }
     inventory_page_count { 1 }
     total_listings { 0 }

--- a/spec/jobs/enrichment_job_spec.rb
+++ b/spec/jobs/enrichment_job_spec.rb
@@ -4,9 +4,15 @@ RSpec.describe EnrichmentJob do
   let(:store) { create(:store) }
 
   describe "#perform" do
-    it "calls both enrichment methods on EnrichmentService" do
-      service = instance_double(EnrichmentService)
+    let(:service) { instance_double(EnrichmentService) }
+
+    before do
       allow(EnrichmentService).to receive(:new).and_return(service)
+    end
+
+    it "calls both enrichment methods on EnrichmentService" do
+      allow(service).to receive(:enrich_releases)
+      allow(service).to receive(:enrich_music_brainz_images)
       expect(service).to receive(:enrich_releases).with(store, listing_ids: [ 1, 2 ])
       expect(service).to receive(:enrich_music_brainz_images).with(store)
 
@@ -14,12 +20,55 @@ RSpec.describe EnrichmentJob do
     end
 
     it "passes listing_ids as nil when not provided" do
-      service = instance_double(EnrichmentService)
-      allow(EnrichmentService).to receive(:new).and_return(service)
+      allow(service).to receive(:enrich_releases)
+      allow(service).to receive(:enrich_music_brainz_images)
       expect(service).to receive(:enrich_releases).with(store, listing_ids: nil)
       expect(service).to receive(:enrich_music_brainz_images).with(store)
 
       described_class.new.perform(store.id)
+    end
+
+    describe "enrichment status transitions" do
+      before do
+        allow(service).to receive(:enrich_releases)
+        allow(service).to receive(:enrich_music_brainz_images)
+        # Make the job use our store instance so we can verify update! calls
+        allow(Store).to receive(:find).with(store.id).and_return(store)
+      end
+
+      it "sets enrichment_status to enriching at start" do
+        expect(store).to receive(:update!).with(hash_including(enrichment_status: "enriching")).ordered
+        expect(store).to receive(:update!).with(hash_including(enrichment_status: "idle", last_enriched_at: instance_of(ActiveSupport::TimeWithZone))).ordered
+
+        described_class.new.perform(store.id)
+      end
+
+      it "sets last_enriched_at on successful completion" do
+        allow(store).to receive(:update!).and_call_original
+
+        described_class.new.perform(store.id)
+
+        expect(store.reload.last_enriched_at).to be_within(1.second).of(Time.current)
+      end
+
+      it "stays idle when enrichment completes despite individual API errors in EnrichmentService" do
+        allow(store).to receive(:update!).and_call_original
+
+        described_class.new.perform(store.id)
+
+        expect(store.reload.enrichment_status).to eq("idle")
+      end
+
+      it "sets enrichment_status to failed and re-raises on hard failure" do
+        allow(service).to receive(:enrich_releases).and_raise(StandardError.new("boom"))
+        allow(store).to receive(:update!).and_call_original
+
+        expect {
+          described_class.new.perform(store.id)
+        }.to raise_error(StandardError, "boom")
+
+        expect(store.reload.enrichment_status).to eq("failed")
+      end
     end
   end
 end

--- a/spec/presenters/crate_presenter_spec.rb
+++ b/spec/presenters/crate_presenter_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe CratePresenter do
         name: store.name,
         discogs_username: store.discogs_username,
         description: store.description,
-        sync_status: store.sync_status
+        sync_status: store.sync_status,
+        enrichment_status: store.enrichment_status
       )
     end
   end


### PR DESCRIPTION
## Summary

The store onboarding loading spinner disappeared as soon as the sync finished, even though release metadata and image enrichment was still running in the background. Users saw a storefront with missing cover images and shifting genre crates that changed between refreshes. The spinner now persists until both sync and enrichment are complete, so the storefront appears only when fully populated.

## Design decisions

- Follows the existing `sync_status` pattern with a separate `enrichment_status` enum on Store (idle / enriching / failed)
- EnrichmentJob sets `enriching` at start, `idle` with `last_enriched_at` on success, and `failed` on error, matching the sync lifecycle in StoreSyncService
- Frontend shows the spinner when either `sync_status === "syncing"` or `enrichment_status === "enriching"` with stage-appropriate copy ("Syncing inventory…" vs "Setting up your store…")
- Added `prefix: "sync"` and `prefix: "enrichment"` to enum definitions to resolve a Rails 8 method name collision

## Post-Deploy Monitoring & Validation

**Log query:** Search for `[EnrichmentJob]` entries — expect no `failed` statuses in normal operation. Monitor for stores stuck in `enriching` status.

**Healthy signal:** Storefront pages load with a brief enrichment spinner (or none for already-enriched stores), then render with cover images and stable genre crate groupings.

**Failure signal:** Spinner never releases → check `enrichment_status` in the DB. If `"enriching"`, the job may have crashed; if `"failed"`, check logs. The `"failed"` state releases the spinner automatically (same recovery as failed syncs).

**Validation window:** First 3 store onboardings after deploy.