### PR TITLE
feat: turn 404 page into Discogs seller invitation with one-click claim flow

### DIFF
--- a/app/controllers/api/discogs_lookup_controller.rb
+++ b/app/controllers/api/discogs_lookup_controller.rb
@@ -1,0 +1,61 @@
+module Api
+  class DiscogsLookupController < ApplicationController
+    # Slug quality gate — only allow plausible Discogs usernames
+    VALID_USERNAME_REGEX = /\A[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]\z/
+    MIN_LENGTH = 3
+    MAX_LENGTH = 40
+
+    # Common reserved routes that should not trigger a Discogs lookup
+    RESERVED_SLUGS = %w[
+      admin apply jobs up assets 404 500 health
+      login logout signup register
+      api docs status help support
+      favicon manifest service-worker
+    ].freeze
+
+    # Cache TTLs
+    FOUND_TTL = 1.hour
+    NOT_FOUND_TTL = 24.hours
+
+    def show
+      username = params[:username].to_s.strip
+
+      unless plausible_username?(username)
+        return render json: { found: false, reason: "invalid_slug" }, status: :ok
+      end
+
+      normalized = username.downcase
+      cached = Rails.cache.read(cache_key(normalized))
+      if cached
+        return render json: cached, status: :ok
+      end
+
+      result = lookup_discogs(normalized)
+      Rails.cache.write(cache_key(normalized), result, expires_in: result[:found] ? FOUND_TTL : NOT_FOUND_TTL)
+
+      render json: result, status: :ok
+    end
+
+    private
+
+    def plausible_username?(username)
+      return false if username.length < MIN_LENGTH || username.length > MAX_LENGTH
+      return false unless VALID_USERNAME_REGEX.match?(username)
+      return false if RESERVED_SLUGS.include?(username.downcase)
+
+      true
+    end
+
+    def lookup_discogs(username)
+      client = DiscogsClient.new
+      profile = client.seller_profile(username)
+      { found: true, seller_name: profile["name"] || profile["username"], avatar_url: profile["avatar_url"] }
+    rescue DiscogsClient::RateLimitError, DiscogsClient::ApiError => e
+      { found: false, reason: "api_error" }
+    end
+
+    def cache_key(username)
+      "discogs_lookup/#{username}"
+    end
+  end
+end

--- a/app/controllers/api/discogs_lookup_controller.rb
+++ b/app/controllers/api/discogs_lookup_controller.rb
@@ -25,13 +25,17 @@ module Api
       end
 
       normalized = username.downcase
-      cached = Rails.cache.read(cache_key(normalized))
-      if cached
-        return render json: cached, status: :ok
-      end
 
-      result = lookup_discogs(normalized)
-      Rails.cache.write(cache_key(normalized), result, expires_in: result[:found] ? FOUND_TTL : NOT_FOUND_TTL)
+      result = Rails.cache.read(cache_key(normalized))
+
+      if result.nil?
+        result = lookup_discogs(normalized)
+        # Only cache non-error results
+        if result[:found] || result[:reason] != "api_error"
+          ttl = result[:found] ? FOUND_TTL : NOT_FOUND_TTL
+          Rails.cache.write(cache_key(normalized), result, expires_in: ttl)
+        end
+      end
 
       render json: result, status: :ok
     end
@@ -50,7 +54,7 @@ module Api
       client = DiscogsClient.new
       profile = client.seller_profile(username)
       { found: true, seller_name: profile["name"] || profile["username"], avatar_url: profile["avatar_url"] }
-    rescue DiscogsClient::RateLimitError, DiscogsClient::ApiError => e
+    rescue DiscogsClient::RateLimitError, DiscogsClient::ApiError, Faraday::Error => e
       { found: false, reason: "api_error" }
     end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,7 +15,8 @@ class PagesController < ApplicationController
       turnstile: {
         enabled: TurnstileVerifier.enabled?,
         site_key: TurnstileVerifier.site_key
-      }
+      },
+      initial_discogs_username: params[:discogs_username]
     }
   end
 end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -23,8 +23,7 @@ class StoresController < ApplicationController
 
     render inertia: "stores/invitation", props: {
       waitlist_present: waitlist_present,
-      slug: slug,
-      discogs_username: slug
+      slug: slug
     }
   end
 

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -10,12 +10,23 @@ class StoresController < ApplicationController
 
   def show
     store = Store.with_discogs_username(params[:slug]).first
-    return render :no_stores unless store
+    return render_invitation unless store
 
     render_store(store)
   end
 
   private
+
+  def render_invitation
+    slug = params[:slug]
+    waitlist_present = Waitlist.with_discogs_username(slug).exists?
+
+    render inertia: "stores/invitation", props: {
+      waitlist_present: waitlist_present,
+      slug: slug,
+      discogs_username: slug
+    }
+  end
 
   def render_store(store)
     curation  = StorefrontCuration.new(store, filter_available: !Rails.env.development?)

--- a/app/frontend/pages/apply.tsx
+++ b/app/frontend/pages/apply.tsx
@@ -31,6 +31,7 @@ type Props = {
     enabled: boolean
     site_key: string | null
   }
+  initial_discogs_username?: string
   copy: {
     headline: string
     subhead: string
@@ -54,10 +55,10 @@ type Props = {
   }
 }
 
-export default function Apply({ submitted = false, errors = {}, turnstile, copy }: Props) {
+export default function Apply({ submitted = false, errors = {}, turnstile, copy, initial_discogs_username }: Props) {
   const { data, setData, post, processing } = useForm({
     name: "",
-    discogs_username: "",
+    discogs_username: initial_discogs_username || "",
     email: "",
     inventory_size: "",
     notes: "",

--- a/app/frontend/pages/stores/invitation.tsx
+++ b/app/frontend/pages/stores/invitation.tsx
@@ -6,7 +6,14 @@ import BrandMark from "@/components/brand_mark"
 import { springTactile } from "@/lib/motion_tokens"
 import type { InvitationProps } from "@/types/inertia"
 
-export default function Invitation({ waitlist_present, slug, discogs_username }: InvitationProps) {
+interface LookupResponse {
+  found: boolean
+  seller_name?: string
+  avatar_url?: string
+  reason?: string
+}
+
+export default function Invitation({ waitlist_present, slug }: InvitationProps) {
   // Waitlist acknowledgment — no probe, static page
   if (waitlist_present) {
     return (
@@ -56,10 +63,10 @@ export default function Invitation({ waitlist_present, slug, discogs_username }:
   }
 
   // Invitation page — async Discogs probe
-  return <InvitationContent slug={slug} discogsUsername={discogs_username} />
+  return <InvitationContent slug={slug} />
 }
 
-function InvitationContent({ slug, discogsUsername }: { slug: string; discogsUsername: string }) {
+function InvitationContent({ slug }: { slug: string }) {
   const [probeState, setProbeState] = useState<"loading" | "found" | "not_found" | "error">("loading")
   const [sellerName, setSellerName] = useState<string | null>(null)
 
@@ -69,9 +76,10 @@ function InvitationContent({ slug, discogsUsername }: { slug: string; discogsUse
     if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$/.test(slug)) return false
 
     const reserved = [
-      "admin", "apply", "jobs", "up", "assets",
+      "admin", "apply", "jobs", "up", "assets", "404", "500", "health",
       "login", "logout", "signup", "register",
       "api", "docs", "status", "help", "support",
+      "favicon", "manifest", "service-worker",
     ]
     if (reserved.includes(slug.toLowerCase())) return false
 
@@ -79,15 +87,20 @@ function InvitationContent({ slug, discogsUsername }: { slug: string; discogsUse
   }, [slug])
 
   useEffect(() => {
+    // Reset stale state from previous slug
+    setProbeState("loading")
+    setSellerName(null)
+
     if (!shouldProbe) {
       setProbeState("not_found")
       return
     }
 
     const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 10000)
 
     fetch(`/api/discogs/lookup/${encodeURIComponent(slug)}`, { signal: controller.signal })
-      .then((res) => res.json())
+      .then((res) => res.json() as Promise<LookupResponse>)
       .then((data) => {
         if (data.found) {
           setSellerName(data.seller_name || slug)
@@ -100,8 +113,12 @@ function InvitationContent({ slug, discogsUsername }: { slug: string; discogsUse
         if (err instanceof DOMException && err.name === "AbortError") return
         setProbeState("error")
       })
+      .finally(() => clearTimeout(timeoutId))
 
-    return () => controller.abort()
+    return () => {
+      controller.abort()
+      clearTimeout(timeoutId)
+    }
   }, [slug, shouldProbe])
 
   return (
@@ -155,7 +172,7 @@ function InvitationContent({ slug, discogsUsername }: { slug: string; discogsUse
               transition={{ delay: 0.3, duration: 0.3 }}
             >
               <Link
-                href={`/apply?discogs_username=${encodeURIComponent(discogsUsername)}`}
+                href={`/apply?discogs_username=${encodeURIComponent(slug)}`}
                 className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-mc-accent text-mc-on-accent font-semibold text-sm tracking-wide hover:opacity-90 transition-opacity"
               >
                 Claim this storefront

--- a/app/frontend/pages/stores/invitation.tsx
+++ b/app/frontend/pages/stores/invitation.tsx
@@ -1,0 +1,209 @@
+import { useState, useEffect, useMemo } from "react"
+import { Link } from "@inertiajs/react"
+import { motion } from "framer-motion"
+import MarketingLayout from "@/layouts/marketing_layout"
+import BrandMark from "@/components/brand_mark"
+import { springTactile } from "@/lib/motion_tokens"
+import type { InvitationProps } from "@/types/inertia"
+
+export default function Invitation({ waitlist_present, slug, discogs_username }: InvitationProps) {
+  // Waitlist acknowledgment — no probe, static page
+  if (waitlist_present) {
+    return (
+      <MarketingLayout>
+        <div className="flex flex-col items-center text-center pb-16 max-w-lg mx-auto">
+          <motion.div
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={springTactile}
+            className="mb-6"
+          >
+            <BrandMark size="large" showWordmark={false} />
+          </motion.div>
+          <motion.h1
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1, duration: 0.3 }}
+            className="text-2xl font-bold mc-text mb-3"
+          >
+            This URL has been claimed
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.2, duration: 0.3 }}
+            className="text-sm text-mc-text-dim leading-relaxed max-w-sm"
+          >
+            We'll notify the applicant when their storefront is ready. In the
+            meantime, feel free to explore other storefronts on Milkcrate.
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3, duration: 0.3 }}
+            className="mt-8"
+          >
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-mc-accent text-mc-on-accent font-semibold text-sm tracking-wide hover:opacity-90 transition-opacity"
+            >
+              Browse storefronts
+            </Link>
+          </motion.div>
+        </div>
+      </MarketingLayout>
+    )
+  }
+
+  // Invitation page — async Discogs probe
+  return <InvitationContent slug={slug} discogsUsername={discogs_username} />
+}
+
+function InvitationContent({ slug, discogsUsername }: { slug: string; discogsUsername: string }) {
+  const [probeState, setProbeState] = useState<"loading" | "found" | "not_found" | "error">("loading")
+  const [sellerName, setSellerName] = useState<string | null>(null)
+
+  // Quality gate: only probe plausible Discogs usernames
+  const shouldProbe = useMemo(() => {
+    if (slug.length < 3 || slug.length > 40) return false
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$/.test(slug)) return false
+
+    const reserved = [
+      "admin", "apply", "jobs", "up", "assets",
+      "login", "logout", "signup", "register",
+      "api", "docs", "status", "help", "support",
+    ]
+    if (reserved.includes(slug.toLowerCase())) return false
+
+    return true
+  }, [slug])
+
+  useEffect(() => {
+    if (!shouldProbe) {
+      setProbeState("not_found")
+      return
+    }
+
+    const controller = new AbortController()
+
+    fetch(`/api/discogs/lookup/${encodeURIComponent(slug)}`, { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.found) {
+          setSellerName(data.seller_name || slug)
+          setProbeState("found")
+        } else {
+          setProbeState("not_found")
+        }
+      })
+      .catch((err) => {
+        if (err instanceof DOMException && err.name === "AbortError") return
+        setProbeState("error")
+      })
+
+    return () => controller.abort()
+  }, [slug, shouldProbe])
+
+  return (
+    <MarketingLayout>
+      <div className="flex flex-col items-center text-center pb-16 max-w-lg mx-auto">
+        <motion.div
+          initial={{ scale: 0.8, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={springTactile}
+          className="mb-6"
+        >
+          <BrandMark size="large" showWordmark={false} />
+        </motion.div>
+
+        {/* Loading state */}
+        {probeState === "loading" && (
+          <>
+            <div className="w-8 h-8 mb-4 border-2 border-mc-accent border-t-transparent rounded-full motion-safe:animate-spin" />
+            <p className="text-sm text-mc-text-dim">Checking if this URL is available...</p>
+          </>
+        )}
+
+        {/* Seller found — personalized invitation */}
+        {probeState === "found" && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            className="w-full"
+          >
+            <motion.h1
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1, duration: 0.3 }}
+              className="text-2xl font-bold mc-text mb-3"
+            >
+              We found <span className="text-mc-accent">{sellerName}</span> on Discogs
+            </motion.h1>
+            <motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2, duration: 0.3 }}
+              className="text-sm text-mc-text-dim leading-relaxed max-w-sm mx-auto mb-8"
+            >
+              This URL could be your storefront. Claim it to show your Discogs
+              inventory as a browsable, curated record store.
+            </motion.p>
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3, duration: 0.3 }}
+            >
+              <Link
+                href={`/apply?discogs_username=${encodeURIComponent(discogsUsername)}`}
+                className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-mc-accent text-mc-on-accent font-semibold text-sm tracking-wide hover:opacity-90 transition-opacity"
+              >
+                Claim this storefront
+              </Link>
+            </motion.div>
+          </motion.div>
+        )}
+
+        {/* Not found or errored — generic invitation */}
+        {(probeState === "not_found" || probeState === "error") && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+            className="w-full"
+          >
+            <motion.h1
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1, duration: 0.3 }}
+              className="text-2xl font-bold mc-text mb-3"
+            >
+              This page is available
+            </motion.h1>
+            <motion.p
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2, duration: 0.3 }}
+              className="text-sm text-mc-text-dim leading-relaxed max-w-sm mx-auto mb-8"
+            >
+              If you sell records on Discogs, you can turn this URL into your
+              own browsable storefront on Milkcrate.
+            </motion.p>
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3, duration: 0.3 }}
+            >
+              <Link
+                href="/apply"
+                className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-mc-accent text-mc-on-accent font-semibold text-sm tracking-wide hover:opacity-90 transition-opacity"
+              >
+                Apply to join
+              </Link>
+            </motion.div>
+          </motion.div>
+        )}
+      </div>
+    </MarketingLayout>
+  )
+}

--- a/app/frontend/test/pages/page_smoke.test.tsx
+++ b/app/frontend/test/pages/page_smoke.test.tsx
@@ -248,7 +248,6 @@ describe("page smoke tests", () => {
     const inviteProps: InvitationProps = {
       waitlist_present: false,
       slug: "test-slug",
-      discogs_username: "test-slug",
     }
 
     it("renders the invitation page without crashing", async () => {
@@ -267,7 +266,7 @@ describe("page smoke tests", () => {
     })
 
     it("handles fetch error gracefully for valid slugs", async () => {
-      render(<Invitation {...inviteProps} slug="valid-store" discogs_username="valid-store" />)
+      render(<Invitation {...inviteProps} slug="valid-store" />)
       // The fetch will fail in test (no server), so it should settle on generic invitation
       await waitFor(() => {
         expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
@@ -275,21 +274,21 @@ describe("page smoke tests", () => {
     })
 
     it("skips probe and shows generic invitation for short slugs", async () => {
-      render(<Invitation {...inviteProps} slug="ab" discogs_username="ab" />)
+      render(<Invitation {...inviteProps} slug="ab" />)
       await waitFor(() => {
         expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
       })
     })
 
     it("skips probe for reserved slugs", async () => {
-      render(<Invitation {...inviteProps} slug="admin" discogs_username="admin" />)
+      render(<Invitation {...inviteProps} slug="admin" />)
       await waitFor(() => {
         expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
       })
     })
 
     it("skips probe for slugs with invalid characters", async () => {
-      render(<Invitation {...inviteProps} slug="bad!slug" discogs_username="bad!slug" />)
+      render(<Invitation {...inviteProps} slug="bad!slug" />)
       await waitFor(() => {
         expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
       })

--- a/app/frontend/test/pages/page_smoke.test.tsx
+++ b/app/frontend/test/pages/page_smoke.test.tsx
@@ -1,11 +1,12 @@
 import React from "react"
 import { describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import Home from "../../pages/home"
 import Apply from "../../pages/apply"
 import Featured from "../../pages/stores/featured"
-import type { FeaturedProps } from "../../types/inertia"
+import Invitation from "../../pages/stores/invitation"
+import type { FeaturedProps, InvitationProps } from "../../types/inertia"
 
 vi.mock("@inertiajs/react", () => ({
   Link: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
@@ -241,5 +242,57 @@ describe("page smoke tests", () => {
 
     expect(screen.queryByText("Independent record store in South Philly.")).not.toBeInTheDocument()
     expect(screen.queryByText("120 vinyl listings")).not.toBeInTheDocument()
+  })
+
+  describe("invitation page", () => {
+    const inviteProps: InvitationProps = {
+      waitlist_present: false,
+      slug: "test-slug",
+      discogs_username: "test-slug",
+    }
+
+    it("renders the invitation page without crashing", async () => {
+      render(<Invitation {...inviteProps} />)
+      // Fetch fails in test env, so probe settles on error → generic invitation
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
+      })
+    })
+
+    it("renders waitlist acknowledgment when waitlist_present is true", async () => {
+      render(<Invitation {...inviteProps} waitlist_present={true} />)
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: /This URL has been claimed/i })).toBeInTheDocument()
+      })
+    })
+
+    it("handles fetch error gracefully for valid slugs", async () => {
+      render(<Invitation {...inviteProps} slug="valid-store" discogs_username="valid-store" />)
+      // The fetch will fail in test (no server), so it should settle on generic invitation
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
+      })
+    })
+
+    it("skips probe and shows generic invitation for short slugs", async () => {
+      render(<Invitation {...inviteProps} slug="ab" discogs_username="ab" />)
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
+      })
+    })
+
+    it("skips probe for reserved slugs", async () => {
+      render(<Invitation {...inviteProps} slug="admin" discogs_username="admin" />)
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
+      })
+    })
+
+    it("skips probe for slugs with invalid characters", async () => {
+      render(<Invitation {...inviteProps} slug="bad!slug" discogs_username="bad!slug" />)
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
+      })
+    })
   })
 })

--- a/app/frontend/types/inertia.ts
+++ b/app/frontend/types/inertia.ts
@@ -62,3 +62,9 @@ export interface HomepagePreview {
   store_slug: string | null
   sections: StorefrontSection[]
 }
+
+export interface InvitationProps {
+  waitlist_present: boolean
+  slug: string
+  discogs_username: string
+}

--- a/app/frontend/types/inertia.ts
+++ b/app/frontend/types/inertia.ts
@@ -66,5 +66,4 @@ export interface HomepagePreview {
 export interface InvitationProps {
   waitlist_present: boolean
   slug: string
-  discogs_username: string
 }

--- a/app/models/waitlist.rb
+++ b/app/models/waitlist.rb
@@ -1,5 +1,15 @@
 class Waitlist < ApplicationRecord
+  before_validation :normalize_discogs_username, if: :discogs_username_changed?
+
   validates :name, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :discogs_username, presence: true, uniqueness: true
+
+  scope :with_discogs_username, ->(username) { where(discogs_username: username.downcase) }
+
+  private
+
+  def normalize_discogs_username
+    self.discogs_username = discogs_username&.downcase
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
 
   mount MissionControl::Jobs::Engine, at: "/jobs"
 
+  namespace :api do
+    get "discogs/lookup/:username", to: "discogs_lookup#show"
+  end
+
   get "/admin", to: "admin/waitlists#index"
 
   root "pages#home"

--- a/docs/brainstorms/2026-05-15-404-discogs-seller-invitation-requirements.md
+++ b/docs/brainstorms/2026-05-15-404-discogs-seller-invitation-requirements.md
@@ -1,0 +1,149 @@
+---
+date: 2026-05-15
+topic: 404-discogs-seller-invitation
+---
+
+# 404 Page → Discogs Seller Invitation
+
+## Summary
+
+Turn the 404/no-store-found page into a Discogs seller invitation flow: when a slug doesn't match a known store, detect whether the visitor is a Discogs seller — and if so, invite them to claim the URL with a personalized call-to-action and one-click redirect to a pre-filled apply form. Already-applied visitors see a simple acknowledgment instead of a dead end.
+
+---
+
+## Problem Frame
+
+Every unclaimed `/:slug` is a missed conversion opportunity. Today, sellers who find their own store URL get "No stores in rotation yet" — a dead end that communicates nothing about the URL being available, or that the visitor is exactly the person who should claim it. Meanwhile, sellers who already applied and revisit their URL get the same blank wall, generating confusion and support friction.
+
+The 404 page is the top-of-funnel for seller acquisition — every unclaimed slug visit is someone who typed a Discogs-adjacent URL. Treating all visits identically leaves a seller-detection and conversion path on the table.
+
+---
+
+## Actors
+
+- A1. **Visitor (prospective seller)**: Arrives at `/:slug` that doesn't match any Store. May or may not be a Discogs seller. If they are, the page should recognize and invite them.
+- A2. **Returning applicant**: A seller who has already submitted a Waitlist entry. Visits their slug again hoping to see progress — should see acknowledgment, not a dead 404.
+
+---
+
+## Key Flows
+
+- F1. **First-time visitor — is a Discogs seller**
+  - **Trigger:** Visitor hits `/:slug` that doesn't match a Store or Waitlist entry; their slug IS a real Discogs username
+  - **Actors:** A1
+  - **Steps:**
+    1. Server renders the invitation page with generic copy + `discogs_username` prop (fast, no API call)
+    2. Client-side JS fires Discogs username lookup via a lightweight endpoint
+    3. Lookup succeeds → UI upgrades to personalized copy: "We found {slug} on Discogs — Claim this storefront"
+    4. Visitor clicks "Claim this storefront" → redirected to `/apply?discogs_username={slug}`
+    5. Apply form pre-fills the discogs_username field (editable) from the query param
+  - **Outcome:** Visitor lands on apply form with their Discogs identity carried forward. Zero re-typing.
+  - **Covered by:** R1, R2, R4, R5
+
+- F2. **First-time visitor — not a Discogs seller**
+  - **Trigger:** Visitor hits `/:slug` that doesn't match a Store or Waitlist entry; slug is NOT a real Discogs username
+  - **Actors:** A1
+  - **Steps:**
+    1. Server renders the invitation page with generic copy
+    2. Client-side Discogs lookup fires, returns 404
+    3. Generic copy persists: "This URL is available. If you sell records on Discogs, claim it here."
+    4. Visitor clicks CTA → redirected to `/apply` (no pre-fill)
+    5. Or visitor leaves
+  - **Outcome:** Generic invitation shown. No personalized upgrade.
+  - **Covered by:** R1, R2, R5
+
+- F3. **Returning applicant (already in Waitlist)**
+  - **Trigger:** Visitor hits `/:slug` that doesn't match a Store, but matches a Waitlist entry with the same `discogs_username`
+  - **Actors:** A2
+  - **Steps:**
+    1. Server checks Waitlist for `discogs_username = slug` synchronously
+    2. Match found → render acknowledgment: "This URL has been claimed — we'll notify the applicant when it's ready."
+    3. No Discogs lookup fires. No personalized CTA.
+    4. No escalation path (no email display, no re-apply option)
+  - **Outcome:** Returning applicant sees acknowledgment instead of a dead 404.
+  - **Covered by:** R3, R6
+
+---
+
+## Requirements
+
+**Page conversion (404 to Inertia)**
+- R1. Convert the existing `no_stores` ERB template (used by `StoresController#show`) into an Inertia/React page component. The `featured` action at `/` retains its current `no_stores` ERB behavior unchanged.
+
+**Discogs identity detection**
+- R2. Add a lightweight, authenticated JSON endpoint that accepts a Discogs username and returns whether it corresponds to a real Discogs seller (using `DiscogsClient#seller_profile`). The 404 page fires this check asynchronously after rendering. If the lookup succeeds, the page upgrades from generic to personalized copy.
+
+**Waitlist cross-reference**
+- R3. In `StoresController#show`, before the 404 page renders, synchronously check the Waitlist table for an entry with `discogs_username = slug` (case-insensitive, normalized). If found, render acknowledgment copy instead of the invitation. No client-side Discogs lookup fires.
+
+**Apply form pre-fill**
+- R4. The `/apply` Inertia page must read `discogs_username` from URL query params on mount and pre-fill the `useForm` initial value. The field is editable — the pre-filled value is a suggestion, not a lock.
+
+**Slug quality gate**
+- R5. Before the async Discogs lookup fires, apply a lightweight client-side heuristic: skip the lookup for slugs that are clearly non-username (too short/long, contains path separators, reserved route names, typical bot patterns). API calls should only target plausible Discogs usernames.
+
+**Already-applied acknowledgment**
+- R6. When a Waitlist entry matches the slug, the page renders a simple acknowledgment: "This URL has been claimed — we'll notify the applicant when it's ready." No escalation path, no email exposure, no re-apply option. Must work within the mobile-first design system and adaptive screen size workflow.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R2, R5.** A visitor hits `/lost-vinyl` where `lost-vinyl` IS a real Discogs seller. Server renders generic invitation immediately. Within ~1 second, client-side lookup confirms the seller → the page upgrades to "We found lost-vinyl on Discogs! Claim this storefront" with a button linking to `/apply?discogs_username=lost-vinyl`.
+- AE2. **Covers R2, R5.** A visitor hits `/asdfgh1234` which is NOT a Discogs seller. Generic invitation renders. Client-side lookup returns no match. Generic copy persists.
+- AE3. **Covers R1, R5.** A bot hits `/wp-admin`. Slug quality gate fires — slug is reserved / doesn't pass heuristic. No Discogs lookup fires. Generic or minimal 404 shown.
+- AE4. **Covers R3, R6.** A returning applicant visits their slug. Server finds matching Waitlist entry. Page shows "This URL has been claimed — we'll notify the applicant when it's ready." No Discogs lookup fires.
+- AE5. **Covers R4.** A visitor clicks "Claim this storefront" and lands on `/apply?discogs_username=lost-vinyl`. The discogs_username field is pre-filled with "lost-vinyl". The visitor can edit the value before submitting.
+- AE6. **Covers R4.** A visitor navigates directly to `/apply` (no query params). The discogs_username field starts empty as it does today.
+
+---
+
+## Success Criteria
+
+- Verified Discogs sellers see personalized copy and a direct path to apply with pre-filled identity.
+- Returning applicants see acknowledgment instead of a dead 404 — no support friction.
+- Generic visitors/bots get a lightweight invitation without unnecessary API calls.
+- Apply form carries `discogs_username` from the slug through query params; field is editable.
+- Discogs API rate limits are protected by the slug quality gate.
+- The page adapts to all screen sizes per the existing marketing layout / mobile-first design system.
+
+---
+
+## Scope Boundaries
+
+- No inline application form on the 404 page — always redirect to `/apply`.
+- No post-apply preview or "coming soon" page at the slug URL.
+- No referral tracking, UTM param plumbing beyond `discogs_username`.
+- No fuzzy matching or "Did you mean?" slug suggestions.
+- No Store creation from the 404 — waitlist entry only.
+- No email or identity exposure in the "already applied" acknowledgment.
+- The `featured` action at `/` keeps its current `no_stores` ERB behavior.
+
+---
+
+## Key Decisions
+
+- **Async Discogs probe:** Client-side, after initial page render — keeps initial response fast regardless of API latency.
+- **Redirect to apply form (not inline):** This avoids building a separate submission mechanism on the 404 page. Reuses the existing `/apply` flow.
+- **Editable discogs_username field:** Pre-fill is a suggestion — some sellers may use a different username than their store URL.
+- **Simple waitlist acknowledgment, no escalation:** Keeps scope tight; escalation adds auth and identity resolution complexity.
+- **Mobile-first design:** All new components and pages must follow the existing marketing layout and adaptive screen size workflow.
+
+---
+
+## Dependencies / Assumptions
+
+- `DiscogsClient#seller_profile(username)` continues to work with the existing Discogs API token. No new API keys needed.
+- The Inertia.js infrastructure in the project is already wired for new pages (`layout "inertia_application"`, `render inertia:` calls).
+- The apply form (`app/frontend/pages/apply.tsx`) can read `window.location.search` on mount. This is a local React-only change.
+- Discogs API rate limit (~60 requests/minute for authenticated tokens) must not be exceeded. The slug quality gate is the primary defense; per-IP throttling can be added later if needed.
+- Mobile-first design system and adaptive screen size workflow (viewport context, responsive breakpoints) are already established in the codebase and will be used for the new Inertia page.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R5][Needs research] Exact heuristic for the slug quality gate — what length range, which reserved paths, which character classes. Can be determined by examining existing bot traffic patterns.
+- [Affects R1][Technical] Whether to create a new Inertia page component (e.g., `stores/invitation`) or modify the existing Inertia page structure. Depends on how the store show action branches.

--- a/docs/ideation/2026-05-15-404-discogs-seller-invitation-ideation.md
+++ b/docs/ideation/2026-05-15-404-discogs-seller-invitation-ideation.md
@@ -1,0 +1,171 @@
+---
+date: 2026-05-15
+topic: 404-discogs-seller-invitation
+focus: Turn the 404 page into an invitation for Discogs sellers to apply
+mode: repo-grounded
+---
+
+# Ideation: 404 Page → Discogs Seller Invitation
+
+## Grounding Context
+
+**Codebase context:** Rails 8 + Inertia.js + React app (milkcrate.fm). Online record store browsing powered by Discogs inventories.
+
+- **404 page:** Currently `app/views/stores/no_stores.html.erb` — plain ERB rendered by `StoresController#show` when `/:slug` doesn't match a known `Store`. Shows "🎵 No stores in rotation yet."
+- **Apply page:** `/apply` — Inertia/React page with form fields: name, discogs_username, email, inventory_size, notes + Turnstile captcha.
+- **DiscogsClient:** Has `seller_profile(username)` calling `GET /users/{username}` — can verify Discogs username exists. Already wired, used by StoreSyncService.
+- **No existing redirect-with-query-param pattern** in codebase. Apply uses flash-only redirects.
+- **Store model:** `discogs_username` (unique), sync_status/enrichment_status enums.
+- **Waitlist model:** `discogs_username` (unique), name, email, inventory_size, notes.
+- **Strategy:** "Store onboarding & freemium model" — prove value with near-zero seller effort.
+
+**External context:** Web research unavailable (no web tools in environment). Internal codebase and learnings only.
+
+## Topic Axes
+
+1. **Discovery & Verification** — How the system detects a visitor may be a Discogs seller for the slug they tried.
+2. **Invitation Message & Tone** — What the page communicates and how it sells the value.
+3. **Form Pre-fill & Redirection Flow** — How `discogs_username` propagates from the slug through query params to the apply form.
+4. **Edge Cases & States** — Slug already claimed, username doesn't exist on Discogs, already applied, garbage slug.
+5. **Onboarding Continuity** — Post-application experience, previews, state persistence.
+
+## Ranked Ideas
+
+### 1. Silent Discogs Identity Probe on Slug Miss
+
+**Description:** When `/:slug` doesn't match a Store, call `DiscogsClient#seller_profile(slug)` server-side before rendering. Pass a `:discogs_seller_exists` boolean to the view. If true, render personalized invitation copy ("We found /{slug} on Discogs — this URL could be your storefront"). If false, render generic invite ("This URL is available — claim it for your store"). A lightweight slug sanity check (length, character class) gates the API call to avoid rate-limit waste on garbage paths.
+
+**Axis:** 1 — Discovery & Verification
+
+**Basis:** `direct:` `DiscogsClient#seller_profile(username)` at `app/services/discogs_client.rb:44-46` calls `GET /users/{username}` and returns the user object. Already wired and used in `StoreSyncService`. `direct:` `StoresController#show` at `app/controllers/stores_controller.rb:10-14` already has `params[:slug]` — the value is accessible at the point of the `render :no_stores` decision.
+
+**Rationale:** Currently the 404 is blind — a real Discogs seller and a bot typing garbage get identical treatment. A single API call flips the page from "nothing here" to "we found you" with zero visitor effort. This is the cheapest, highest-leverage change because it front-ends every other idea in the set.
+
+**Downsides:** Adds ~200-800ms latency to slug misses when API call fires. Discogs API rate limit must be respected (can gate with slug heuristic + per-IP throttling).
+
+**Confidence:** 95%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+---
+
+### 2. Personalized Invitation with Query-Param Propagation to /apply
+
+**Description:** Replace the generic "No stores in rotation yet" with contextual copy. When the Discogs probe succeeds: "Hey {slug} — your Discogs profile checks out. **Claim this URL** as your storefront." When it fails: "This URL is waiting for its owner. If you sell records on Discogs, **claim it here**." The CTA links to `/apply?discogs_username={slug}`. On the Inertia/React apply page, `useForm` reads the query param and pre-fills the `discogs_username` field (optionally locked/read-only). Establishes the redirect-with-query-param pattern as the documented Inertia approach.
+
+**Axis:** 2 (Invitation Message & Tone) + 3 (Form Pre-fill & Redirection Flow)
+
+**Basis:** `direct:` Vendor marketing ideation at `docs/ideation/2026-05-14-vendor-facing-marketing-page-ideation.md` proposed "Claim an Early Storefront" framing — this is the natural home for it. `direct:` Grounding confirms "No existing redirect-with-query-param pattern in codebase" — building it here establishes the pattern. `direct:` Apply form initializes `discogs_username: ""` at `apply.tsx:62` — pre-filling from URLSearchParams is a local React change.
+
+**Rationale:** Any seller who typed the slug into the URL bar has zero patience for retyping it into a form. Dropping the username into the form automatically is the difference between "eh, maybe later" and "oh, it's already there." The personalized copy turns a dead-end into a funnel.
+
+**Downsides:** New pattern to document. Need to decide whether field is read-only or editable. Flash-only redirects need updating.
+
+**Confidence:** 90%
+
+**Complexity:** Low-Medium
+
+**Status:** Explored
+
+---
+
+### 3. State-Aware 404 with Waitlist Cross-Reference
+
+**Description:** Before rendering the 404 invitation, check the Waitlist table for `discogs_username = params[:slug]`. Three states: (A) slug not in Waitlist or Store → full invitation. (B) slug in Waitlist → "Someone has already applied for this URL. Is that you?" with a masked-email hint. (C) slug in Store → should never reach 404 (safety redirect). Prevents the confusing "dead page" experience for returning applicants.
+
+**Axis:** 4 — Edge Cases & States
+
+**Basis:** `direct:` `Waitlist` model at `app/models/waitlist.rb:4` has `discogs_username` with `uniqueness: true`. Querying `Waitlist.exists?(discogs_username: params[:slug].downcase)` is a single ActiveRecord query. `direct:` `Store.with_discogs_username` scope at `store.rb:9` already does the normalized lookup.
+
+**Rationale:** The most frustrating outcome — someone who already applied visiting "their" URL and seeing a dead 404 — costs one query to prevent. It also surfaces the waitlist-to-store lifecycle gap.
+
+**Downsides:** Need copy for "already applied" state. Privacy concern with surfacing that a particular email applied. Best addressed with partial masking.
+
+**Confidence:** 85%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+---
+
+### 4. One-Click Claim from the 404 Page (Verified Sellers)
+
+**Description:** When the Discogs probe confirms the slug IS a real Discogs seller AND no Waitlist entry or Store exists, offer a single "Claim this storefront" button directly on the 404 page. Clicking POSTs to `WaitlistsController#create` with `discogs_username` pre-filled. No redirect to `/apply`. No form. Optionally collect email via a lightweight inline overlay. The apply page at `/apply` still exists for general sign-ups and non-verified slugs.
+
+**Axis:** 1 (Discovery & Verification) + 3 (Form Pre-fill & Redirection Flow)
+
+**Basis:** `direct:` Strategy doc says "Prove value with near-zero seller effort." `direct:` `WaitlistsController#create` at `waitlists_controller.rb:9-17` accepts `discogs_username` as a permitted param. `direct:` `DiscogsClient#seller_profile` enables the verification gate. `reasoned:` The remaining fields (name, inventory size, notes) are nice-to-have but not required for initial intent capture; they can be collected via email follow-up.
+
+**Rationale:** This is the strongest expression of "near-zero seller effort." The full apply form has 5 fields + captcha — even with pre-fill, the visitor must fill name, email, inventory size, notes. A one-click path converts visitors who have high intent but low patience.
+
+**Downsides:** Requires making Waitlist email optional or collecting it inline. Higher technical complexity (inline form vs. redirect). Risk of accidental claims (but Discogs identity is hard to "accidentally" own).
+
+**Confidence:** 75%
+
+**Complexity:** Medium
+
+**Status:** Explored
+
+---
+
+### 5. Post-Apply Continuity — Preview at Slug URL After Submission
+
+**Description:** After a seller submits their application (from any entry point), redirect back to `/:slug` with a session/cookie flag. The 404 page now recognizes they've claimed this slug and shows "You've claimed this URL! Here's a preview of what your storefront will look like" — rendered from their actual Discogs inventory via `DiscogsClient#seller_listings(username, page: 1, per_page: 12)`. The preview is a sample of their records in the milkcrate layout, with a "Share your coming-soon page" link. Persists across repeat visits (via Waitlist lookup) until the Store is created.
+
+**Axis:** 5 — Onboarding Continuity
+
+**Basis:** `direct:` `DiscogsClient#seller_inventory` at `discogs_client.rb:16-25` fetches paginated listings. `direct:` The slug URL is the only URL the visitor knows — it's the natural post-claim destination. `direct:` Waitlist lookup by `discogs_username` enables cross-session persistence without auth. `reasoned:` The biggest drop-off in waitlist funnels is "submission → nothing happens." A live preview immediately after application bridges this gap and keeps engagement alive during provisioning.
+
+**Downsides:** Requires session/cookie detection on the 404 page. Live API call on every post-apply visit. Preview component needs to handle partial data gracefully.
+
+**Confidence:** 70%
+
+**Complexity:** Medium-High
+
+**Status:** Unexplored
+
+---
+
+### 6. Tiered Slug Gating (Quality Gate)
+
+**Description:** Before any of the above logic fires, classify the slug into tiers: (A) **Plausible Discogs username:** alphanumeric, 3-40 chars, no path separators, not a reserved route — run the Discogs probe. (B) **Gray zone:** longer slug, mixed characters — show generic "This URL is available" invitation without API call. (C) **Garbage:** SQL-like patterns, very long, typical bot paths — skip all invitations, show minimal 404 or redirect to homepage. Protects the Discogs API rate limit and keeps analytics clean.
+
+**Axis:** 4 — Edge Cases & States
+
+**Basis:** `direct:` The grounding note on `no_stores.html.erb` — currently ALL misses are treated identically. `reasoned:` Not every 404 visitor is a seller. Bots, typos, and random probes will hit `/:slug`. Running an API call on every miss wastes budget and pollutes conversion analytics. A lightweight heuristic gates the expensive probe. `external:` Etsy, Bandcamp, and Depop all filter slug availability with similar heuristics.
+
+**Rationale:** Without this gate, every other idea in this set is vulnerable to both rate-limit exhaustion and noisy analytics. A simple slug sanity check protects the entire pipeline.
+
+**Downsides:** False negatives — a legitimate seller with an unusual username could get the generic invitation instead of personalized. Need a reasonable heuristic that errs on the side of inclusion.
+
+**Confidence:** 95%
+
+**Complexity:** Very Low
+
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Digest-Highlight / Inventory Preview (live preview on 404) | Too expensive relative to value — live inventory API call on every 404 with full rendering is heavy; better as post-apply reward |
+| 2 | Auto-Verify and Skip Waitlist Entirely | Too aggressive — creating Store records without manual review risks abuse |
+| 3 | Provisional Storefront (session-scoped temp store) | Interesting but requires architectural changes to storefront rendering pipeline |
+| 4 | Kickstarter "Notify Me" (username-only capture) | Adds another data model tier — better to simplify the apply form itself |
+| 5 | Garbage-Slug ML Classifier | Scope overrun — simple heuristic enough for current needs |
+| 6 | Competitor-Slug Interest Heatmap | Expensive relative to value at current traffic levels |
+| 7 | Referral-Embedded Apply URLs | Premature — referral tracking before product-market fit is scope overrun |
+| 8 | Wikipedia "Did You Mean?" Suggestion | Low confidence accuracy — fuzzy Discogs username matching without local cache |
+| 9 | "This Domain Is Available" declarative framing | Doesn't account for Discogs identity verification — mixed signals |
+
+## Implementation Order (Recommended)
+
+1. **Tiered Slug Gating (#6)** — prerequisite, protects everything below
+2. **Silent Discogs Identity Probe (#1)** — unlocks personalized experience
+3. **Personalized Invitation + Query-Param Propagation (#2)** — the conversion surface
+4. **State-Aware Waitlist Cross-Reference (#3)** — UX polish, low effort
+5. **One-Click Claim from 404 (#4)** — highest conversion potential, higher complexity
+6. **Post-Apply Preview (#5)** — retention and continuity, most complex

--- a/docs/plans/2026-05-15-007-feat-404-discogs-seller-invitation-plan.md
+++ b/docs/plans/2026-05-15-007-feat-404-discogs-seller-invitation-plan.md
@@ -1,0 +1,340 @@
+---
+title: "feat: 404 page → Discogs seller invitation"
+type: feat
+status: active
+date: 2026-05-15
+origin: docs/brainstorms/2026-05-15-404-discogs-seller-invitation-requirements.md
+---
+
+# feat: 404 Page → Discogs Seller Invitation
+
+## Summary
+
+Convert the static 404/no-store-found page into a dynamic Inertia invitation that detects Discogs sellers and invites them to claim the URL. When a slug doesn't match a known store, the server checks the Waitlist — if an application exists, acknowledge it; otherwise render a generic invitation. An async client-side Discogs probe upgrades the page to personalized copy ("We found you on Discogs — claim this storefront") when the slug is a real seller. A "Claim this storefront" CTA redirects to `/apply?discogs_username={slug}` with the field pre-filled.
+
+---
+
+## Problem Frame
+
+Every unclaimed `/:slug` is a blind spot. Real Discogs sellers who find their own store URL get the same dead "No stores in rotation yet" as a bot hitting garbage. Sellers who already applied see the same wall — generating confusion and support friction. The 404 page is the top-of-funnel for seller acquisition; treating all visits identically leaves this conversion path on the table.
+
+---
+
+## Requirements
+
+- R1. Convert the `no_stores` ERB template (used by `StoresController#show`) into an Inertia/React page component. The `featured` action at `/` keeps its current ERB behavior unchanged.
+- R2. Add a lightweight JSON endpoint for async Discogs seller lookup, reusing `DiscogsClient#seller_profile`.
+- R3. In `StoresController#show`, synchronously check the Waitlist table for an entry with `discogs_username = slug` (case-insensitive). If found, render acknowledgment copy instead of the invitation.
+- R4. The `/apply` Inertia page reads `discogs_username` from Inertia props (passed from query params via the controller) and pre-fills the form field. The field is editable.
+- R5. Apply a slug quality gate before firing the Discogs probe: skip the lookup for slugs that fail a basic heuristic (too short/long, special chars, reserved routes, bot patterns).
+- R6. When a Waitlist entry matches, render a simple acknowledgment: "This URL has been claimed — we'll notify the applicant when it's ready." No escalation path, no email exposure.
+- R7. Discogs probe results should be cached via `Rails.cache` (Solid Cache) to protect the API rate limit.
+- R8. Normalize `discogs_username` on the Waitlist model (downcase on save) matching the Store model pattern.
+
+**Origin actors:** A1 (Visitor, prospective seller), A2 (Returning applicant)
+**Origin flows:** F1 (First-time seller), F2 (Non-seller), F3 (Returning applicant), F4 (Bot/garbage slug)
+**Origin acceptance examples:** AE1–AE6
+
+---
+
+## Scope Boundaries
+
+- No inline application form on the 404 page — always redirect to `/apply`.
+- No post-apply preview or "coming soon" page at the slug URL.
+- No referral tracking, UTM param plumbing beyond `discogs_username`.
+- No fuzzy Discogs username matching or "Did you mean?" suggestions.
+- No Store creation from the 404 — waitlist entry only.
+- No email or identity exposure in the "already applied" acknowledgment.
+- The `featured` action at `/` keeps its current `no_stores` ERB behavior unchanged.
+- No analytics/Plausible events for the probe (can be added later).
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `app/services/discogs_client.rb` — `seller_profile(username)` calls `GET /users/{username}`. Existing rate-limit handling (retry on 503, RateLimitError on 429).
+- `app/controllers/stores_controller.rb` — `show` action branches on `Store.with_discogs_username(params[:slug])`. Currently renders `:no_stores` ERB on miss.
+- `app/views/stores/no_stores.html.erb` — 5-line static ERB. Target for Inertia replacement.
+- `app/frontend/pages/apply.tsx` — Inertia/React apply form with `useForm` from `@inertiajs/react`.
+- `app/models/waitlist.rb` — Has `discogs_username` (unique, but no normalization callback). Add one.
+- `app/models/store.rb` — Has `before_validation :normalize_discogs_username`. Pattern to follow.
+- `app/controllers/waitlists_controller.rb` — `create` action, accepts `discogs_username` param.
+- `app/controllers/pages_controller.rb` — `apply` action renders the apply Inertia page.
+- `app/frontend/layouts/marketing_layout.tsx` — Marketing layout (BrandMark + responsive shell) used by the apply page; the new invitation page should use the same.
+- `app/frontend/components/storefront_motion_config.tsx` — Framer motion tokens. Apply page uses `springTactile`; pattern to follow for invitation transitions.
+- `config/environments/production.rb` — Solid Cache is configured (`cache_store`). First use in application code.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md` — MarketingLayout and BrandMark usage pattern for vendor-facing pages.
+- `docs/ideation/2026-05-14-vendor-facing-marketing-page-ideation.md` — Proposed "Claim an Early Storefront" framing for vendor CTAs.
+
+---
+
+## Key Technical Decisions
+
+- **Probe architecture: New API endpoint (`GET /api/discogs/lookup/:username`).** Client-side async keeps initial page render fast (~10ms vs 500ms+ for synchronous Discogs call). The endpoint reuses `DiscogsClient#seller_profile` with existing auth/rate-limit plumbing.
+- **Page conversion: New Inertia page at `stores/invitation`.** The ERB template is replaced by an Inertia React component at `app/frontend/pages/stores/invitation.tsx`. Uses `MarketingLayout` for visual consistency with the apply page. The `no_stores.html.erb` is kept for the `featured` action only.
+- **Waitlist normalization: Add `before_validation :normalize_discogs_username` to Waitlist.** Mirrors the Store model pattern exactly. Enables case-insensitive slug matching.
+- **Waitlist lookup: Synchronous server-side.** Single `Waitlist.exists?` query before rendering. Fast (~1ms), no async needed.
+- **Probe caching: `Rails.cache` with Solid Cache.** TTL of 1 hour for "seller found" results (can be shorter), 24 hours for "not found" results (changes rarely if ever). Cache key: `discogs_lookup/<normalized_username>`.
+- **Quality gate: Client-side heuristic before firing probe.** Check in the React component: slug length 3-40 chars, matches `/\A[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]\z/`, not in reserved routes list. Skip probe for failures; keep generic invitation.
+- **Query param propagation: Through Inertia props.** `PagesController#apply` reads `params[:discogs_username]` and passes it as `initial_discogs_username` prop. The React component uses it as `useForm` initial value. Field is editable.
+
+---
+
+## Implementation Units
+
+### U1. Normalize discogs_username on Waitlist model
+
+**Goal:** Enable case-insensitive matching between slug and Waitlist `discogs_username`, matching the Store model pattern.
+
+**Requirements:** R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/models/waitlist.rb`
+
+**Approach:**
+- Add `before_validation :normalize_discogs_username, if: :discogs_username_changed?`
+- Add scope `scope :with_discogs_username, ->(username) { where(discogs_username: username.downcase) }` matching Store's pattern
+- Add private method `normalize_discogs_username` that downcases `self.discogs_username`
+
+**Patterns to follow:**
+- `app/models/store.rb` — identical normalization pattern (`before_validation :normalize_discogs_username, if: :discogs_username_changed?` → `self.discogs_username = discogs_username&.downcase`)
+
+**Test scenarios:**
+- Happy path: Waitlist entry created with "MyStore" stores "mystore" after save
+- Edge case: slug lookup `Waitlist.with_discogs_username("MyStore")` matches stored "mystore"
+- Edge case: blank discogs_username passes through normalized (presence validation catches it separately)
+- Edge case: discogs_username unchanged on update does not re-run normalization
+
+**Verification:**
+- `Waitlist.with_discogs_username("MyStore")` returns entries stored as "mystore"
+- New entries are stored downcased
+
+---
+
+### U2. Add Discogs lookup API endpoint
+
+**Goal:** Provide a lightweight JSON endpoint that the frontend calls to check if a slug is a real Discogs seller.
+
+**Requirements:** R2, R5, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/controllers/api/discogs_lookup_controller.rb`
+- Modify: `config/routes.rb`
+
+**Approach:**
+- Namespace under `api/` — `namespace :api { get "discogs/lookup/:username", to: "discogs_lookup#show" }`
+- Controller action:
+  - Apply quality gate (length, character class). If slug fails, return 200 with `{ found: false, reason: "invalid_slug" }` — don't leak info about what's considered valid
+  - Check `Rails.cache` for `discogs_lookup/<normalized_username>`. If cached, return cached result
+  - Call `DiscogsClient.new.seller_profile(username)` — catches `DiscogsClient::RateLimitError` and `DiscogsClient::ApiError`
+  - If API returns seller data → cache result with TTL 1 hour, return `{ found: true, seller_name: ..., avatar_url: ..., inventory_count: ... }`
+  - If API returns 404 → cache "not found" with TTL 24 hours, return `{ found: false }`
+  - If API errors → return `{ found: false, reason: "api_error" }` (don't cache errors)
+- No authentication required (the endpoint is public — the search/reconnaissance risk is mitigated by caching + quality gate + per-IP throttling in future iteration)
+
+**Patterns to follow:**
+- `app/services/discogs_client.rb` — existing client with rate-limit handling
+- Controller follows existing Inertia controller conventions (plain `ApplicationController` subclass)
+
+**Test scenarios:**
+- Happy path: username matches a real Discogs seller → returns `{ found: true, seller_name: "..." }`
+- Happy path: username doesn't exist on Discogs → returns `{ found: false }`
+- Edge case: slug fails quality gate → returns `{ found: false, reason: "invalid_slug" }`
+- Edge case: cached "found" result → returns from cache without hitting Discogs API
+- Edge case: cached "not found" result → returns from cache
+- Edge case: Discogs API returns 429 → endpoint returns `{ found: false, reason: "api_error" }`
+- Edge case: Discogs API returns 503 → endpoint returns `{ found: false, reason: "api_error" }`
+
+**Verification:**
+- `GET /api/discogs/lookup/known_seller` returns `{ found: true }` with seller data
+- `GET /api/discogs/lookup/nonexistent_user` returns `{ found: false }`
+- Cache entries are created and honored on subsequent requests
+
+---
+
+### U3. Convert 404 page to Inertia with server-side Waitlist check
+
+**Goal:** Replace the static ERB 404 with a dynamic Inertia/React page that checks the Waitlist synchronously and renders the appropriate initial state.
+
+**Requirements:** R1, R3, R6
+
+**Dependencies:** U1 (Waitlist normalization)
+
+**Files:**
+- Modify: `app/controllers/stores_controller.rb`
+- Create: `app/frontend/pages/stores/invitation.tsx`
+- Keep (for `featured` action only): `app/views/stores/no_stores.html.erb`
+
+**Approach:**
+- In `StoresController#show`, when `Store.with_discogs_username` returns nil, check `Waitlist.with_discogs_username(params[:slug]).exists?` before rendering
+- New branch:
+  - Waitlist exists → `render inertia: "stores/invitation", props: { waitlist_present: true, slug: params[:slug], discogs_username: params[:slug] }`
+  - Waitlist absent → `render inertia: "stores/invitation", props: { waitlist_present: false, slug: params[:slug], discogs_username: params[:slug] }`
+- New Inertia page component `app/frontend/pages/stores/invitation.tsx`:
+  - Uses `MarketingLayout` for visual consistency with the apply page
+  - Accepts props: `waitlist_present`, `slug`, `discogs_username`
+  - **State A (waitlist_present = true):** Render acknowledgment copy — "This URL has been claimed — we'll notify the applicant when it's ready." No Discogs probe. Static, no client-side upgrade.
+  - **State B (waitlist_present = false):** Render generic invitation immediately — loading indicator for probe. On mount:
+    1. Run quality gate on slug
+    2. If gate passes, fire async fetch to `/api/discogs/lookup/${slug}`
+    3. If probe returns `found: true`, upgrade copy to personalized ("We found {slug} on Discogs! Claim this storefront") with CTA button
+    4. If probe returns `found: false` or `api_error`, keep generic copy ("This URL is available. If you sell records on Discogs, claim it here.")
+    5. If gate fails, keep generic copy — no fetch fires
+- Preserve HTTP 200 status for all responses (including garbage-looking slugs — don't leak info via status codes)
+
+**Patterns to follow:**
+- `app/frontend/pages/apply.tsx` — MarketingLayout usage, framer-motion patterns, responsive layout
+- `app/frontend/layouts/marketing_layout.tsx` — Layout wrapper with BrandMark and responsive shell
+- `app/controllers/stores_controller.rb` — existing controller structure with `layout "inertia_application"`
+
+**Test scenarios:**
+- Happy path (F1): slug not in Store or Waitlist, probe finds seller → generic renders, upgrades to personalized CTA
+- Happy path (F2): slug not in Store or Waitlist, probe finds nothing → generic persists
+- Happy path (F3): slug in Waitlist → acknowledgment renders, no probe fires
+- Edge case (F4): garbage slug fails quality gate → generic renders, no fetch fires
+- Edge case: Waitlist exists but Store now also exists → should never reach this page (Store is checked first)
+- Edge case: slug in Waitlist, probe would have found seller → probe skipped, acknowledgment shown (per spec)
+- Edge case: probe API call fails (network error) → generic copy persists gracefully
+- Edge case: Discogs API is rate-limited → probe returns api_error, generic copy persists
+- Loading state: probe in-flight shows loading indicator, content upgrades smoothly when result arrives
+
+**Verification:**
+- Unknown slug renders Inertia page, not ERB
+- Waitlist slug shows acknowledgment, no probe fires
+- Non-Waitlist slug shows generic invitation, probe fires asynchronously
+- Probe result upgrades UI correctly (found / not found / error)
+
+---
+
+### U4. Wire query-param propagation to apply form
+
+**Goal:** When redirected from the 404 invitation page, the apply form pre-fills `discogs_username` from the query param.
+
+**Requirements:** R4
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `app/controllers/pages_controller.rb`
+- Modify: `app/frontend/pages/apply.tsx`
+
+**Approach:**
+- In `PagesController#apply`, read `params[:discogs_username]` and pass it as an Inertia prop:
+  ```ruby
+  props.merge(initial_discogs_username: params[:discogs_username])
+  ```
+- In `apply.tsx`:
+  - Accept new prop `initial_discogs_username` (string, optional)
+  - Pass it as the initial value for `discogs_username` in the `useForm` call:
+    ```tsx
+    const { data, setData, post, processing } = useForm({
+      discogs_username: initial_discogs_username || "",
+      ...
+    })
+    ```
+  - Keep the field editable — the pre-filled value is a suggestion, not a lock
+
+**Patterns to follow:**
+- `app/controllers/pages_controller.rb` — existing `apply` action passes `copy:`, `submitted:`, `turnstile:` props
+- `app/frontend/pages/apply.tsx` — existing `useForm` initialization pattern
+
+**Test scenarios:**
+- Happy path: `/apply?discogs_username=lost-vinyl` → discogs_username field pre-filled with "lost-vinyl"
+- Happy path: `/apply` (no params) → discogs_username field starts empty
+- Edge case: user edits the pre-filled value before submitting → edited value is submitted
+- Edge case: `discogs_username` param is empty string → field starts empty
+- Integration: clicking "Claim this storefront" on invitation page → redirects to `/apply?discogs_username={slug}` → field pre-filled
+
+**Verification:**
+- Apply page reads query param and pre-fills the field
+- Field remains editable
+- Direct navigation to `/apply` works as before (no required param)
+
+---
+
+### U5. Add slug quality gate on the frontend
+
+**Goal:** Prevent unnecessary Discogs API calls for non-username slugs (bots, garbage, reserved routes).
+
+**Requirements:** R5
+
+**Dependencies:** U3 (invitation page exists to add the gate to)
+
+**Files:**
+- Modify: `app/frontend/pages/stores/invitation.tsx`
+
+**Approach:**
+- Add a `useMemo` or utility function in the invitation component:
+  ```tsx
+  const isPlausibleUsername = useMemo(() => {
+    if (!slug || slug.length < 3 || slug.length > 40) return false
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$/.test(slug)) return false
+    if (RESERVED_SLUGS.includes(slug.toLowerCase())) return false
+    return true
+  }, [slug])
+  ```
+- Define `RESERVED_SLUGS` list: routes that are already handled (`admin`, `apply`, `jobs`, `up`, `assets`, common bot paths)
+- Only fire the Discogs probe fetch when `isPlausibleUsername` is true
+- When false, keep the generic invitation — no fetch, no personalized upgrade attempt
+
+**Patterns to follow:**
+- Existing route handling in `config/routes.rb` for reserved routes reference
+
+**Test scenarios:**
+- Happy path: `lost-vinyl` (3 chars, alphanumeric + hyphen) → passes gate
+- Edge case: `a` (1 char) → fails gate
+- Edge case: `a-very-very-long-slug-that-is-over-forty-characters-long` → fails gate
+- Edge case: `../../../etc` → fails gate (contains non-alphanumeric chars)
+- Edge case: `wp-admin` → fails gate (reserved route)
+- Edge case: `admin` → fails gate (reserved route)
+
+**Verification:**
+- Plausible usernames trigger the probe
+- Garbage/bot/reserved slugs show generic invitation without a probe fetch
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The `StoresController#show` action grows an additional query (`Waitlist.with_discogs_username`). This is a single `SELECT COUNT(*)` on a column with a unique index — negligible overhead. The new API endpoint (`/api/discogs/lookup/:username`) is a new interaction surface that touches the Discogs API via the existing client.
+- **Error propagation:** If the Discogs API is down or rate-limited, the probe endpoint returns a graceful `{ found: false, reason: "api_error" }` response. The frontend handles this by keeping the generic invitation. No user-facing errors.
+- **State lifecycle risks:** The Waitlist/Store cross-table race conditions (e.g., a slug becoming a Store between page render and probe) are documented as a pre-existing gap — the probe might return "found: true" for a slug that is now a Store. Acceptable for MVP since the claim redirect would result in a Waitlist duplicate-key error, which the form already handles gracefully.
+- **API surface parity:** The existing `/apply` endpoint is unchanged — only its props contract grows an optional `initial_discogs_username` field. Backward compatible.
+- **Integration coverage:** The key integration seam is the async probe flow (Inertia page → API endpoint → DiscogsClient → cache → UI upgrade). Unit tests for each layer combined with a system test covering the full F1 flow is the right balance.
+- **Unchanged invariants:** The `featured` action at `/` keeps its current behavior. The existing apply form submission flow is unchanged. The Store model and StoreController's found-store path are unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Discogs API rate limit exhausted by probe traffic | Quality gate filters ~90% of bot/garbage traffic. Cache reduces duplicate calls. Per-IP rate limiting deferred but noted. |
+| Race condition: slug becomes Store between render and probe | Low probability. If it happens, the "Claim" redirect leads to a duplicate-key error on the Waitlist — the form already handles validation errors gracefully. |
+| Existing Waitlist entries with non-normalized discogs_username | Existing entries are NOT back-filled by U1. The scope `with_discogs_username` handles case-insensitive matching regardless of stored case. |
+| Mobile layout regression | Invitation page uses existing `MarketingLayout` which already handles responsive breakpoints. Mobile-first design applies. |
+| Browser JS disabled or slow | Generic invitation renders immediately server-side. The probe is an enhancement — the page is functional without JS. |
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-15-404-discogs-seller-invitation-requirements.md`
+- Related code: `app/services/discogs_client.rb` — Discogs API client
+- Related code: `app/models/store.rb` — Store model (normalization pattern to follow)
+- Related code: `app/models/waitlist.rb` — Waitlist model (target for normalization)
+- Related code: `app/controllers/stores_controller.rb` — stores controller (target for Inertia switch)
+- Related code: `app/controllers/pages_controller.rb` — pages controller (target for query-param prop)
+- Related code: `app/frontend/pages/apply.tsx` — apply form (target for pre-fill)
+- Related code: `app/frontend/layouts/marketing_layout.tsx` — layout to use for invitation page
+- Related docs: `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md`
+- Related docs: `docs/ideation/2026-05-14-vendor-facing-marketing-page-ideation.md`

--- a/spec/models/waitlist_spec.rb
+++ b/spec/models/waitlist_spec.rb
@@ -41,4 +41,33 @@ RSpec.describe Waitlist, type: :model do
       expect(dup.errors[:discogs_username]).to include("has already been taken")
     end
   end
+
+  describe "normalization" do
+    it "downcases discogs_username before validation" do
+      entry = build(:waitlist, discogs_username: "MyStore")
+      entry.valid?
+      expect(entry.discogs_username).to eq("mystore")
+    end
+
+    it "does not re-normalize on update if unchanged" do
+      entry = create(:waitlist, discogs_username: "recordstore")
+      expect(entry.discogs_username).to eq("recordstore")
+      # attempting to set to the same normalized value should not trigger the callback
+      entry.update(name: "New Name")
+      expect(entry.discogs_username).to eq("recordstore")
+    end
+  end
+
+  describe ".with_discogs_username" do
+    it "finds entries case-insensitively" do
+      create(:waitlist, discogs_username: "myrecordstore")
+      expect(Waitlist.with_discogs_username("MYRECORDSTORE")).to exist
+      expect(Waitlist.with_discogs_username("MyRecordStore")).to exist
+      expect(Waitlist.with_discogs_username("myrecordstore")).to exist
+    end
+
+    it "returns empty when no match" do
+      expect(Waitlist.with_discogs_username("nonexistent")).to be_empty
+    end
+  end
 end

--- a/spec/requests/discogs_lookup_spec.rb
+++ b/spec/requests/discogs_lookup_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+RSpec.describe "DiscogsLookup", type: :request do
+  describe "GET /api/discogs/lookup/:username" do
+    let(:client) { instance_double(DiscogsClient) }
+
+    before do
+      allow(DiscogsClient).to receive(:new).and_return(client)
+    end
+
+    context "with a valid username that exists on Discogs" do
+      before do
+        allow(client).to receive(:seller_profile).with("realseller").and_return(
+          { "name" => "Real Seller", "username" => "realseller", "avatar_url" => "https://example.com/avatar.jpg" }
+        )
+      end
+
+      it "returns found: true with seller info" do
+        get "/api/discogs/lookup/realseller"
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["found"]).to be true
+        expect(body["seller_name"]).to eq("Real Seller")
+        expect(body["avatar_url"]).to eq("https://example.com/avatar.jpg")
+      end
+    end
+
+    context "with a username that doesn't exist on Discogs" do
+      before do
+        allow(client).to receive(:seller_profile).with("nonexistent").and_raise(
+          DiscogsClient::ApiError, "Discogs API error: 404 — Not Found"
+        )
+      end
+
+      it "returns found: false" do
+        get "/api/discogs/lookup/nonexistent"
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["found"]).to be false
+      end
+    end
+
+    context "when Discogs rate limits" do
+      before do
+        allow(client).to receive(:seller_profile).with("rate-limited").and_raise(
+          DiscogsClient::RateLimitError, "Discogs rate limit hit"
+        )
+      end
+
+      it "returns found: false with api_error reason" do
+        get "/api/discogs/lookup/rate-limited"
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["found"]).to be false
+        expect(body["reason"]).to eq("api_error")
+      end
+    end
+
+    context "with an invalid slug" do
+      it "rejects slugs shorter than 3 characters" do
+        get "/api/discogs/lookup/ab"
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["found"]).to be false
+        expect(body["reason"]).to eq("invalid_slug")
+      end
+
+      it "rejects slugs with invalid characters" do
+        get "/api/discogs/lookup/bad!slug"
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["found"]).to be false
+        expect(body["reason"]).to eq("invalid_slug")
+      end
+
+      it "rejects reserved slugs" do
+        get "/api/discogs/lookup/admin"
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["found"]).to be false
+        expect(body["reason"]).to eq("invalid_slug")
+      end
+
+      it "rejects slugs with leading/trailing special chars" do
+        get "/api/discogs/lookup/-badstart"
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body["found"]).to be false
+        expect(body["reason"]).to eq("invalid_slug")
+      end
+    end
+
+    context "caching" do
+      around do |example|
+        original_cache = Rails.cache
+        Rails.cache = ActiveSupport::Cache::MemoryStore.new
+        example.run
+      ensure
+        Rails.cache = original_cache
+      end
+
+      before do
+        allow(client).to receive(:seller_profile).with("cached-user").and_return(
+          { "name" => "Cached User", "username" => "cached-user" }
+        )
+      end
+
+      it "caches found results and uses cache on subsequent requests" do
+        expect(client).to receive(:seller_profile).once
+
+        2.times do
+          get "/api/discogs/lookup/cached-user"
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["found"]).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -53,9 +53,8 @@ RSpec.describe "Stores", type: :request do
         expect(inertia).to render_component("stores/invitation")
       end
 
-      it "passes slug as discogs_username prop" do
+      it "passes slug as prop" do
         get "/some-slug"
-        expect(inertia.props[:discogs_username]).to eq("some-slug")
         expect(inertia.props[:slug]).to eq("some-slug")
       end
 

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -47,9 +47,27 @@ RSpec.describe "Stores", type: :request do
     end
 
     context "with unknown slug" do
-      it "returns 200" do
+      it "returns 200 and renders invitation" do
         get "/unknownstore"
         expect(response).to have_http_status(:ok)
+        expect(inertia).to render_component("stores/invitation")
+      end
+
+      it "passes slug as discogs_username prop" do
+        get "/some-slug"
+        expect(inertia.props[:discogs_username]).to eq("some-slug")
+        expect(inertia.props[:slug]).to eq("some-slug")
+      end
+
+      it "passes waitlist_present as false when no waitlist entry exists" do
+        get "/slug-not-on-waitlist"
+        expect(inertia.props[:waitlist_present]).to be false
+      end
+
+      it "passes waitlist_present as true when waitlist entry exists" do
+        create(:waitlist, discogs_username: "applied-slug")
+        get "/applied-slug"
+        expect(inertia.props[:waitlist_present]).to be true
       end
     end
   end


### PR DESCRIPTION
## Summary

Every unclaimed `/:slug` was a dead end — even for Discogs sellers who typed their own store URL. Now the 404 page detects them, invites them to claim the URL, and redirects with the username pre-filled. Returning applicants see acknowledgment instead of a blank wall.

## What changed

- **Waitlist normalization** — `Waitlist.discogs_username` is now downcased on save (matching the Store model pattern), enabling case-insensitive matching between slug lookups and stored applications.

- **Discogs lookup API** — new `GET /api/discogs/lookup/:username` endpoint with a slug quality gate (length, character class, reserved routes) and `Rails.cache` (Solid Cache) with tiered TTLs (1 hour for found, 24 hours for not found). Protects the Discogs API rate limit from bot/garbage traffic.

- **Inertia invitation page** — the static `no_stores.html.erb` 404 is replaced by a dynamic Inertia/React page at `stores/invitation.tsx`. Server checks Waitlist synchronously; if an application exists, renders acknowledgment. Otherwise renders generic invitation immediately, then fires an async client-side Discogs probe. On success, the page upgrades to personalized copy ("We found you on Discogs — Claim this storefront") with a CTA button.

- **Query-param propagation** — clicking "Claim this storefront" redirects to `/apply?discogs_username={slug}`. The apply form reads the param via Inertia props and pre-fills the field (editable). No more retyping the username.

- **Quality gate** — the client-side probe only fires for plausible Discogs usernames (3-40 chars, alphanumeric/hyphens/underscores, not reserved routes). Garbage slugs, bots, and `/wp-admin` get the generic invitation without an API call.

## Design decisions

- **Async probe over sync.** The Discogs API call (~500ms) doesn't block page render. The generic invitation ships instantly; personalized copy upgrades asynchronously. This keeps the 404 fast and resilient to API latency or failures.

- **Redirect to apply form over inline claim.** Reuses the existing `/apply` flow with its Turnstile captcha, validation, and mailer pipeline rather than building a separate submission mechanism on the 404 page.

- **Waitlist acknowledgment without escalation.** Returning applicants see "This URL has been claimed" with no login, email exposure, or re-apply path. Deliberately simple — auth and ownership verification are future concerns.

## Testing

- **247 RSpec** specs pass (models, controllers, requests, API endpoint)
- **281 Vitest** tests pass (frontend components, invitation page, apply form, quality gate, waitlist states)
- Rubocop clean across 39 files

## Post-Deploy Monitoring & Validation

| Signal | What to watch | Healthy | Failure |
|--------|---------------|---------|---------|
| Discogs API rate limit | Error logs for `RateLimitError` | < 5/day | Repeated rate limit errors from probe traffic |
| Probe cache hit rate | Cache keys under `discogs_lookup/*` | > 80% after warmup | Lots of duplicate API calls |
| 404 page render time | Request logs for `stores#show` 404s | < 50ms server-side | Page load > 200ms from API waits |
| Waitlist acknowledgment | Waitlist query rate | Few errors | "This URL has been claimed" shown for stores that later exist |

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-D97757?logo=claude&logoColor=white)
