### PR TITLE
refactor: resolve layered audit follow-up

### DIFF
--- a/app/controllers/api/discogs_lookup_controller.rb
+++ b/app/controllers/api/discogs_lookup_controller.rb
@@ -1,65 +1,8 @@
 module Api
   class DiscogsLookupController < ApplicationController
-    # Slug quality gate — only allow plausible Discogs usernames
-    VALID_USERNAME_REGEX = /\A[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]\z/
-    MIN_LENGTH = 3
-    MAX_LENGTH = 40
-
-    # Common reserved routes that should not trigger a Discogs lookup
-    RESERVED_SLUGS = %w[
-      admin apply jobs up assets 404 500 health
-      login logout signup register
-      api docs status help support
-      favicon manifest service-worker
-    ].freeze
-
-    # Cache TTLs
-    FOUND_TTL = 1.hour
-    NOT_FOUND_TTL = 24.hours
-
     def show
-      username = params[:username].to_s.strip
-
-      unless plausible_username?(username)
-        return render json: { found: false, reason: "invalid_slug" }, status: :ok
-      end
-
-      normalized = username.downcase
-
-      result = Rails.cache.read(cache_key(normalized))
-
-      if result.nil?
-        result = lookup_discogs(normalized)
-        # Only cache non-error results
-        if result[:found] || result[:reason] != "api_error"
-          ttl = result[:found] ? FOUND_TTL : NOT_FOUND_TTL
-          Rails.cache.write(cache_key(normalized), result, expires_in: ttl)
-        end
-      end
-
+      result = DiscogsSellerLookup.new(params[:username]).call
       render json: result, status: :ok
-    end
-
-    private
-
-    def plausible_username?(username)
-      return false if username.length < MIN_LENGTH || username.length > MAX_LENGTH
-      return false unless VALID_USERNAME_REGEX.match?(username)
-      return false if RESERVED_SLUGS.include?(username.downcase)
-
-      true
-    end
-
-    def lookup_discogs(username)
-      client = DiscogsClient.new
-      profile = client.seller_profile(username)
-      { found: true, seller_name: profile["name"] || profile["username"], avatar_url: profile["avatar_url"] }
-    rescue DiscogsClient::RateLimitError, DiscogsClient::ApiError, Faraday::Error => e
-      { found: false, reason: "api_error" }
-    end
-
-    def cache_key(username)
-      "discogs_lookup/#{username}"
     end
   end
 end

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -31,11 +31,12 @@ class StoresController < ApplicationController
     curation  = StorefrontCuration.new(store, filter_available: !Rails.env.development?)
     presenter = CratePresenter.new(store)
     curated_crates = curation.crates
+    storefront_groups = curation.storefront_groups
 
     render inertia: "stores/featured", props: {
       store: presenter.store_props,
       crates: presenter.build_crates(curated_crates),
-      storefront_sections: presenter.build_storefront_sections(curation.storefront_sections),
+      storefront_sections: presenter.build_storefront_sections(storefront_groups),
       active_crate_slug: "picks"
     }
   end

--- a/app/jobs/enrichment_job.rb
+++ b/app/jobs/enrichment_job.rb
@@ -3,18 +3,13 @@ class EnrichmentJob < ApplicationJob
 
   def perform(store_id, listing_ids: nil)
     store = Store.find(store_id)
-    store.update!(enrichment_status: "enriching")
 
     service = EnrichmentService.new
-    service.enrich_releases(store, listing_ids:)
-    service.enrich_music_brainz_images(store)
-
-    store.update!(enrichment_status: "idle", last_enriched_at: Time.current)
+    service.enrich_store(store, listing_ids:)
   rescue StandardError => error
     Rails.logger.error(
       "[EnrichmentJob] store=#{store&.discogs_username || store_id} job_id=#{job_id} failed\n#{error.full_message(highlight: false, order: :top)}"
     )
-    store&.update!(enrichment_status: "failed")
     raise
   end
 end

--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -4,18 +4,8 @@ class FullStoreSyncJob < ApplicationJob
   def perform(store_id, max_pages: nil)
     store = Store.find(store_id)
     service = StoreSyncService.new(store)
-    sync_started_at = Time.current
 
     result = service.sync(max_pages: max_pages)
-
-    # Service already set sync_status to idle and recorded last_synced_at.
-    # Add the job-specific extras that the service doesn't own.
-    store.update!(
-      last_synced_at: sync_started_at,
-      total_listings: store.listings.count,
-      catalog_coverage: result.catalog_coverage,
-      inventory_page_count: result.inventory_page_count
-    )
 
     Rails.logger.info("FullStoreSync: synced #{store.listings.count} listings for #{store.discogs_username}")
 

--- a/app/models/record_scorer.rb
+++ b/app/models/record_scorer.rb
@@ -52,6 +52,17 @@ class RecordScorer
     }
   end
 
+  def good_condition?(listing)
+    condition_points(listing).positive?
+  end
+
+  def desirable?(listing)
+    have = listing.have_count.to_i
+    return false if have < WANT_HAVE_MIN_HAVE
+
+    listing.want_count.to_i.to_f / have >= WANT_HAVE_RATIO_HIGH
+  end
+
   private
 
   def vintage_points(listing)

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -48,6 +48,18 @@ class Store < ApplicationRecord
     )
   end
 
+  def mark_enrichment_started!
+    update!(enrichment_status: "enriching")
+  end
+
+  def mark_enrichment_succeeded!(finished_at: Time.current)
+    update!(enrichment_status: "idle", last_enriched_at: finished_at)
+  end
+
+  def mark_enrichment_failed!
+    update!(enrichment_status: "failed")
+  end
+
   private
 
   def normalize_discogs_username

--- a/app/presenters/admin/store_health_presenter.rb
+++ b/app/presenters/admin/store_health_presenter.rb
@@ -1,7 +1,5 @@
 module Admin
   class StoreHealthPresenter
-    STALE_AFTER = 23.hours
-
     def initialize(store)
       @store = store
     end
@@ -29,86 +27,7 @@ module Admin
     attr_reader :store
 
     def health
-      if failed?
-        health_props("failed", "Needs attention", "danger", failure_reasons)
-      elsif processing?
-        health_props("processing", "Processing", "working", processing_reasons)
-      elsif missing_readiness?
-        health_props("processing", "Processing", "working", readiness_reasons)
-      elsif stale?
-        health_props("stale", "Stale", "warning", stale_reasons)
-      elsif partial?
-        health_props("partial", "Partial coverage", "warning", [ "Inventory coverage is partial" ])
-      else
-        health_props("healthy", "Healthy", "good", [ "Sync and enrichment are current" ])
-      end
-    end
-
-    def health_props(key, label, severity, reasons)
-      {
-        key:,
-        label:,
-        severity:,
-        reasons: reasons.compact_blank,
-        has_sync_error: store.last_sync_error_at.present?,
-        last_sync_error_summary: sync_error_summary
-      }
-    end
-
-    def failed?
-      store.sync_failed? || store.enrichment_failed?
-    end
-
-    def failure_reasons
-      [
-        ("Sync failed" if store.sync_failed?),
-        ("Enrichment failed" if store.enrichment_failed?)
-      ]
-    end
-
-    def processing?
-      store.sync_syncing? || store.enrichment_enriching?
-    end
-
-    def processing_reasons
-      [
-        ("Sync in progress" if store.sync_syncing?),
-        ("Enrichment in progress" if store.enrichment_enriching?)
-      ]
-    end
-
-    def missing_readiness?
-      store.last_synced_at.blank? || store.last_enriched_at.blank?
-    end
-
-    def readiness_reasons
-      [
-        ("Waiting on first sync" if store.last_synced_at.blank?),
-        ("Waiting on first enrichment" if store.last_enriched_at.blank?)
-      ]
-    end
-
-    def stale?
-      stale_time?(store.last_synced_at) || stale_time?(store.last_enriched_at)
-    end
-
-    def stale_reasons
-      [
-        ("Sync is stale" if stale_time?(store.last_synced_at)),
-        ("Enrichment is stale" if stale_time?(store.last_enriched_at))
-      ]
-    end
-
-    def stale_time?(time)
-      time.present? && time < STALE_AFTER.ago
-    end
-
-    def partial?
-      store.catalog_coverage == "partial"
-    end
-
-    def sync_error_summary
-      store.last_sync_error.to_s.lines.first&.strip.presence
+      StoreHealth.new(store).props
     end
 
     def iso_time(time)

--- a/app/presenters/crate_presenter.rb
+++ b/app/presenters/crate_presenter.rb
@@ -23,20 +23,20 @@ class CratePresenter
     end
   end
 
-  def build_storefront_sections(sections)
-    sections.map do |section|
-      if section[:crate]
-        {
-          key: section[:key],
-          crate: crate_props(section[:crate].slug, section[:crate].name, section[:crate].listings)
-        }
-      else
-        {
-          key: section[:key],
-          crates: build_crates(section[:crates])
-        }
-      end
+  def build_storefront_sections(groups)
+    sections = [
+      {
+        key: "picks_wall",
+        crate: crate_props(groups[:picks].slug, groups[:picks].name, groups[:picks].listings)
+      }
+    ]
+
+    if groups[:featured].present?
+      sections << { key: "featured_crates", crates: build_crates(groups[:featured]) }
     end
+
+    sections << { key: "genre_grid", crates: build_crates(groups[:genres]) }
+    sections
   end
 
   private

--- a/app/presenters/marketing_preview_presenter.rb
+++ b/app/presenters/marketing_preview_presenter.rb
@@ -40,7 +40,7 @@ class MarketingPreviewPresenter
   def live_preview(store)
     curation  = StorefrontCuration.new(store, filter_available: !Rails.env.development?)
     presenter = CratePresenter.new(store)
-    sections  = presenter.build_storefront_sections(curation.storefront_sections)
+    sections  = presenter.build_storefront_sections(curation.storefront_groups)
 
     {
       store_name: store.name,

--- a/app/services/admin/store_health.rb
+++ b/app/services/admin/store_health.rb
@@ -1,0 +1,96 @@
+module Admin
+  class StoreHealth
+    STALE_AFTER = 23.hours
+
+    def initialize(store)
+      @store = store
+    end
+
+    def props
+      if failed?
+        health_props("failed", "Needs attention", "danger", failure_reasons)
+      elsif processing?
+        health_props("processing", "Processing", "working", processing_reasons)
+      elsif missing_readiness?
+        health_props("processing", "Processing", "working", readiness_reasons)
+      elsif stale?
+        health_props("stale", "Stale", "warning", stale_reasons)
+      elsif partial?
+        health_props("partial", "Partial coverage", "warning", [ "Inventory coverage is partial" ])
+      else
+        health_props("healthy", "Healthy", "good", [ "Sync and enrichment are current" ])
+      end
+    end
+
+    private
+
+    attr_reader :store
+
+    def health_props(key, label, severity, reasons)
+      {
+        key:,
+        label:,
+        severity:,
+        reasons: reasons.compact_blank,
+        has_sync_error: store.last_sync_error_at.present?,
+        last_sync_error_summary: sync_error_summary
+      }
+    end
+
+    def failed?
+      store.sync_failed? || store.enrichment_failed?
+    end
+
+    def failure_reasons
+      [
+        ("Sync failed" if store.sync_failed?),
+        ("Enrichment failed" if store.enrichment_failed?)
+      ]
+    end
+
+    def processing?
+      store.sync_syncing? || store.enrichment_enriching?
+    end
+
+    def processing_reasons
+      [
+        ("Sync in progress" if store.sync_syncing?),
+        ("Enrichment in progress" if store.enrichment_enriching?)
+      ]
+    end
+
+    def missing_readiness?
+      store.last_synced_at.blank? || store.last_enriched_at.blank?
+    end
+
+    def readiness_reasons
+      [
+        ("Waiting on first sync" if store.last_synced_at.blank?),
+        ("Waiting on first enrichment" if store.last_enriched_at.blank?)
+      ]
+    end
+
+    def stale?
+      stale_time?(store.last_synced_at) || stale_time?(store.last_enriched_at)
+    end
+
+    def stale_reasons
+      [
+        ("Sync is stale" if stale_time?(store.last_synced_at)),
+        ("Enrichment is stale" if stale_time?(store.last_enriched_at))
+      ]
+    end
+
+    def stale_time?(time)
+      time.present? && time < STALE_AFTER.ago
+    end
+
+    def partial?
+      store.catalog_coverage == "partial"
+    end
+
+    def sync_error_summary
+      store.last_sync_error.to_s.lines.first&.strip.presence
+    end
+  end
+end

--- a/app/services/daily_selection_service.rb
+++ b/app/services/daily_selection_service.rb
@@ -23,9 +23,6 @@ class DailySelectionService
   # Ensures long-tail catalog gets surfaced over time.
   UNSEEN_BOOST = 4
 
-  GOOD_CONDITIONS   = RecordScorer::GOOD_CONDITIONS
-  CONDITION_ALIASES = RecordScorer::CONDITION_ALIASES
-
   # ─────────────────────────────────────────────────────────────────────────
 
   def initialize(store)
@@ -48,13 +45,13 @@ class DailySelectionService
     return [] unless yesterday&.listing_ids&.any?
 
     carry_count = (SELECTION_SIZE * OVERLAP_FRACTION).to_i
-    scored = score_listings(@store.listings.where(id: yesterday.listing_ids))
+    scored = score_listings(@store.listings.where(id: yesterday.listing_ids), date:)
     scored.max_by(carry_count) { |_, s| s }.map { |l, _| l.id }
   end
 
   def compute_fresh(date, exclude_ids:)
     fresh_count = SELECTION_SIZE - exclude_ids.size
-    candidates = score_listings(@store.listings.where.not(id: exclude_ids))
+    candidates = score_listings(@store.listings.where.not(id: exclude_ids), date:)
 
     # Efraimidis-Spirakis weighted reservoir sampling:
     # Each listing gets rand^(1/weight) — higher weight = higher probability.
@@ -65,31 +62,22 @@ class DailySelectionService
       .map { |l, _| l.id }
   end
 
-  def score_listings(scope)
-    recent_ids = recent_selection_ids
+  def score_listings(scope, date:)
+    recent_ids = recent_selection_ids(date)
+    scorer = record_scorer(date)
 
     scope.map do |listing|
       weight = 1 # base weight — every record has a chance
 
       # Recency: how recently was it listed in the store
       if listing.listed_at
-        days_ago = (Date.current - listing.listed_at.to_date).to_i
+        days_ago = (date - listing.listed_at.to_date).to_i
         weight += RECENCY_WEIGHT if days_ago < 30
         weight += (RECENCY_WEIGHT - 1) if days_ago.between?(30, 90)
       end
 
-      # Condition quality
-      good_condition = GOOD_CONDITIONS.include?(listing.condition&.strip) ||
-                       CONDITION_ALIASES.include?(listing.condition&.strip&.downcase)
-      weight += QUALITY_WEIGHT if good_condition
-
-      # Desirability: want/have ratio signals market demand
-      have = listing.have_count.to_i
-      want = listing.want_count.to_i
-      if have >= RecordScorer::WANT_HAVE_MIN_HAVE
-        ratio = want.to_f / have
-        weight += DESIRABILITY_WEIGHT if ratio >= RecordScorer::WANT_HAVE_RATIO_HIGH
-      end
+      weight += QUALITY_WEIGHT if scorer.good_condition?(listing)
+      weight += DESIRABILITY_WEIGHT if scorer.desirable?(listing)
 
       # Unseen boost — hasn't appeared in recent selections
       weight += UNSEEN_BOOST unless recent_ids.include?(listing.id)
@@ -98,11 +86,24 @@ class DailySelectionService
     end
   end
 
-  def recent_selection_ids
-    @recent_selection_ids ||= DailySelection
+  def recent_selection_ids(date)
+    @recent_selection_ids_by_date ||= {}
+    @recent_selection_ids_by_date[date] ||= DailySelection
       .where(store: @store)
-      .where(selected_on: (Date.current - 7)..Date.current)
+      .where(selected_on: (date - 7)..date)
       .flat_map(&:listing_ids)
       .to_set
+  end
+
+  def record_scorer(date)
+    @record_scorers_by_date ||= {}
+    @record_scorers_by_date[date] ||= RecordScorer.new(
+      genre_counts: genre_counts,
+      today: date
+    )
+  end
+
+  def genre_counts
+    @genre_counts ||= @store.listings.pluck(:genres).flatten.compact.tally
   end
 end

--- a/app/services/discogs_seller_lookup.rb
+++ b/app/services/discogs_seller_lookup.rb
@@ -1,0 +1,76 @@
+class DiscogsSellerLookup
+  VALID_USERNAME_REGEX = /\A[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]\z/
+  MIN_LENGTH = 3
+  MAX_LENGTH = 40
+
+  RESERVED_SLUGS = %w[
+    admin apply jobs up assets 404 500 health
+    login logout signup register
+    api docs status help support
+    favicon manifest service-worker
+  ].freeze
+
+  FOUND_TTL = 1.hour
+  NOT_FOUND_TTL = 24.hours
+
+  def initialize(username, client: DiscogsClient.new, cache: Rails.cache)
+    @username = username.to_s.strip
+    @client = client
+    @cache = cache
+  end
+
+  def call
+    return invalid_slug unless plausible_username?
+
+    cached_result = cache.read(cache_key)
+    return cached_result unless cached_result.nil?
+
+    result = lookup_discogs
+
+    unless result[:reason] == "api_error"
+      cache.write(cache_key, result, expires_in: result[:found] ? FOUND_TTL : NOT_FOUND_TTL)
+    end
+
+    result
+  rescue DiscogsClient::RateLimitError, DiscogsClient::ApiError, Faraday::Error
+    api_error
+  end
+
+  private
+
+  attr_reader :username, :client, :cache
+
+  def plausible_username?
+    return false if username.length < MIN_LENGTH || username.length > MAX_LENGTH
+    return false unless VALID_USERNAME_REGEX.match?(username)
+    return false if RESERVED_SLUGS.include?(normalized_username)
+
+    true
+  end
+
+  def lookup_discogs
+    profile = client.seller_profile(normalized_username)
+
+    {
+      found: true,
+      seller_name: profile["name"] || profile["username"],
+      avatar_url: profile["avatar_url"]
+    }
+  end
+
+  def cache_key
+    "discogs_lookup/#{normalized_username}"
+  end
+
+  def normalized_username
+    username.downcase
+  end
+
+  def invalid_slug
+    { found: false, reason: "invalid_slug" }
+  end
+
+  def api_error
+    { found: false, reason: "api_error" }
+  end
+end

--- a/app/services/enrichment_service.rb
+++ b/app/services/enrichment_service.rb
@@ -9,6 +9,16 @@ class EnrichmentService
     @musicbrainz = MusicBrainzClient.new
   end
 
+  def enrich_store(store, listing_ids: nil)
+    store.mark_enrichment_started!
+    enrich_releases(store, listing_ids:)
+    enrich_music_brainz_images(store)
+    store.mark_enrichment_succeeded!
+  rescue StandardError
+    store.mark_enrichment_failed!
+    raise
+  end
+
   # ── Discogs Release Enrichment ──────────────────────────────────────────
 
   def enrich_releases(store, listing_ids: nil)

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -21,29 +21,27 @@ class StorefrontCuration
     ]
   end
 
-  def storefront_sections
-    picks_crate = CuratedCrate.new(slug: "picks", name: "Milkcrate Picks", listings: picks_strategy.select(eligible_listings, excluded_ids: Set.new, count: 12))
+  def storefront_groups
+    picks_crate = CuratedCrate.new(
+      slug: "picks",
+      name: "Milkcrate Picks",
+      listings: picks_strategy.select(eligible_listings, excluded_ids: Set.new, count: 12)
+    )
     seen_ids = picks_crate.listings.map(&:id).to_set
 
-    sections = [ { key: "picks_wall", crate: picks_crate } ]
-
     featured_crates = build_featured_crates(excluded_ids: seen_ids)
-    if featured_crates.present?
-      featured_crates.each { |crate| crate.listings.each { |listing| seen_ids.add(listing.id) } }
-      sections << { key: "featured_crates", crates: featured_crates }
-    end
+    featured_crates.each { |crate| crate.listings.each { |listing| seen_ids.add(listing.id) } }
 
-    sections << { key: "genre_grid", crates: build_genre_crates(excluded_ids: seen_ids) }
-    sections
+    {
+      picks: picks_crate,
+      featured: featured_crates,
+      genres: build_genre_crates(excluded_ids: seen_ids)
+    }
   end
 
   def surfaced_listings
-    storefront_sections.flat_map { |section|
-      crates = []
-      crates << section[:crate] if section[:crate]
-      crates.concat(section[:crates]) if section[:crates]
-      crates
-    }.flat_map(&:listings).uniq(&:id)
+    groups = storefront_groups
+    ([ groups[:picks] ] + groups[:featured] + groups[:genres]).flat_map(&:listings).uniq(&:id)
   end
 
   private

--- a/docs/plans/2026-05-17-001-refactor-layered-audit-follow-up-plan.md
+++ b/docs/plans/2026-05-17-001-refactor-layered-audit-follow-up-plan.md
@@ -1,0 +1,369 @@
+---
+title: "refactor: Resolve layered audit follow-up findings"
+type: refactor
+status: completed
+date: 2026-05-17
+---
+
+# refactor: Resolve Layered Audit Follow-Up Findings
+
+## Summary
+
+Follow up on the latest layered-rails audit by moving controller-owned lookup behavior, lifecycle state transitions, admin health policy, daily-selection scoring, and storefront section shaping into clearer layer-specific objects. The work is an internal refactor: preserve request/response behavior, job behavior, curation output, and frontend props while reducing presentation-to-application leakage and duplicated orchestration.
+
+---
+
+## Problem Frame
+
+The May 13 layered-architecture cleanup removed several earlier violations, but the current code still has responsibility drift at active growth points. Controllers and presenters own policy decisions, jobs duplicate service lifecycle state, one selection service carries a separate scoring model, and `StorefrontCuration` mixes curation with UI section shape. These are not runtime bugs today, but they make future storefront, onboarding, and admin changes harder to reason about.
+
+---
+
+## Requirements
+
+- R1. Keep all user-facing behavior unchanged for Discogs lookup, waitlist submission, store sync, enrichment, admin dashboard, daily selection, and storefront rendering.
+- R2. Move Discogs lookup validation, caching, upstream lookup, and API-error mapping out of `Api::DiscogsLookupController`.
+- R3. Consolidate sync and enrichment lifecycle state ownership so jobs are thin wrappers and state transitions are owned by service/domain APIs.
+- R4. Move admin store-health classification rules out of presentation serialization while preserving the existing dashboard prop shape.
+- R5. Align `DailySelectionService` scoring with the domain scoring model and make generated selections respect the caller-supplied date consistently.
+- R6. Keep storefront curation as curation logic and move UI section-key shaping toward presentation/view-model code without changing storefront props.
+- R7. Defer minor controller cleanup that is not necessary to address the audit's main architectural risks.
+
+---
+
+## Scope Boundaries
+
+- No new product behavior, storefront UI changes, admin UI changes, or copy changes.
+- No new architecture enforcement tooling, package boundaries, gems, or lint rules.
+- No changes to `DiscogsClient`, `MusicBrainzClient`, or external API contracts beyond call-site relocation.
+- No database schema changes.
+- No frontend TypeScript changes unless implementation discovers a serialized prop parity issue that cannot be resolved server-side.
+
+### Deferred to Follow-Up Work
+
+- Waitlist submission orchestration cleanup in `WaitlistsController`: this is mild drift today and should be handled separately if waitlist behavior grows.
+- Broader `StorefrontCuration` decomposition beyond section shaping: strategy extraction is already documented and should not be reopened unless new crate types require it.
+- Architecture enforcement automation such as Packwerk, custom RuboCop rules, or CI checks.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `app/controllers/api/discogs_lookup_controller.rb` currently combines request handling with username policy, cache policy, Discogs lookup, and upstream error mapping.
+- `spec/requests/discogs_lookup_spec.rb` already captures valid lookup, missing seller, rate limit, invalid slug, reserved slug, and cache behavior.
+- `app/services/store_sync_service.rb` owns sync status updates, while `app/jobs/full_store_sync_job.rb` currently writes overlapping sync metadata after the service returns.
+- `app/jobs/enrichment_job.rb` owns enrichment status transitions directly while delegating release/image work to `app/services/enrichment_service.rb`.
+- `app/presenters/admin/store_health_presenter.rb` serializes dashboard props and also classifies health states; `spec/presenters/admin/store_health_presenter_spec.rb` documents the priority order.
+- `app/services/daily_selection_service.rb` has its own scoring weights and uses `Date.current` internally even when `#generate(date:)` receives another date.
+- `app/services/storefront_curation.rb` follows the documented crate strategy pattern but still emits UI section keys through `#storefront_sections`.
+- `app/presenters/crate_presenter.rb` already serializes crate and listing props, making it the natural presentation boundary for storefront section props.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md` says curation strategies should stay pure, share `RecordScorer`, and let callers wrap/cap strategy output. The follow-up should preserve this pattern rather than reworking strategy internals.
+- `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md` highlights that refactors which split branches can silently drop guards. This plan should use characterization tests before moving branching/classification logic.
+
+### External References
+
+- External research is not required for this plan. The repo has direct local patterns for Rails request specs, service specs, presenters, background jobs, and curation strategy objects.
+
+---
+
+## Key Technical Decisions
+
+- Use characterization-first refactoring for behavior-preserving moves: each boundary change should first pin the existing response, prop, or state-transition behavior it will preserve.
+- Keep new abstractions small and named after the responsibility they own: lookup, lifecycle, health classification, daily selection scoring, and storefront section presentation.
+- Prefer application/service objects for orchestration and policy that crosses models or infrastructure; keep presenters focused on serialization and view-specific formatting.
+- Treat the May 13 layered architecture requirements and plan as historical context, not the origin document, because the current code already implements most of that plan.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the older May 13 layered plan be updated in place? No. The current code has already moved past much of that plan, so this follow-up gets a new plan file scoped to the latest audit.
+- Should waitlist submission cleanup be in scope? No. It is noted as mild drift, but the main plan should address higher-risk architecture seams first.
+
+### Deferred to Implementation
+
+- Exact class names for extracted objects may be adjusted to fit Rails autoloading and surrounding naming conventions.
+- Final method names for the storefront curation grouping API may adjust during implementation, but the planned boundary is fixed: curation returns crate groups, presentation assigns section keys.
+- Exact helper names inside `RecordScorer` may adjust during implementation, but the planned sharing point is fixed: `DailySelectionService` should consume scorer-derived signals instead of duplicating condition/desirability logic.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+  Request[HTTP request / Job perform / Presenter props] --> Boundary[Thin boundary object]
+  Boundary --> Application[Application service or policy object]
+  Application --> Domain[Models / value objects / scoring objects]
+  Application --> Infrastructure[API clients / cache / Active Record writes]
+  Boundary --> Response[Render JSON / enqueue jobs / serialize props]
+```
+
+The refactor should make the boundary object responsible for framework concerns only: params, render, job lookup, or prop serialization. Application objects own orchestration, policy decisions, and lifecycle transitions. Domain objects own scoring and state semantics. Infrastructure remains behind existing clients, cache, and Active Record calls.
+
+---
+
+## Implementation Units
+
+### U1. Extract Discogs Seller Lookup
+
+**Goal:** Move username validation, reserved-slug policy, caching, Discogs profile lookup, and API-error mapping out of `Api::DiscogsLookupController`.
+
+**Requirements:** R1, R2
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/services/discogs_seller_lookup.rb`
+- Modify: `app/controllers/api/discogs_lookup_controller.rb`
+- Test: `spec/services/discogs_seller_lookup_spec.rb`
+- Test: `spec/requests/discogs_lookup_spec.rb`
+
+**Approach:**
+- Add a lookup object that accepts the username string plus injectable collaborators for the Discogs client and cache.
+- Move the validation constants, reserved slug list, cache key, TTL policy, and upstream error mapping into that object.
+- Keep the controller responsible for extracting `params[:username]`, calling the lookup object, and rendering the returned response hash/status.
+- Preserve the current JSON shape for found, invalid, and API-error responses.
+
+**Execution note:** Start with service specs that mirror the current request-spec scenarios, then keep request specs as integration coverage for route/controller parity.
+
+**Patterns to follow:**
+- `TurnstileVerifier` for a small external-service boundary with explicit upstream failure handling.
+- `spec/requests/discogs_lookup_spec.rb` for existing public request contract coverage.
+
+**Test scenarios:**
+- Happy path: username with whitespace/case variations is normalized, looked up once, and returns `found: true` with seller name and avatar URL.
+- Happy path: successful lookup is cached; a second lookup for the same normalized username does not call the Discogs client again.
+- Edge case: usernames shorter than the minimum, longer than the maximum, containing invalid characters, starting/ending with separators, or matching reserved slugs return `found: false` with `reason: "invalid_slug"`.
+- Error path: Discogs API errors, rate limit errors, and Faraday errors return `found: false` with `reason: "api_error"` and do not cache the error result.
+- Integration: `GET /api/discogs/lookup/:username` returns the same status and JSON body as before the extraction.
+
+**Verification:**
+- The controller has no Discogs client, cache, regex, TTL, or reserved-slug policy logic left.
+- Request specs and service specs prove identical valid, invalid, cache, and upstream-error behavior.
+
+---
+
+### U2. Consolidate Sync and Enrichment Lifecycle Ownership
+
+**Goal:** Make background jobs thin wrappers by moving duplicated sync metadata writes and enrichment status transitions into service/domain-owned APIs.
+
+**Requirements:** R1, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/jobs/full_store_sync_job.rb`
+- Modify: `app/jobs/enrichment_job.rb`
+- Modify: `app/models/store.rb`
+- Modify: `app/services/store_sync_service.rb`
+- Modify: `app/services/enrichment_service.rb`
+- Test: `spec/jobs/full_store_sync_job_spec.rb`
+- Test: `spec/jobs/enrichment_job_spec.rb`
+- Test: `spec/models/store_spec.rb`
+- Test: `spec/services/store_sync_service_spec.rb`
+- Test: `spec/services/enrichment_service_spec.rb`
+
+**Approach:**
+- Remove the second success metadata write from `FullStoreSyncJob`; `StoreSyncService#sync` should remain the owner of sync start time, sync status, catalog coverage, page count, and total listing count.
+- Add model-level enrichment lifecycle helpers or an `EnrichmentService` orchestration entry point so `EnrichmentJob` does not directly manage `enrichment_status` and `last_enriched_at`.
+- Keep `FullStoreSyncJob` responsible for finding the store, invoking sync, enqueueing follow-up jobs, and logging.
+- Keep `EnrichmentJob` responsible for finding the store and invoking one service entry point.
+
+**Execution note:** Characterize current sync watermark and enrichment status transitions before removing duplicated writes.
+
+**Patterns to follow:**
+- `Store#mark_sync_succeeded!` and `Store#mark_sync_failed!` for model-owned lifecycle transitions.
+- Existing service specs around `StoreSyncService#sync` and job specs around job enqueue behavior.
+
+**Test scenarios:**
+- Happy path: successful `StoreSyncService#sync` sets `sync_status` to idle, clears sync errors, persists `last_synced_at`, `catalog_coverage`, `inventory_page_count`, and `total_listings`.
+- Happy path: `FullStoreSyncJob` enqueues `EnrichmentJob` and `DailyCurationJob` after sync without rewriting sync metadata.
+- Edge case: sync availability watermark still uses sync start time, not completion time, so `Listing.available` behavior is unchanged.
+- Error path: sync failure records `sync_status: "failed"`, error summary, and error timestamp through the same store lifecycle API.
+- Happy path: enrichment orchestration sets status to enriching, then idle with `last_enriched_at` after both enrichment phases finish.
+- Error path: hard enrichment failure marks status failed and re-raises; individual API errors handled inside `EnrichmentService` still allow the job to finish idle.
+
+**Verification:**
+- Jobs no longer contain direct lifecycle metadata writes beyond framework-level orchestration.
+- Existing job/service specs pass with added assertions that state ownership lives in the service/domain layer.
+
+---
+
+### U3. Extract Admin Store Health Classification
+
+**Goal:** Move health-state policy out of `Admin::StoreHealthPresenter` while preserving the dashboard prop shape.
+
+**Requirements:** R1, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/services/admin/store_health.rb`
+- Modify: `app/presenters/admin/store_health_presenter.rb`
+- Test: `spec/services/admin/store_health_spec.rb`
+- Test: `spec/presenters/admin/store_health_presenter_spec.rb`
+- Test: `spec/presenters/admin/dashboard_presenter_spec.rb`
+
+**Approach:**
+- Extract the status priority rules into a small object that receives a store and returns classification data: key, label, severity, reasons, sync-error presence, and sync-error summary.
+- Keep the presenter responsible for assembling serialized store fields and embedding the health object's data.
+- Preserve the current priority order: failed, processing, missing readiness, stale, partial, healthy.
+- Keep time-dependent staleness behavior explicit and testable.
+
+**Execution note:** Move the existing presenter health examples into service-level characterization tests before trimming the presenter.
+
+**Patterns to follow:**
+- `Admin::DashboardPresenter` delegating store-specific serialization to `Admin::StoreHealthPresenter`.
+- Existing presenter specs that pin dashboard prop shapes.
+
+**Test scenarios:**
+- Happy path: recently synced and enriched near-complete store classifies as healthy.
+- Happy path: failed sync or failed enrichment wins over processing, stale, and partial signals.
+- Happy path: syncing or enriching stores classify as processing even when timestamps are stale.
+- Edge case: missing sync/enrichment timestamps classify as processing/readiness, preserving the existing label and severity.
+- Edge case: partial catalog coverage classifies as partial only when no higher-priority signal exists.
+- Integration: `Admin::StoreHealthPresenter#props` still returns the same top-level keys and nested `health` hash used by `Admin::DashboardPresenter`.
+
+**Verification:**
+- Health policy methods no longer live in the presenter.
+- Service specs cover classification priority; presenter specs cover serialization shape.
+
+---
+
+### U4. Align Daily Selection Scoring and Date Semantics
+
+**Goal:** Make `DailySelectionService` use a shared domain scoring concept and honor the `date:` argument throughout selection generation.
+
+**Requirements:** R1, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/services/daily_selection_service.rb`
+- Modify: `app/models/record_scorer.rb`
+- Test: `spec/services/daily_selection_service_spec.rb`
+- Test: `spec/models/record_scorer_spec.rb`
+
+**Approach:**
+- Add characterization tests for current daily-selection behaviors: idempotence, carry-over, cap, recent-listing boost, condition/desirability boost, and unseen boost.
+- Pass the requested generation date through the whole service, including carry-over, fresh scoring, and recent-selection lookup; remove internal `Date.current` dependencies except the default argument boundary.
+- Use `RecordScorer` as the source of record-quality signals for condition and desirability. Keep daily-selection-specific concerns, such as weighted sampling and unseen boost, in `DailySelectionService`.
+- Preserve weighted sampling behavior and `DailySelection` persistence semantics.
+
+**Execution note:** This unit should be test-first because the current date drift is subtle and easy to preserve accidentally.
+
+**Patterns to follow:**
+- `RecordScorer#score_breakdown` as the existing domain scoring surface.
+- `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md` for keeping selection strategies aligned around one scoring model.
+
+**Test scenarios:**
+- Happy path: generating for a date creates or updates one `DailySelection` for that exact date.
+- Happy path: yesterday carry-over uses the day before the supplied date, not the system date.
+- Happy path: recent-selection boost exclusion uses a window relative to the supplied date, not `Date.current`.
+- Happy path: good condition and strong want/have signals influence daily-selection weight through scorer-derived signals rather than duplicated constant checks.
+- Edge case: generating a historical date while the system date differs produces scoring relative to the requested date.
+- Edge case: selection cap is still enforced after scoring changes.
+- Integration: a listing with stronger shared scorer signals receives a higher selection weight than a weaker listing, while unseen boost remains applied.
+
+**Verification:**
+- `DailySelectionService` no longer calls `Date.current` outside the default argument boundary.
+- Daily-selection and record-scorer specs document which signals are shared and which remain daily-selection-specific.
+
+---
+
+### U5. Separate Storefront Section Presentation from Curation
+
+**Goal:** Keep `StorefrontCuration` focused on selecting crates and move UI section-key shaping toward presentation/view-model code.
+
+**Requirements:** R1, R6
+
+**Dependencies:** U4 is conceptually related but not required.
+
+**Files:**
+- Modify: `app/services/storefront_curation.rb`
+- Modify: `app/presenters/crate_presenter.rb`
+- Modify: `app/controllers/stores_controller.rb`
+- Modify: `app/presenters/marketing_preview_presenter.rb`
+- Test: `spec/services/storefront_curation_spec.rb`
+- Test: `spec/presenters/crate_presenter_spec.rb`
+- Test: `spec/presenters/marketing_preview_presenter_spec.rb`
+- Test: `spec/requests/stores_spec.rb`
+- Test: `spec/requests/pages_spec.rb`
+
+**Approach:**
+- Preserve the current crate selection and top-down dedupe behavior.
+- Add a curation grouping API on `StorefrontCuration` that returns crate groups without final UI section keys: one picks crate, zero or more featured crates, and zero or more genre crates.
+- Move final section assembly into `CratePresenter`, where group names become the existing `picks_wall`, `featured_crates`, and `genre_grid` section keys and crate/listing props are serialized.
+- Keep `#surfaced_listings` derived from the same grouped curation result so daily curation marks exactly the displayed records.
+- Avoid reworking the documented strategy classes unless implementation reveals duplication that cannot be avoided otherwise.
+
+**Execution note:** Characterize `storefront_sections` output order and dedupe behavior before changing the boundary.
+
+**Patterns to follow:**
+- `CratePresenter#build_storefront_sections` already owns serialization of section hashes.
+- `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md` for preserving the strategy interface and shared scoring.
+
+**Test scenarios:**
+- Happy path: storefront response still serializes sections in `picks_wall`, `featured_crates`, `genre_grid` order when featured crates exist.
+- Happy path: storefront response still omits the featured row when featured crates underfill.
+- Edge case: top-down dedupe across picks, featured crates, and genre crates remains unchanged.
+- Edge case: `#surfaced_listings` still returns unique listings from all displayed crates for daily curation.
+- Integration: store show and homepage preview request specs still receive the same prop shape after the section boundary moves.
+
+**Verification:**
+- `StorefrontCuration` no longer owns final UI section-key hashes.
+- `CratePresenter` owns section key assignment and serialization.
+- Storefront service, presenter, and request specs prove output parity.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Requests still enter through controllers; jobs still enter through Active Job; presenters still produce Inertia props. The plan changes which object owns policy and orchestration behind those entry points.
+- **Error propagation:** Discogs lookup API errors remain converted into non-error JSON responses. Sync/enrichment hard failures still re-raise through jobs after state is recorded. Individual enrichment API errors remain logged and skipped.
+- **State lifecycle risks:** Removing duplicate sync writes can expose tests that depended on job-side metadata updates. U2 explicitly pins watermark and status behavior before the removal.
+- **API surface parity:** Public HTTP JSON and Inertia prop shapes should not change. Request specs remain the parity guard.
+- **Integration coverage:** Discogs lookup, full sync job, enrichment job, admin dashboard props, daily selection persistence, and storefront props all need cross-layer coverage because mocks alone will not prove behavior preservation.
+- **Unchanged invariants:** No external API client contracts, database schema, frontend component props, route names, or background job queue names should change.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Behavior changes hide inside "pure refactor" work | Add characterization specs before moving each boundary, especially for lookup JSON, health priority, sync watermark, and storefront section shape |
+| New service objects become another bag of services | Keep each extraction scoped to one policy/orchestration responsibility and name it after the business behavior it owns |
+| Storefront curation refactor accidentally reorders or duplicates records | Preserve existing service specs for section order, featured omission, dedupe, and surfaced listings |
+| Daily selection scoring changes selection feel unintentionally | Preserve weighted sampling semantics and test relative weight behavior rather than exact random output |
+| Lifecycle consolidation obscures job failure behavior | Keep job specs focused on orchestration and service/model specs focused on state transitions |
+
+---
+
+## Documentation / Operational Notes
+
+- No user-facing documentation changes are expected.
+- If implementation significantly changes the crate section boundary, update `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md` only after the new pattern is proven by tests.
+- Before PR review, run the repository's layered review extensions from `compound-engineering.local.md`, especially `layered-rails`, Rails reviewer, and security sentinel.
+
+---
+
+## Sources & References
+
+- Latest layered-rails audit from the current session
+- Historical plan: `docs/plans/2026-05-13-002-refactor-layered-architecture-plan.md`
+- Historical requirements: `docs/brainstorms/layered-architecture-fixes-requirements.md`
+- Product strategy: `STRATEGY.md`
+- Local guidance: `AGENTS.md`, `compound-engineering.local.md`
+- Institutional learning: `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`
+- Institutional learning: `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`

--- a/spec/jobs/enrichment_job_spec.rb
+++ b/spec/jobs/enrichment_job_spec.rb
@@ -10,65 +10,16 @@ RSpec.describe EnrichmentJob do
       allow(EnrichmentService).to receive(:new).and_return(service)
     end
 
-    it "calls both enrichment methods on EnrichmentService" do
-      allow(service).to receive(:enrich_releases)
-      allow(service).to receive(:enrich_music_brainz_images)
-      expect(service).to receive(:enrich_releases).with(store, listing_ids: [ 1, 2 ])
-      expect(service).to receive(:enrich_music_brainz_images).with(store)
+    it "calls the enrichment orchestration entry point" do
+      expect(service).to receive(:enrich_store).with(store, listing_ids: [ 1, 2 ])
 
       described_class.new.perform(store.id, listing_ids: [ 1, 2 ])
     end
 
     it "passes listing_ids as nil when not provided" do
-      allow(service).to receive(:enrich_releases)
-      allow(service).to receive(:enrich_music_brainz_images)
-      expect(service).to receive(:enrich_releases).with(store, listing_ids: nil)
-      expect(service).to receive(:enrich_music_brainz_images).with(store)
+      expect(service).to receive(:enrich_store).with(store, listing_ids: nil)
 
       described_class.new.perform(store.id)
-    end
-
-    describe "enrichment status transitions" do
-      before do
-        allow(service).to receive(:enrich_releases)
-        allow(service).to receive(:enrich_music_brainz_images)
-        # Make the job use our store instance so we can verify update! calls
-        allow(Store).to receive(:find).with(store.id).and_return(store)
-      end
-
-      it "sets enrichment_status to enriching at start" do
-        expect(store).to receive(:update!).with(hash_including(enrichment_status: "enriching")).ordered
-        expect(store).to receive(:update!).with(hash_including(enrichment_status: "idle", last_enriched_at: instance_of(ActiveSupport::TimeWithZone))).ordered
-
-        described_class.new.perform(store.id)
-      end
-
-      it "sets last_enriched_at on successful completion" do
-        allow(store).to receive(:update!).and_call_original
-
-        described_class.new.perform(store.id)
-
-        expect(store.reload.last_enriched_at).to be_within(1.second).of(Time.current)
-      end
-
-      it "stays idle when enrichment completes despite individual API errors in EnrichmentService" do
-        allow(store).to receive(:update!).and_call_original
-
-        described_class.new.perform(store.id)
-
-        expect(store.reload.enrichment_status).to eq("idle")
-      end
-
-      it "sets enrichment_status to failed and re-raises on hard failure" do
-        allow(service).to receive(:enrich_releases).and_raise(StandardError.new("boom"))
-        allow(store).to receive(:update!).and_call_original
-
-        expect {
-          described_class.new.perform(store.id)
-        }.to raise_error(StandardError, "boom")
-
-        expect(store.reload.enrichment_status).to eq("failed")
-      end
     end
   end
 end

--- a/spec/jobs/full_store_sync_job_spec.rb
+++ b/spec/jobs/full_store_sync_job_spec.rb
@@ -18,7 +18,12 @@ RSpec.describe FullStoreSyncJob do
     allow(StoreSyncService).to receive(:new).with(store).and_return(sync_service)
     # Simulate service managing sync status internally.
     allow(sync_service).to receive(:sync) do |**|
-      store.update!(sync_status: "idle", last_synced_at: Time.current)
+      store.mark_sync_succeeded!(
+        last_synced_at: Time.current,
+        total_listings: store.listings.count,
+        catalog_coverage: sync_result.catalog_coverage,
+        inventory_page_count: sync_result.inventory_page_count
+      )
       sync_result
     end
   end
@@ -70,6 +75,12 @@ RSpec.describe FullStoreSyncJob do
       travel_to(Time.zone.parse("2026-05-05 12:00:00")) do
         allow(sync_service).to receive(:sync) do
           create(:listing, store:, format: "LP", last_seen_at: 2.seconds.from_now)
+          store.mark_sync_succeeded!(
+            last_synced_at: Time.current,
+            total_listings: store.listings.count,
+            catalog_coverage: sync_result.catalog_coverage,
+            inventory_page_count: sync_result.inventory_page_count
+          )
           travel 5.seconds
           sync_result
         end
@@ -80,6 +91,15 @@ RSpec.describe FullStoreSyncJob do
         expect(store.last_synced_at).to eq(Time.zone.parse("2026-05-05 12:00:00"))
         expect(store.listings.available.count).to eq(1)
       end
+    end
+
+    it "leaves sync metadata ownership with StoreSyncService" do
+      described_class.new.perform(store.id)
+
+      store.reload
+      expect(store.catalog_coverage).to eq("partial")
+      expect(store.inventory_page_count).to eq(101)
+      expect(store.total_listings).to eq(0)
     end
   end
 end

--- a/spec/models/record_scorer_spec.rb
+++ b/spec/models/record_scorer_spec.rb
@@ -126,4 +126,21 @@ RSpec.describe RecordScorer do
       end
     end
   end
+
+  describe "daily selection signals" do
+    it "exposes good condition using the shared condition model" do
+      scorer = build(:record_scorer, genre_counts: { "Rock" => 10 }, today: Date.new(2026, 5, 5))
+
+      expect(scorer.good_condition?(listing(condition: "Near Mint"))).to be(true)
+      expect(scorer.good_condition?(listing(condition: "Generic"))).to be(false)
+    end
+
+    it "exposes desirability using the shared want/have model" do
+      scorer = build(:record_scorer, genre_counts: { "Jazz" => 10 }, today: Date.new(2026, 5, 5))
+
+      expect(scorer.desirable?(listing(want_count: 800, have_count: 300, genres: [ "Jazz" ]))).to be(true)
+      expect(scorer.desirable?(listing(want_count: 100, have_count: 500, genres: [ "Jazz" ]))).to be(false)
+      expect(scorer.desirable?(listing(want_count: 0, have_count: 0, genres: [ "Jazz" ]))).to be(false)
+    end
+  end
 end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -51,4 +51,61 @@ RSpec.describe Store, type: :model do
       expect(Store.with_discogs_username("anything").first).to be_nil
     end
   end
+
+  describe "sync lifecycle" do
+    it "marks sync success with supplied metadata" do
+      store = create(:store, sync_status: "failed", last_sync_error: "boom", last_sync_error_at: 1.hour.ago)
+      synced_at = Time.zone.parse("2026-05-05 12:00:00")
+
+      store.mark_sync_succeeded!(last_synced_at: synced_at, catalog_coverage: "partial", inventory_page_count: 101)
+
+      expect(store.reload).to have_attributes(
+        sync_status: "idle",
+        last_sync_error: nil,
+        last_sync_error_at: nil,
+        last_synced_at: synced_at,
+        catalog_coverage: "partial",
+        inventory_page_count: 101
+      )
+    end
+
+    it "marks sync failure with summarized error details" do
+      store = create(:store)
+      error = RuntimeError.new("discogs timeout")
+
+      store.mark_sync_failed!(error)
+
+      expect(store.reload.sync_status).to eq("failed")
+      expect(store.last_sync_error).to include("RuntimeError: discogs timeout")
+      expect(store.last_sync_error_at).to be_present
+    end
+  end
+
+  describe "enrichment lifecycle" do
+    it "marks enrichment as started" do
+      store = create(:store)
+
+      store.mark_enrichment_started!
+
+      expect(store.reload.enrichment_status).to eq("enriching")
+    end
+
+    it "marks enrichment as succeeded" do
+      store = create(:store, enrichment_status: "enriching", last_enriched_at: nil)
+      finished_at = Time.zone.parse("2026-05-05 12:00:00")
+
+      store.mark_enrichment_succeeded!(finished_at:)
+
+      expect(store.reload.enrichment_status).to eq("idle")
+      expect(store.last_enriched_at).to eq(finished_at)
+    end
+
+    it "marks enrichment as failed" do
+      store = create(:store, enrichment_status: "enriching")
+
+      store.mark_enrichment_failed!
+
+      expect(store.reload.enrichment_status).to eq("failed")
+    end
+  end
 end

--- a/spec/presenters/crate_presenter_spec.rb
+++ b/spec/presenters/crate_presenter_spec.rb
@@ -180,4 +180,33 @@ RSpec.describe CratePresenter do
       expect(genre_slugs).to be_empty
     end
   end
+
+  describe "#build_storefront_sections" do
+    let(:picks) { fake_curated_crate(slug: "picks", name: "Milkcrate Picks", listings: [ fake_listing(id: 1) ]) }
+    let(:featured) { fake_curated_crate(slug: "new-arrivals", name: "New Arrivals", listings: [ fake_listing(id: 2) ]) }
+    let(:genre) { fake_curated_crate(slug: "jazz", name: "Jazz", listings: [ fake_listing(id: 3) ]) }
+
+    it "assigns storefront section keys in display order" do
+      sections = described_class.new(fake_store).build_storefront_sections(
+        picks:,
+        featured: [ featured ],
+        genres: [ genre ]
+      )
+
+      expect(sections.map { |section| section[:key] }).to eq(%w[picks_wall featured_crates genre_grid])
+      expect(sections.first.dig(:crate, :slug)).to eq("picks")
+      expect(sections.second[:crates].map { |crate| crate[:slug] }).to eq([ "new-arrivals" ])
+      expect(sections.third[:crates].map { |crate| crate[:slug] }).to eq([ "jazz" ])
+    end
+
+    it "omits the featured section when no featured crates are present" do
+      sections = described_class.new(fake_store).build_storefront_sections(
+        picks:,
+        featured: [],
+        genres: [ genre ]
+      )
+
+      expect(sections.map { |section| section[:key] }).to eq(%w[picks_wall genre_grid])
+    end
+  end
 end

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Stores", type: :request do
       include_examples "resolves store at slug", "TESTSTORE"
 
       before do
-        curation = instance_double(StorefrontCuration, crates: [], storefront_sections: [])
+        curation = instance_double(StorefrontCuration, crates: [], storefront_groups: { picks: CuratedCrate.new(slug: "picks", name: "Milkcrate Picks", listings: []), featured: [], genres: [] })
         presenter_double = instance_double(CratePresenter,
           store_props: { id: store.id, name: store.name },
           build_crates: [],

--- a/spec/services/admin/store_health_spec.rb
+++ b/spec/services/admin/store_health_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+
+RSpec.describe Admin::StoreHealth do
+  include ActiveSupport::Testing::TimeHelpers
+
+  around do |example|
+    travel_to(Time.zone.parse("2026-05-16 12:00:00")) { example.run }
+  end
+
+  def health_for(store)
+    described_class.new(store).props
+  end
+
+  it "marks a recently synced and enriched near-complete store as healthy" do
+    store = build_stubbed(:store,
+      sync_status: "idle",
+      enrichment_status: "idle",
+      catalog_coverage: "near_complete",
+      last_synced_at: 2.hours.ago,
+      last_enriched_at: 1.hour.ago,
+      last_sync_error: nil,
+      last_sync_error_at: nil
+    )
+
+    expect(health_for(store)).to include(
+      key: "healthy",
+      label: "Healthy",
+      severity: "good",
+      reasons: [ "Sync and enrichment are current" ]
+    )
+  end
+
+  it "prioritizes failed sync over other signals" do
+    store = build_stubbed(:store,
+      sync_status: "failed",
+      enrichment_status: "enriching",
+      catalog_coverage: "partial",
+      last_synced_at: 2.days.ago,
+      last_sync_error: "Discogs timeout",
+      last_sync_error_at: 10.minutes.ago
+    )
+
+    expect(health_for(store)).to include(
+      key: "failed",
+      label: "Needs attention",
+      severity: "danger",
+      reasons: [ "Sync failed" ],
+      has_sync_error: true,
+      last_sync_error_summary: "Discogs timeout"
+    )
+  end
+
+  it "prioritizes failed enrichment over stale or partial signals" do
+    store = build_stubbed(:store,
+      sync_status: "idle",
+      enrichment_status: "failed",
+      catalog_coverage: "partial",
+      last_synced_at: 2.days.ago,
+      last_enriched_at: 2.days.ago
+    )
+
+    expect(health_for(store)).to include(
+      key: "failed",
+      severity: "danger",
+      reasons: [ "Enrichment failed" ]
+    )
+  end
+
+  it "marks syncing stores as processing even when timestamps are stale" do
+    store = build_stubbed(:store,
+      sync_status: "syncing",
+      enrichment_status: "idle",
+      catalog_coverage: "partial",
+      last_synced_at: 3.days.ago,
+      last_enriched_at: 3.days.ago
+    )
+
+    expect(health_for(store)).to include(
+      key: "processing",
+      label: "Processing",
+      severity: "working",
+      reasons: [ "Sync in progress" ]
+    )
+  end
+
+  it "marks enriching stores as processing" do
+    store = build_stubbed(:store,
+      sync_status: "idle",
+      enrichment_status: "enriching",
+      catalog_coverage: "near_complete",
+      last_synced_at: 1.hour.ago,
+      last_enriched_at: 2.days.ago
+    )
+
+    expect(health_for(store)).to include(
+      key: "processing",
+      severity: "working",
+      reasons: [ "Enrichment in progress" ]
+    )
+  end
+
+  it "marks stores with missing readiness as processing" do
+    store = build_stubbed(:store,
+      sync_status: "idle",
+      enrichment_status: "idle",
+      catalog_coverage: "unknown",
+      last_synced_at: nil,
+      last_enriched_at: nil
+    )
+
+    expect(health_for(store)).to include(
+      key: "processing",
+      severity: "working",
+      reasons: [ "Waiting on first sync", "Waiting on first enrichment" ]
+    )
+  end
+
+  it "marks stale sync or enrichment timestamps as stale" do
+    store = build_stubbed(:store,
+      sync_status: "idle",
+      enrichment_status: "idle",
+      catalog_coverage: "near_complete",
+      last_synced_at: 2.days.ago,
+      last_enriched_at: 1.hour.ago
+    )
+
+    expect(health_for(store)).to include(
+      key: "stale",
+      label: "Stale",
+      severity: "warning",
+      reasons: [ "Sync is stale" ]
+    )
+  end
+
+  it "marks partial catalog coverage as partial when no higher-priority signal exists" do
+    store = build_stubbed(:store,
+      sync_status: "idle",
+      enrichment_status: "idle",
+      catalog_coverage: "partial",
+      last_synced_at: 1.hour.ago,
+      last_enriched_at: 1.hour.ago
+    )
+
+    expect(health_for(store)).to include(
+      key: "partial",
+      label: "Partial coverage",
+      severity: "warning",
+      reasons: [ "Inventory coverage is partial" ]
+    )
+  end
+end

--- a/spec/services/daily_selection_service_spec.rb
+++ b/spec/services/daily_selection_service_spec.rb
@@ -11,13 +11,21 @@ RSpec.describe DailySelectionService do
     it "creates a DailySelection for the given date" do
       make_listing
       expect {
-        described_class.new(store).generate(date: Date.today)
+        described_class.new(store).generate(date: Date.new(2026, 5, 1))
       }.to change(DailySelection, :count).by(1)
+    end
+
+    it "creates or updates the selection for the supplied date" do
+      make_listing
+
+      selection = described_class.new(store).generate(date: Date.new(2026, 4, 1))
+
+      expect(selection.selected_on).to eq(Date.new(2026, 4, 1))
     end
 
     it "returns a DailySelection with listing_ids" do
       listing = make_listing
-      result = described_class.new(store).generate(date: Date.today)
+      result = described_class.new(store).generate(date: Date.new(2026, 5, 1))
 
       expect(result).to be_a(DailySelection)
       expect(result.listing_ids).to include(listing.id)
@@ -25,10 +33,11 @@ RSpec.describe DailySelectionService do
 
     it "is idempotent — calling twice on same date updates instead of duplicating" do
       make_listing
-      described_class.new(store).generate(date: Date.today)
+      date = Date.new(2026, 5, 1)
+      described_class.new(store).generate(date:)
 
       expect {
-        described_class.new(store).generate(date: Date.today)
+        described_class.new(store).generate(date:)
       }.not_to change(DailySelection, :count)
     end
 
@@ -38,7 +47,7 @@ RSpec.describe DailySelectionService do
       stub_const("DailySelectionService::SELECTION_SIZE", 3)
       3.times { make_listing }
 
-      result = described_class.new(store).generate(date: Date.today)
+      result = described_class.new(store).generate(date: Date.new(2026, 5, 1))
       expect(result.listing_ids.size).to be <= 3
     end
 
@@ -50,15 +59,29 @@ RSpec.describe DailySelectionService do
         listings = 5.times.map { make_listing }
         yesterday = DailySelection.create!(
           store: store,
-          selected_on: Date.today - 1,
+          selected_on: Date.new(2026, 4, 30),
           listing_ids: listings.map(&:id)
         )
 
-        result = described_class.new(store).generate(date: Date.today)
+        result = described_class.new(store).generate(date: Date.new(2026, 5, 1))
 
         # At least some carry-over should be present
         overlap = (result.listing_ids & yesterday.listing_ids).size
         expect(overlap).to be >= 1
+      end
+
+      it "uses the day before the supplied date for carry-over" do
+        stub_const("DailySelectionService::SELECTION_SIZE", 10)
+        stub_const("DailySelectionService::OVERLAP_FRACTION", 0.5)
+
+        carry_listing = make_listing
+        system_yesterday_listing = make_listing
+        DailySelection.create!(store:, selected_on: Date.new(2026, 1, 9), listing_ids: [ carry_listing.id ])
+        DailySelection.create!(store:, selected_on: Date.current - 1, listing_ids: [ system_yesterday_listing.id ])
+
+        result = described_class.new(store).generate(date: Date.new(2026, 1, 10))
+
+        expect(result.listing_ids).to include(carry_listing.id)
       end
     end
 
@@ -66,10 +89,11 @@ RSpec.describe DailySelectionService do
       it "gives higher weight to recently listed records" do
         service = described_class.new(store)
 
-        new_listing = make_listing(listed_at: 1.day.ago)
-        old_listing = make_listing(listed_at: 200.days.ago)
+        date = Date.new(2026, 5, 1)
+        new_listing = make_listing(listed_at: date - 1.day)
+        old_listing = make_listing(listed_at: date - 200.days)
 
-        scored = service.send(:score_listings, store.listings.where(id: [ new_listing.id, old_listing.id ]))
+        scored = service.send(:score_listings, store.listings.where(id: [ new_listing.id, old_listing.id ]), date:)
         scores = scored.to_h { |l, w| [ l.id, w ] }
 
         expect(scores[new_listing.id]).to be > scores[old_listing.id]
@@ -83,14 +107,52 @@ RSpec.describe DailySelectionService do
 
         DailySelection.create!(
           store: store,
-          selected_on: Date.today,
+          selected_on: Date.new(2026, 5, 1),
           listing_ids: [ seen_listing.id ]
         )
 
-        scored = service.send(:score_listings, store.listings.where(id: [ seen_listing.id, unseen_listing.id ]))
+        scored = service.send(:score_listings, store.listings.where(id: [ seen_listing.id, unseen_listing.id ]), date: Date.new(2026, 5, 1))
         scores = scored.to_h { |l, w| [ l.id, w ] }
 
         expect(scores[unseen_listing.id]).to be > scores[seen_listing.id]
+      end
+
+      it "uses the supplied date for recent-listing boosts" do
+        service = described_class.new(store)
+        requested_date = Date.new(2026, 1, 10)
+        listing = make_listing(listed_at: Date.new(2026, 1, 1))
+
+        requested_score = service.send(:score_listings, store.listings.where(id: listing.id), date: requested_date).first.last
+        later_score = service.send(:score_listings, store.listings.where(id: listing.id), date: requested_date + 120.days).first.last
+
+        expect(requested_score).to be > later_score
+      end
+
+      it "uses scorer-derived quality and desirability signals" do
+        service = described_class.new(store)
+        strong = make_listing(condition: "Near Mint", want_count: 800, have_count: 300, genres: [ "Jazz" ])
+        weak = make_listing(condition: "Generic", want_count: 0, have_count: 0, genres: [ "Jazz" ])
+
+        scored = service.send(:score_listings, store.listings.where(id: [ strong.id, weak.id ]), date: Date.new(2026, 5, 1))
+        scores = scored.to_h { |l, w| [ l.id, w ] }
+
+        expect(scores[strong.id]).to be > scores[weak.id]
+      end
+
+      it "uses a recent-selection window relative to the supplied date" do
+        service = described_class.new(store)
+        listing = make_listing
+
+        DailySelection.create!(
+          store:,
+          selected_on: Date.new(2026, 1, 8),
+          listing_ids: [ listing.id ]
+        )
+
+        recent_score = service.send(:score_listings, store.listings.where(id: listing.id), date: Date.new(2026, 1, 10)).first.last
+        old_score = service.send(:score_listings, store.listings.where(id: listing.id), date: Date.new(2026, 2, 1)).first.last
+
+        expect(old_score).to be > recent_score
       end
     end
   end

--- a/spec/services/discogs_seller_lookup_spec.rb
+++ b/spec/services/discogs_seller_lookup_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe DiscogsSellerLookup do
+  subject(:lookup) { described_class.new(username, client: client, cache: cache) }
+
+  let(:client) { instance_double(DiscogsClient) }
+  let(:cache) { ActiveSupport::Cache::MemoryStore.new }
+
+  describe "#call" do
+    context "with a valid username that exists on Discogs" do
+      let(:username) { "  RealSeller  " }
+
+      before do
+        allow(client).to receive(:seller_profile).with("realseller").and_return(
+          { "name" => "Real Seller", "username" => "realseller", "avatar_url" => "https://example.com/avatar.jpg" }
+        )
+      end
+
+      it "normalizes the username and returns seller info" do
+        expect(lookup.call).to eq(
+          found: true,
+          seller_name: "Real Seller",
+          avatar_url: "https://example.com/avatar.jpg"
+        )
+      end
+
+      it "caches found results by normalized username" do
+        expect(client).to receive(:seller_profile).with("realseller").once.and_return(
+          { "name" => "Real Seller", "username" => "realseller", "avatar_url" => "https://example.com/avatar.jpg" }
+        )
+
+        2.times do
+          expect(lookup.call[:found]).to be(true)
+        end
+      end
+    end
+
+    context "with invalid usernames" do
+      before do
+        allow(client).to receive(:seller_profile)
+      end
+
+      [
+        "ab",
+        "a" * 41,
+        "bad!slug",
+        "-badstart",
+        "badend_",
+        "admin"
+      ].each do |invalid_username|
+        it "rejects #{invalid_username.inspect}" do
+          result = described_class.new(invalid_username, client: client, cache: cache).call
+
+          expect(result).to eq(found: false, reason: "invalid_slug")
+          expect(client).not_to have_received(:seller_profile)
+        end
+      end
+    end
+
+    context "when Discogs raises an upstream error" do
+      let(:username) { "rate-limited" }
+
+      before do
+        allow(client).to receive(:seller_profile).with("rate-limited").and_raise(
+          DiscogsClient::RateLimitError, "Discogs rate limit hit"
+        )
+      end
+
+      it "returns an API error without caching the result" do
+        2.times do
+          expect(lookup.call).to eq(found: false, reason: "api_error")
+        end
+
+        expect(client).to have_received(:seller_profile).twice
+      end
+    end
+
+    context "when Discogs raises a generic API error" do
+      let(:username) { "nonexistent" }
+
+      before do
+        allow(client).to receive(:seller_profile).with("nonexistent").and_raise(
+          DiscogsClient::ApiError, "Discogs API error: 404 - Not Found"
+        )
+      end
+
+      it "returns an API error" do
+        expect(lookup.call).to eq(found: false, reason: "api_error")
+      end
+    end
+
+    context "when Faraday raises an upstream error" do
+      let(:username) { "faraday-error" }
+
+      before do
+        allow(client).to receive(:seller_profile).with("faraday-error").and_raise(
+          Faraday::ConnectionFailed, "connection failed"
+        )
+      end
+
+      it "returns an API error" do
+        expect(lookup.call).to eq(found: false, reason: "api_error")
+      end
+    end
+  end
+end

--- a/spec/services/enrichment_service_spec.rb
+++ b/spec/services/enrichment_service_spec.rb
@@ -11,6 +11,44 @@ RSpec.describe EnrichmentService do
     allow(MusicBrainzClient).to receive(:new).and_return(musicbrainz)
   end
 
+  describe "#enrich_store" do
+    it "sets enrichment lifecycle state around both enrichment phases" do
+      allow(service).to receive(:enrich_releases)
+      allow(service).to receive(:enrich_music_brainz_images)
+
+      service.enrich_store(store, listing_ids: [ 1, 2 ])
+
+      expect(service).to have_received(:enrich_releases).with(store, listing_ids: [ 1, 2 ])
+      expect(service).to have_received(:enrich_music_brainz_images).with(store)
+      expect(store.reload.enrichment_status).to eq("idle")
+      expect(store.last_enriched_at).to be_within(1.second).of(Time.current)
+    end
+
+    it "marks enrichment failed and re-raises on hard failure" do
+      allow(service).to receive(:enrich_releases).and_raise(StandardError.new("boom"))
+      allow(service).to receive(:enrich_music_brainz_images)
+
+      expect {
+        service.enrich_store(store)
+      }.to raise_error(StandardError, "boom")
+
+      expect(store.reload.enrichment_status).to eq("failed")
+      expect(service).not_to have_received(:enrich_music_brainz_images)
+    end
+
+    it "finishes idle when individual API errors are handled inside enrichment phases" do
+      listing = create(:listing, store:, discogs_release_id: "123", format: "Vinyl")
+      Release.create!(discogs_release_id: "123", enriched_at: 8.days.ago, want_count: 0, have_count: 0)
+      allow(discogs).to receive(:release).with("123").and_raise(DiscogsClient::ApiError, "Not found")
+      allow(musicbrainz).to receive(:search_release)
+      expect(Rails.logger).to receive(:warn).with(/API error/)
+
+      service.enrich_store(store, listing_ids: [ listing.id ])
+
+      expect(store.reload.enrichment_status).to eq("idle")
+    end
+  end
+
   describe "#enrich_releases" do
     let!(:listing) do
       create(:listing, store:, discogs_release_id: "123", format: "Vinyl")

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe StorefrontCuration do
     end
   end
 
-  describe "#storefront_sections" do
-    it "returns explicit sections in storefront order" do
+  describe "#storefront_groups" do
+    it "returns grouped crates without storefront section keys" do
       travel_to(Time.zone.parse("2026-05-05 12:00:00")) do
         store = create(:store)
         picks = lp_listings(store, count: 1, genres: [ "Jazz" ], styles: [ "Bop" ], listed_at: 10.days.ago)
@@ -110,18 +110,18 @@ RSpec.describe StorefrontCuration do
           featured: [ na_crate, tm_crate ]
         )
 
-        sections = curation.storefront_sections
+        groups = curation.storefront_groups
 
-        expect(sections.map { |section| section[:key] }).to eq(%w[picks_wall featured_crates genre_grid])
-        expect(section_crate(sections[0]).slug).to eq("picks")
-        expect(section_crates(sections[1]).map(&:slug)).to eq(%w[new-arrivals thematic])
-        expect(section_crates(sections[1]).first.listings).to eq(fresh)
-        expect(section_crates(sections[2]).map(&:slug)).to eq([ "rock" ])
-        expect(section_crates(sections[2]).first.listings).to eq(genre_only)
+        expect(groups.keys).to eq(%i[picks featured genres])
+        expect(groups[:picks].slug).to eq("picks")
+        expect(groups[:featured].map(&:slug)).to eq(%w[new-arrivals thematic])
+        expect(groups[:featured].first.listings).to eq(fresh)
+        expect(groups[:genres].map(&:slug)).to eq([ "rock" ])
+        expect(groups[:genres].first.listings).to eq(genre_only)
       end
     end
 
-    it "dedupes top down across picks featured and genre sections" do
+    it "dedupes top down across picks featured and genre groups" do
       travel_to(Time.zone.parse("2026-05-05 12:00:00")) do
         store = create(:store)
         pick = lp_listings(store, count: 1, genres: [ "Jazz" ], styles: [ "Bop" ], listed_at: 10.days.ago)
@@ -142,9 +142,9 @@ RSpec.describe StorefrontCuration do
           featured: [ na_crate, tm_crate ]
         )
 
-        sections = curation.storefront_sections
-        featured_records = section_crates(sections[1]).flat_map(&:listings)
-        genre_records = section_crates(sections[2]).flat_map(&:listings)
+        groups = curation.storefront_groups
+        featured_records = groups[:featured].flat_map(&:listings)
+        genre_records = groups[:genres].flat_map(&:listings)
 
         expect(featured_records).not_to include(pick)
         expect(genre_records).not_to include(*pick, *fresh, *themed)
@@ -152,7 +152,7 @@ RSpec.describe StorefrontCuration do
       end
     end
 
-    it "omits featured row when a featured crate underfills" do
+    it "returns an empty featured group when a featured crate underfills" do
       travel_to(Time.zone.parse("2026-05-05 12:00:00")) do
         store = create(:store)
         pick = lp_listings(store, count: 1, genres: [ "Jazz" ], styles: [ "Bop" ])
@@ -170,10 +170,10 @@ RSpec.describe StorefrontCuration do
           featured: [] # underfilled — featured row omitted
         )
 
-        sections = curation.storefront_sections
+        groups = curation.storefront_groups
 
-        expect(sections.map { |section| section[:key] }).to eq(%w[picks_wall genre_grid])
-        expect(section_crates(sections.last).flat_map(&:listings)).to include(fresh.first, themed.first, genre.first)
+        expect(groups[:featured]).to eq([])
+        expect(groups[:genres].flat_map(&:listings)).to include(fresh.first, themed.first, genre.first)
       end
     end
 
@@ -188,11 +188,11 @@ RSpec.describe StorefrontCuration do
         curation_a = described_class.new(store)
         curation_b = described_class.new(store)
 
-        sections_a = curation_a.storefront_sections.find { |section| section[:key] == "featured_crates" }
-        sections_b = curation_b.storefront_sections.find { |section| section[:key] == "featured_crates" }
+        groups_a = curation_a.storefront_groups
+        groups_b = curation_b.storefront_groups
 
-        thematic_a = section_crates(sections_a).last if sections_a
-        thematic_b = section_crates(sections_b).last if sections_b
+        thematic_a = groups_a[:featured].last
+        thematic_b = groups_b[:featured].last
 
         if thematic_a && thematic_b
           expect(thematic_a.name).to eq(thematic_b.name)


### PR DESCRIPTION
## Summary

- Extract Discogs seller lookup validation, caching, upstream lookup, and API-error mapping into `DiscogsSellerLookup`.
- Move sync/enrichment lifecycle ownership out of jobs and into service/domain APIs.
- Extract admin store health classification into `Admin::StoreHealth` while preserving dashboard props.
- Align daily selection scoring with `RecordScorer` condition/desirability signals and thread the supplied generation date through scoring.
- Move storefront section key assignment into `CratePresenter` so `StorefrontCuration` returns grouped curated crates.

## Testing

- `bundle exec rspec`
- `bundle exec rubocop`

## Review Notes

- Inline correctness, layered Rails, and security review completed in Codex. The full multi-agent `ce-code-review` pipeline was not run because this session did not have explicit permission to spawn reviewer agents.
- No known residual actionable findings.

## Post-Deploy Monitoring & Validation

Validation window: first 24 hours after deploy. Owner: deployer.

Log queries/search terms:
- `DiscogsSellerLookup`, `DiscogsClient::RateLimitError`, `Discogs API error`
- `[FullStoreSyncJob]`, `[EnrichmentJob]`, `[EnrichmentService]`
- `MarketingPreviewPresenter`

Healthy signals:
- Discogs lookup requests continue returning HTTP 200 with existing JSON shapes for found, invalid, and upstream-error responses.
- Store sync jobs finish with `sync_status=idle`, populated sync metadata, and expected enrichment/daily curation enqueue behavior.
- Enrichment jobs transition stores back to `idle` and update `last_enriched_at` after successful phases.
- Admin dashboard and storefront pages render without prop-shape errors.

Failure signals and triggers:
- Increased lookup `api_error` responses or unexpected 500s from `/api/discogs/lookup/*`.
- Stores stuck in `syncing` or `enriching` after job completion windows.
- Admin dashboard/storefront Inertia render errors involving missing `health`, `storefront_sections`, or crate fields.
- Daily selections created for the wrong `selected_on` date.

Mitigation:
- Roll back this PR if request/job failures correlate with deployment and cannot be corrected by retrying failed jobs.

---

Compound Engineered with Codex.