### PR TITLE
feat(admin): add direct Discogs onboarding

### DIFF
--- a/app/controllers/admin/discogs_lookups_controller.rb
+++ b/app/controllers/admin/discogs_lookups_controller.rb
@@ -1,0 +1,72 @@
+class Admin::DiscogsLookupsController < Admin::BaseController
+  def show
+    username = params[:username].to_s.strip
+    normalized_username = username.downcase
+    lookup = DiscogsSellerLookup.new(username).call
+
+    unless lookup[:found]
+      render json: failed_lookup_response(lookup), status: :ok
+      return
+    end
+
+    if (store = Store.with_discogs_username(normalized_username).first)
+      render json: already_active_response(normalized_username, store), status: :ok
+      return
+    end
+
+    if (applicant = Waitlist.with_discogs_username(normalized_username).first)
+      render json: existing_applicant_response(normalized_username, applicant), status: :ok
+      return
+    end
+
+    render json: creatable_response(normalized_username, lookup), status: :ok
+  end
+
+  private
+
+  def failed_lookup_response(lookup)
+    reason = lookup[:reason].to_s
+
+    {
+      status: reason == "invalid_slug" ? "invalid" : "lookup_error",
+      creatable: false,
+      reason:
+    }
+  end
+
+  def creatable_response(username, lookup)
+    {
+      status: "creatable",
+      creatable: true,
+      username:,
+      seller_name: lookup[:seller_name],
+      avatar_url: lookup[:avatar_url]
+    }
+  end
+
+  def already_active_response(username, store)
+    {
+      status: "already_active",
+      creatable: false,
+      username:,
+      store: {
+        id: store.id,
+        name: store.name,
+        discogs_username: store.discogs_username
+      }
+    }
+  end
+
+  def existing_applicant_response(username, applicant)
+    {
+      status: "existing_applicant",
+      creatable: false,
+      username:,
+      applicant: {
+        id: applicant.id,
+        name: applicant.name,
+        discogs_username: applicant.discogs_username
+      }
+    }
+  end
+end

--- a/app/controllers/admin/onboardings_controller.rb
+++ b/app/controllers/admin/onboardings_controller.rb
@@ -12,4 +12,28 @@ class Admin::OnboardingsController < Admin::BaseController
   rescue StoreOnboarding::Error => error
     redirect_to admin_path, alert: error.message
   end
+
+  def direct
+    discogs_username = params[:discogs_username].to_s.strip.downcase
+
+    if discogs_username.blank?
+      redirect_to admin_path, alert: "Discogs username is required"
+      return
+    end
+
+    if Store.with_discogs_username(discogs_username).exists?
+      redirect_to admin_path, alert: "Store already exists for #{discogs_username}"
+      return
+    end
+
+    if Waitlist.with_discogs_username(discogs_username).exists?
+      redirect_to admin_path, alert: "#{discogs_username} already has an applicant. Use the applicant onboarding path."
+      return
+    end
+
+    result = StoreOnboarding.call(discogs_username:, waitlist: nil)
+    redirect_to admin_path, notice: "Onboarding queued for #{result.store.name}"
+  rescue StoreOnboarding::Error => error
+    redirect_to admin_path, alert: error.message
+  end
 end

--- a/app/frontend/pages/admin/dashboard.tsx
+++ b/app/frontend/pages/admin/dashboard.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useRef, useState } from "react"
 import type { AdminApplicantSummary, AdminDashboardProps, AdminHealthSeverity, AdminStoreSummary } from "@/types/inertia"
 import Badge from "@/components/ui/badge"
 import Button from "@/components/ui/button"
@@ -26,7 +26,37 @@ function severityVariant(severity: AdminHealthSeverity) {
   return severity
 }
 
-export default function Dashboard({ active_stores, applicants, notice, alert }: AdminDashboardProps) {
+type AdminDiscogsLookupResponse = {
+  status: "creatable"
+  creatable: true
+  username: string
+  seller_name?: string | null
+  avatar_url?: string | null
+} | {
+  status: "invalid" | "lookup_error"
+  creatable: false
+  reason?: string
+} | {
+  status: "already_active"
+  creatable: false
+  username: string
+  store: {
+    id: number
+    name: string
+    discogs_username: string
+  }
+} | {
+  status: "existing_applicant"
+  creatable: false
+  username: string
+  applicant: {
+    id: number
+    name: string
+    discogs_username: string
+  }
+}
+
+export default function Dashboard({ active_stores, applicants, discogs_onboarding, notice, alert }: AdminDashboardProps) {
   const healthyCount = active_stores.filter((store) => store.health.key === "healthy").length
   const attentionCount = active_stores.filter((store) => ["failed", "stale", "partial"].includes(store.health.key)).length
   const processingCount = active_stores.filter((store) => store.health.key === "processing").length
@@ -61,6 +91,8 @@ export default function Dashboard({ active_stores, applicants, notice, alert }: 
           </div>
         )}
 
+        <DiscogsOnboardingPanel lookupPath={discogs_onboarding.lookup_path} createPath={discogs_onboarding.create_path} />
+
         <section aria-labelledby="active-stores-heading">
           <SectionHeader
             title="Active stores"
@@ -94,6 +126,186 @@ export default function Dashboard({ active_stores, applicants, notice, alert }: 
         </section>
       </div>
     </main>
+  )
+}
+
+function DiscogsOnboardingPanel({ lookupPath, createPath }: { lookupPath: string; createPath: string }) {
+  const [username, setUsername] = useState("")
+  const [lookup, setLookup] = useState<AdminDiscogsLookupResponse | null>(null)
+  const [state, setState] = useState<"idle" | "loading" | "error">("idle")
+  const lookupRequestId = useRef(0)
+  const csrfToken = document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content
+
+  function handleUsernameChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setUsername(event.target.value)
+    setLookup(null)
+    lookupRequestId.current += 1
+    if (state !== "idle") setState("idle")
+  }
+
+  async function handleLookup(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const trimmedUsername = username.trim()
+
+    if (!trimmedUsername) {
+      setLookup({ status: "invalid", creatable: false, reason: "blank" })
+      setState("idle")
+      return
+    }
+
+    setState("loading")
+    setLookup(null)
+    const requestId = lookupRequestId.current + 1
+    lookupRequestId.current = requestId
+
+    try {
+      const url = new URL(lookupPath, window.location.origin)
+      url.searchParams.set("username", trimmedUsername)
+      const response = await fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+      })
+
+      if (!response.ok) throw new Error(`Lookup failed with ${response.status}`)
+
+      const result = await response.json() as AdminDiscogsLookupResponse
+      if (lookupRequestId.current !== requestId) return
+
+      setLookup(result)
+      setState("idle")
+    } catch {
+      if (lookupRequestId.current !== requestId) return
+
+      setLookup(null)
+      setState("error")
+    }
+  }
+
+  return (
+    <section aria-labelledby="discogs-onboarding-heading">
+      <Card>
+        <CardHeader>
+          <CardTitle id="discogs-onboarding-heading">Add Discogs storefront</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]" onSubmit={handleLookup}>
+            <label className="min-w-0">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-mc-text-dim">
+                Discogs username
+              </span>
+              <input
+                type="text"
+                name="discogs_username_lookup"
+                value={username}
+                onChange={handleUsernameChange}
+                className="min-h-10 w-full rounded-md border border-mc-border bg-mc-bg px-3 py-2 text-sm text-mc-text outline-none transition-colors placeholder:text-mc-text-dim focus:border-mc-accent focus:ring-2 focus:ring-mc-accent/40"
+                placeholder="seller-name"
+                autoComplete="off"
+              />
+            </label>
+            <div className="flex items-end">
+              <Button type="submit" variant="secondary" className="w-full md:w-auto" disabled={state === "loading"}>
+                {state === "loading" ? "Checking..." : "Lookup"}
+              </Button>
+            </div>
+          </form>
+
+          {state === "error" && (
+            <LookupMessage tone="danger">
+              Lookup failed. Try again before creating a storefront.
+            </LookupMessage>
+          )}
+
+          {state === "loading" && (
+            <LookupMessage tone="neutral">
+              Checking Discogs and current admin records...
+            </LookupMessage>
+          )}
+
+          {lookup && <LookupResult lookup={lookup} createPath={createPath} csrfToken={csrfToken} />}
+        </CardContent>
+      </Card>
+    </section>
+  )
+}
+
+function LookupResult({
+  lookup,
+  createPath,
+  csrfToken,
+}: {
+  lookup: AdminDiscogsLookupResponse
+  createPath: string
+  csrfToken?: string
+}) {
+  if (lookup.status === "creatable") {
+    return (
+      <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            {lookup.avatar_url && (
+              <img
+                src={lookup.avatar_url}
+                alt=""
+                className="h-12 w-12 shrink-0 rounded-md border border-emerald-500/30 object-cover"
+              />
+            )}
+            <div className="min-w-0">
+              <p className="font-semibold mc-text">{lookup.seller_name || lookup.username}</p>
+              <p className="break-all text-sm text-mc-text-dim">@{lookup.username}</p>
+            </div>
+          </div>
+          <form action={createPath} method="post" className="shrink-0">
+            {csrfToken && <input type="hidden" name="authenticity_token" value={csrfToken} />}
+            <input type="hidden" name="discogs_username" value={lookup.username} />
+            <Button type="submit" className="w-full sm:w-auto">Onboard storefront</Button>
+          </form>
+        </div>
+      </div>
+    )
+  }
+
+  if (lookup.status === "already_active") {
+    return (
+      <LookupMessage tone="warning">
+        {lookup.store.name} is already active as @{lookup.store.discogs_username}.
+      </LookupMessage>
+    )
+  }
+
+  if (lookup.status === "existing_applicant") {
+    return (
+      <LookupMessage tone="warning">
+        {lookup.applicant.name} already applied as @{lookup.applicant.discogs_username}. Use the applicant onboarding path.
+      </LookupMessage>
+    )
+  }
+
+  if (lookup.status === "invalid") {
+    return (
+      <LookupMessage tone="danger">
+        Enter a valid Discogs username before creating a storefront.
+      </LookupMessage>
+    )
+  }
+
+  return (
+    <LookupMessage tone="danger">
+      Discogs could not verify this seller right now. No storefront can be created from this lookup.
+    </LookupMessage>
+  )
+}
+
+function LookupMessage({ tone, children }: { tone: "neutral" | "warning" | "danger"; children: React.ReactNode }) {
+  const classes = {
+    neutral: "border-mc-border bg-mc-bg-raised text-mc-text-dim",
+    warning: "border-amber-500/30 bg-amber-500/10 text-amber-100",
+    danger: "border-red-500/30 bg-red-500/10 text-red-100",
+  }
+
+  return (
+    <p className={`rounded-md border px-3 py-2 text-sm ${classes[tone]}`}>
+      {children}
+    </p>
   )
 }
 

--- a/app/frontend/test/pages/admin_dashboard.test.tsx
+++ b/app/frontend/test/pages/admin_dashboard.test.tsx
@@ -1,11 +1,16 @@
 import React from "react"
-import { describe, expect, it } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { renderWithTier } from "@/test/viewport-test-utils"
 import Dashboard from "@/pages/admin/dashboard"
 import type { AdminDashboardProps } from "@/types/inertia"
 
 const props: AdminDashboardProps = {
+  discogs_onboarding: {
+    lookup_path: "/admin/discogs_lookup",
+    create_path: "/admin/onboarding",
+  },
   active_stores: [
     {
       id: 1,
@@ -88,6 +93,10 @@ const props: AdminDashboardProps = {
 }
 
 describe("Admin dashboard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it("renders active stores before applicants", () => {
     render(<Dashboard {...props} />)
 
@@ -116,22 +125,193 @@ describe("Admin dashboard", () => {
     expect(screen.getByText("applicant@example.com")).toBeInTheDocument()
     expect(screen.getByText("@applicant-records")).toBeInTheDocument()
     expect(screen.getByText("Strong jazz inventory and used LPs.")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Onboard store" })).toBeInTheDocument()
-    expect(document.querySelector("form")?.getAttribute("action")).toBe("/admin/waitlists/10/onboarding")
+    const onboardButton = screen.getByRole("button", { name: "Onboard store" })
+    expect(onboardButton).toBeInTheDocument()
+    expect(onboardButton.closest("form")).toHaveAttribute("action", "/admin/waitlists/10/onboarding")
   })
 
   it("renders useful empty states", () => {
-    render(<Dashboard active_stores={[]} applicants={[]} />)
+    render(<Dashboard {...props} active_stores={[]} applicants={[]} />)
 
     expect(screen.getByText("No stores online yet.")).toBeInTheDocument()
     expect(screen.getByText("No applicants waiting.")).toBeInTheDocument()
   })
 
   it("renders admin flash notices and alerts", () => {
-    render(<Dashboard active_stores={[]} applicants={[]} notice="Onboarding queued" alert="Store already exists" />)
+    render(<Dashboard {...props} active_stores={[]} applicants={[]} notice="Onboarding queued" alert="Store already exists" />)
 
     expect(screen.getByText("Onboarding queued")).toBeInTheDocument()
     expect(screen.getByText("Store already exists")).toBeInTheDocument()
+  })
+
+  it("renders the admin-created storefront lookup panel", () => {
+    render(<Dashboard {...props} />)
+
+    expect(screen.getByRole("heading", { name: "Add Discogs storefront" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Discogs username")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Lookup" })).toBeInTheDocument()
+  })
+
+  it("renders a creatable lookup preview with a separate confirmation form", async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "creatable",
+        creatable: true,
+        username: "realseller",
+        seller_name: "Real Seller",
+        avatar_url: "https://example.com/avatar.jpg",
+      }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { container } = render(<Dashboard {...props} />)
+
+    await user.type(screen.getByLabelText("Discogs username"), "RealSeller")
+    await user.click(screen.getByRole("button", { name: "Lookup" }))
+
+    expect(await screen.findByText("Real Seller")).toBeInTheDocument()
+    expect(screen.getByText("@realseller")).toBeInTheDocument()
+    expect(container.querySelector("img")).toHaveAttribute("src", "https://example.com/avatar.jpg")
+
+    const confirmButton = screen.getByRole("button", { name: "Onboard storefront" })
+    const confirmForm = confirmButton.closest("form")
+    expect(confirmForm).toHaveAttribute("action", "/admin/onboarding")
+    expect(confirmForm?.querySelector("input[name='discogs_username']")).toHaveAttribute("value", "realseller")
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:3000/admin/discogs_lookup?username=RealSeller", {
+      headers: { Accept: "application/json" },
+    })
+  })
+
+  it("does not render confirmation for invalid lookup state", async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "invalid", creatable: false, reason: "invalid_slug" }),
+    }))
+
+    render(<Dashboard {...props} />)
+
+    await user.type(screen.getByLabelText("Discogs username"), "ab")
+    await user.click(screen.getByRole("button", { name: "Lookup" }))
+
+    expect(await screen.findByText("Enter a valid Discogs username before creating a storefront.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
+  })
+
+  it("does not render confirmation for lookup errors", async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "lookup_error", creatable: false, reason: "api_error" }),
+    }))
+
+    render(<Dashboard {...props} />)
+
+    await user.type(screen.getByLabelText("Discogs username"), "broken-store")
+    await user.click(screen.getByRole("button", { name: "Lookup" }))
+
+    expect(await screen.findByText("Discogs could not verify this seller right now. No storefront can be created from this lookup.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
+  })
+
+  it("blocks confirmation when lookup finds an active store", async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "already_active",
+        creatable: false,
+        username: "healthy-records",
+        store: { id: 1, name: "Healthy Records", discogs_username: "healthy-records" },
+      }),
+    }))
+
+    render(<Dashboard {...props} />)
+
+    await user.type(screen.getByLabelText("Discogs username"), "healthy-records")
+    await user.click(screen.getByRole("button", { name: "Lookup" }))
+
+    expect(await screen.findByText("Healthy Records is already active as @healthy-records.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
+  })
+
+  it("blocks confirmation when lookup finds an applicant", async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "existing_applicant",
+        creatable: false,
+        username: "applicant-records",
+        applicant: { id: 10, name: "Applicant Records", discogs_username: "applicant-records" },
+      }),
+    }))
+
+    render(<Dashboard {...props} />)
+
+    await user.type(screen.getByLabelText("Discogs username"), "applicant-records")
+    await user.click(screen.getByRole("button", { name: "Lookup" }))
+
+    expect(await screen.findByText("Applicant Records already applied as @applicant-records. Use the applicant onboarding path.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
+  })
+
+  it("clears stale preview when the username changes", async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: "creatable",
+        creatable: true,
+        username: "realseller",
+        seller_name: "Real Seller",
+      }),
+    }))
+
+    render(<Dashboard {...props} />)
+
+    await user.type(screen.getByLabelText("Discogs username"), "realseller")
+    await user.click(screen.getByRole("button", { name: "Lookup" }))
+    expect(await screen.findByText("Real Seller")).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText("Discogs username"), "-changed")
+
+    await waitFor(() => {
+      expect(screen.queryByText("Real Seller")).not.toBeInTheDocument()
+    })
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
+  })
+
+  it("ignores stale lookup responses after the username changes", async () => {
+    const user = userEvent.setup()
+    let resolveLookup: (value: { ok: boolean; json: () => Promise<unknown> }) => void = () => {}
+    const pendingLookup = new Promise<{ ok: boolean; json: () => Promise<unknown> }>((resolve) => {
+      resolveLookup = resolve
+    })
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pendingLookup))
+
+    render(<Dashboard {...props} />)
+
+    await user.type(screen.getByLabelText("Discogs username"), "realseller")
+    await user.click(screen.getByRole("button", { name: "Lookup" }))
+    await user.type(screen.getByLabelText("Discogs username"), "-changed")
+
+    resolveLookup({
+      ok: true,
+      json: async () => ({
+        status: "creatable",
+        creatable: true,
+        username: "realseller",
+        seller_name: "Real Seller",
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText("Real Seller")).not.toBeInTheDocument()
+    })
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
   })
 
   it("renders the same operational content on compact and wide tiers", () => {
@@ -139,6 +319,7 @@ describe("Admin dashboard", () => {
       const { unmount } = renderWithTier(tier, <Dashboard {...props} />)
 
       expect(screen.getByText("Healthy Records")).toBeInTheDocument()
+      expect(screen.getByRole("heading", { name: "Add Discogs storefront" })).toBeInTheDocument()
       expect(screen.getByText("Applicant Records")).toBeInTheDocument()
       expect(screen.getByRole("button", { name: "Onboard store" })).toBeInTheDocument()
 

--- a/app/frontend/test/pages/page_smoke.test.tsx
+++ b/app/frontend/test/pages/page_smoke.test.tsx
@@ -100,6 +100,10 @@ const featuredProps: FeaturedProps = {
 }
 
 const adminProps: AdminDashboardProps = {
+  discogs_onboarding: {
+    lookup_path: "/admin/discogs_lookup",
+    create_path: "/admin/onboarding",
+  },
   active_stores: [
     {
       id: 1,

--- a/app/frontend/test/pages/responsive_surface_matrix.test.tsx
+++ b/app/frontend/test/pages/responsive_surface_matrix.test.tsx
@@ -132,6 +132,10 @@ const featuredProps: FeaturedProps = {
 }
 
 const adminProps: AdminDashboardProps = {
+  discogs_onboarding: {
+    lookup_path: "/admin/discogs_lookup",
+    create_path: "/admin/onboarding",
+  },
   active_stores: [
     {
       id: 1,

--- a/app/frontend/types/inertia.ts
+++ b/app/frontend/types/inertia.ts
@@ -106,9 +106,15 @@ export interface AdminApplicantSummary {
   submitted_at: string
 }
 
+export interface AdminDiscogsOnboardingConfig {
+  lookup_path: string
+  create_path: string
+}
+
 export interface AdminDashboardProps {
   active_stores: AdminStoreSummary[]
   applicants: AdminApplicantSummary[]
+  discogs_onboarding: AdminDiscogsOnboardingConfig
   notice?: string
   alert?: string
 }

--- a/app/presenters/admin/dashboard_presenter.rb
+++ b/app/presenters/admin/dashboard_presenter.rb
@@ -3,11 +3,19 @@ module Admin
     def props
       {
         active_stores: active_stores,
-        applicants: applicants
+        applicants: applicants,
+        discogs_onboarding: discogs_onboarding
       }
     end
 
     private
+
+    def discogs_onboarding
+      {
+        lookup_path: "/admin/discogs_lookup",
+        create_path: "/admin/onboarding"
+      }
+    end
 
     def active_stores
       Store.order(created_at: :desc).map { |store| StoreHealthPresenter.new(store).props }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   end
 
   get "/admin", to: "admin/dashboard#show"
+  get "/admin/discogs_lookup", to: "admin/discogs_lookups#show", as: :admin_discogs_lookup
   post "/admin/waitlists/:waitlist_id/onboarding", to: "admin/onboardings#create", as: :admin_waitlist_onboarding
 
   root "pages#home"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   get "/admin", to: "admin/dashboard#show"
   get "/admin/discogs_lookup", to: "admin/discogs_lookups#show", as: :admin_discogs_lookup
+  post "/admin/onboarding", to: "admin/onboardings#direct", as: :admin_discogs_onboarding
   post "/admin/waitlists/:waitlist_id/onboarding", to: "admin/onboardings#create", as: :admin_waitlist_onboarding
 
   root "pages#home"

--- a/docs/plans/2026-05-17-002-feat-admin-discogs-onboarding-plan.md
+++ b/docs/plans/2026-05-17-002-feat-admin-discogs-onboarding-plan.md
@@ -1,0 +1,373 @@
+---
+title: "feat: Admin Discogs storefront onboarding"
+type: feat
+status: completed
+date: 2026-05-17
+origin: docs/brainstorms/2026-05-17-admin-discogs-storefront-onboarding-requirements.md
+---
+
+# feat: Admin Discogs Storefront Onboarding
+
+## Summary
+
+Build the admin-created storefront flow by extending the existing admin dashboard with a verified Discogs lookup state and a separate confirmation action. The backend should reuse the existing seller lookup service for Discogs validation, add admin-only duplicate/applicant checks behind `/admin`, and route confirmation through the existing store onboarding operation.
+
+---
+
+## Problem Frame
+
+The current admin dashboard can approve inbound applicants, but manually sourced Discogs sellers still need an awkward workaround: create an applicant first or use lower-level operational tooling. This plan adds a direct admin path while preserving the deliberate preview step needed to avoid queuing sync work for the wrong seller.
+
+---
+
+## Requirements
+
+- R1. `/admin` exposes an admin-only way to enter a Discogs username for a store that did not come through the applicant flow.
+- R2. The lookup reuses the existing Discogs seller verification capability used by the unclaimed-slug invitation flow, including username validity and Discogs existence checks.
+- R3. A successful lookup shows a minimal identity preview: Discogs username plus basic seller identity returned by the lookup, such as display name and avatar when available.
+- R4. The preview is intentionally basic; it is not an inventory review, applicant profile, or seller CRM surface.
+- R5. The lookup blocks or clearly warns when the username is invalid, not found, already has an active store, or already has a current applicant record.
+- R6. Store creation only starts after the admin explicitly confirms from a successful preview state.
+- R7. Confirmation uses the same storefront creation behavior as applicant approval: create the store and queue long-running sync/enrichment work instead of running it synchronously in the admin request.
+- R8. After confirmation, the new store appears in the active-store dashboard lane with existing processing and health states.
+- R9. Existing applicant approval remains unchanged; this flow is an additional admin path for stores the operator sources directly.
+- R10. The admin flow must make the two-step state obvious: lookup first, confirmation second.
+- R11. Success and failure outcomes must be visible on the dashboard without requiring the admin to inspect logs.
+- R12. The flow must remain usable on mobile and desktop within the existing admin dashboard experience.
+
+**Origin actors:** A1 (Admin operator), A2 (Discogs seller), A3 (Active store)
+**Origin flows:** F1 (Admin verifies a sourced seller), F2 (Admin starts storefront onboarding)
+**Origin acceptance examples:** AE1-AE5
+
+---
+
+## Scope Boundaries
+
+- No admin-created applicant records as an intermediate step.
+- No full seller CRM, notes workflow, rejection workflow, or outreach tracking.
+- No detailed inventory review or listing-count preflight before creation.
+- No change to the public application flow or existing applicant approval behavior.
+- No automatic seller communication when an admin-created storefront is queued.
+- No dedicated job/log console replacement inside the admin dashboard.
+
+### Deferred to Follow-Up Work
+
+- Admin deep links or richer controls for applicant records: useful later, but this version only needs to prevent bypassing an already-applied seller.
+- Public lookup endpoint hardening beyond the current service behavior: this plan keeps the public slug invitation flow unchanged.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `DiscogsSellerLookup` already centralizes username plausibility checks, reserved slug rejection, Discogs profile lookup, API-error handling, and caching.
+- `Api::DiscogsLookupController` exposes that lookup for the public unclaimed-slug invitation page; admin-specific Store/Waitlist state should stay behind admin auth instead of being added to the public response.
+- `StoreOnboarding` already accepts `discogs_username:` with optional `waitlist:`, creates the store, and queues `FullStoreSyncJob`.
+- `Admin::OnboardingsController` already handles applicant approval and redirects back to `/admin` with flash notices/alerts.
+- `Admin::DashboardPresenter` already shapes `active_stores` and `applicants`; this is the right boundary for server-rendered admin props.
+- `app/frontend/pages/admin/dashboard.tsx` already renders the admin dashboard with local `Button`, `Card`, `Badge`, `SectionHeader`, and `StatusDot` primitives.
+- Request coverage exists for admin dashboard auth/rendering, applicant onboarding, public Discogs lookup, and the store onboarding service.
+- Frontend coverage exists for admin dashboard content, flash messages, applicant onboarding form, and compact/wide rendering via `renderWithTier`.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md` establishes compact/comfy/wide viewport testing and warns against untested responsive branches.
+- `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md` reinforces using a shared service boundary when multiple entry points need the same behavior.
+
+### External References
+
+- None. Local Rails, Inertia, request-spec, service-spec, and React test patterns are sufficient for this feature.
+
+---
+
+## Key Technical Decisions
+
+- **Admin lookup gets an admin endpoint:** Reuse `DiscogsSellerLookup` for Discogs verification, but add admin-only state checks for existing stores and applicants behind `Admin::BaseController`. This preserves the public lookup contract while giving the dashboard operational state.
+- **Already-applied sellers stay on the applicant path:** When a username already has a Waitlist record, block direct admin-created store creation and point the operator back to applicant onboarding behavior. This avoids two ways to onboard the same seller.
+- **Confirmation reuses `StoreOnboarding`:** The manual admin path should call the same application operation as applicant approval, with `waitlist: nil`, so store creation and job queuing stay consistent.
+- **Dashboard state remains server-authored except for lookup fetch state:** Active store/applicant lists continue to come from Inertia props; the lookup panel owns only transient input, loading, preview, and error states.
+- **Keep the UI inline and basic:** Add the lookup/preview control as an operational dashboard panel, not a modal, wizard, or full applicant editor.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Already-applied behavior: block direct creation and guide the operator to use the existing applicant onboarding path.
+- Lookup reuse boundary: reuse the seller lookup service, not only the public API endpoint, because admin lookup has extra Store/Waitlist state.
+- Preview scope: basic seller identity only; no inventory count or application-like fields.
+
+### Deferred to Implementation
+
+- Exact microcopy for each lookup state: implement with clear operator-facing labels, then tune through frontend tests.
+- Exact placement within the dashboard: default to an inline panel near the top of the admin dashboard; adjust if implementation shows a clearer layout within the existing structure.
+
+---
+
+## Implementation Units
+
+### U1. Admin Storefront Lookup Boundary
+
+**Goal:** Add an authenticated backend lookup path that reuses existing Discogs verification and adds admin-only duplicate/applicant state.
+
+**Requirements:** R1, R2, R3, R5, R9, R11; F1; AE1, AE2, AE3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/controllers/admin/discogs_lookups_controller.rb`
+- Modify: `config/routes.rb`
+- Create: `spec/requests/admin/discogs_lookups_spec.rb`
+- Modify if needed: `app/services/discogs_seller_lookup.rb`
+- Modify if needed: `spec/services/discogs_seller_lookup_spec.rb`
+
+**Approach:**
+- Add an admin-authenticated lookup route for a submitted Discogs username.
+- Delegate Discogs validity/existence checks to `DiscogsSellerLookup` so reserved names, username shape, API failures, and cached profile lookup stay consistent with the unclaimed-slug flow.
+- After the seller lookup succeeds, check normalized username against `Store` and `Waitlist`.
+- Return a UI-ready state that distinguishes: found and creatable, invalid/not found, upstream lookup error, already active store, and existing applicant.
+- Do not add Store/Waitlist state to the public `/api/discogs/lookup/:username` response.
+- If `DiscogsSellerLookup` does not currently return normalized username, either derive normalization consistently in the admin boundary or extend the service in a backward-compatible way.
+
+**Patterns to follow:**
+- `app/controllers/api/discogs_lookup_controller.rb` for seller lookup delegation.
+- `app/controllers/admin/base_controller.rb` for admin auth.
+- `spec/requests/discogs_lookup_spec.rb` for request-level lookup stubbing.
+- `spec/requests/admin/dashboard_spec.rb` and `spec/requests/admin/onboardings_spec.rb` for admin auth expectations.
+
+**Test scenarios:**
+- Happy path: authenticated admin looks up a valid Discogs seller with no Store or Waitlist record and receives a creatable preview with seller name/avatar when available.
+- Happy path: lookup delegates to `DiscogsSellerLookup` rather than duplicating Discogs client behavior in the controller.
+- Error path: unauthenticated lookup request returns unauthorized.
+- Error path: invalid username returns a non-creatable invalid state and does not query Store/Waitlist as if it were valid.
+- Error path: Discogs API error returns a non-creatable lookup-error state and does not show a confirm action.
+- Edge case: username matching an existing Store returns an already-active state with enough data for the dashboard to block duplicate onboarding.
+- Edge case: username matching an existing Waitlist returns an existing-applicant state and blocks direct creation.
+- Integration: public lookup response shape remains unchanged for existing request specs.
+- Covers AE1: valid seller with no Store/Waitlist can reach preview state.
+- Covers AE2: existing active store blocks duplicate onboarding.
+- Covers AE3: existing applicant blocks direct creation.
+
+**Verification:**
+- Admin lookup request specs cover auth, seller lookup reuse, duplicate/applicant checks, and failure states.
+- Existing public Discogs lookup specs still pass without requiring new admin-only fields.
+
+---
+
+### U2. Direct Admin Onboarding Confirmation
+
+**Goal:** Add the admin confirmation action that creates a store from a verified username using the existing onboarding operation.
+
+**Requirements:** R6, R7, R8, R9, R11; F2; AE4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/controllers/admin/onboardings_controller.rb`
+- Modify: `config/routes.rb`
+- Modify: `spec/requests/admin/onboardings_spec.rb`
+- Modify if needed: `app/services/store_onboarding.rb`
+- Modify if needed: `spec/services/store_onboarding_spec.rb`
+
+**Approach:**
+- Keep the existing applicant onboarding route and behavior intact.
+- Add a separate admin-created onboarding route that accepts a Discogs username from a confirmed preview state.
+- Before calling `StoreOnboarding`, re-check for duplicate Store and existing Waitlist records server-side; do not trust the previous lookup response as authorization to create.
+- Call `StoreOnboarding` with the username and no waitlist for admin-sourced stores.
+- Redirect back to `/admin` with flash notice or alert so success/failure is visible in the existing dashboard flash area.
+- Let the dashboard presenter place the newly created store in active stores with the current processing/health behavior.
+
+**Patterns to follow:**
+- Existing `Admin::OnboardingsController#create` applicant flow.
+- `StoreOnboarding` service behavior and tests.
+- Rails redirect + flash pattern already used by applicant onboarding.
+
+**Test scenarios:**
+- Happy path: authenticated admin posts a verified username, `StoreOnboarding` is called with that username and no waitlist, and the response redirects to `/admin` with a success notice.
+- Happy path: applicant onboarding still calls `StoreOnboarding` with the waitlist object.
+- Error path: unauthenticated direct onboarding request returns unauthorized.
+- Error path: existing Store blocks direct onboarding and does not call `StoreOnboarding`.
+- Error path: existing Waitlist blocks direct onboarding and does not call `StoreOnboarding`.
+- Error path: `StoreOnboarding::Error` redirects to `/admin` with an alert.
+- Edge case: blank username redirects with an alert and does not call onboarding.
+- Integration: after a real `StoreOnboarding` call creates a store, dashboard presenter excludes any matching applicant through existing filtering.
+- Covers AE4: confirmation queues onboarding without running full sync/enrichment inline and returns the dashboard to a processing store state.
+
+**Verification:**
+- Applicant approval request specs still pass unchanged or with only route-name updates.
+- Direct admin onboarding specs prove duplicate/applicant guards run at confirmation time, not only lookup time.
+
+---
+
+### U3. Dashboard Props and Types for Admin Lookup
+
+**Goal:** Provide the frontend with any static URLs or metadata needed to submit lookup and confirmation actions without hard-coding brittle assumptions in multiple places.
+
+**Requirements:** R1, R5, R10, R11, R12; F1, F2
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `app/presenters/admin/dashboard_presenter.rb`
+- Modify: `spec/presenters/admin/dashboard_presenter_spec.rb`
+- Modify: `app/frontend/types/inertia.ts`
+- Modify if needed: `app/frontend/test/pages/page_smoke.test.tsx`
+
+**Approach:**
+- Extend admin dashboard props with a small lookup/onboarding config if the frontend needs URLs or CSRF-relevant action targets beyond what Rails forms already provide.
+- Keep this prop small and operational: it should not preload lookup results or duplicate active store/applicant collections.
+- Preserve existing `active_stores`, `applicants`, `notice`, and `alert` props so current dashboard tests and page smoke tests remain meaningful.
+- Type the lookup response states in frontend TypeScript close to the admin dashboard page or shared Inertia types, depending on reuse.
+
+**Patterns to follow:**
+- Existing `Admin::DashboardPresenter#props`.
+- Existing `AdminDashboardProps`, `AdminStoreSummary`, and `AdminApplicantSummary` types.
+- Page smoke test fixtures in `app/frontend/test/pages/page_smoke.test.tsx`.
+
+**Test scenarios:**
+- Happy path: dashboard presenter still returns active stores and applicants with existing fields.
+- Happy path: new lookup/onboarding config, if added, contains only stable admin action data needed by the page.
+- Edge case: empty active stores/applicants still produce renderable props.
+- Integration: TypeScript fixtures compile with the updated prop shape.
+
+**Verification:**
+- Presenter specs and frontend tests agree on the admin prop contract.
+- No public storefront or application page types need changes for admin-only data.
+
+---
+
+### U4. Admin Dashboard Lookup and Preview UI
+
+**Goal:** Add the inline admin panel for username entry, lookup state, minimal preview, duplicate/applicant blocking, and confirmation submission.
+
+**Requirements:** R1, R3, R4, R5, R6, R10, R11, R12; F1, F2; AE1, AE2, AE3, AE5
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `app/frontend/pages/admin/dashboard.tsx`
+- Modify: `app/frontend/test/pages/admin_dashboard.test.tsx`
+- Modify if needed: `app/frontend/types/inertia.ts`
+- Modify if needed: `app/frontend/components/ui/button.tsx`
+
+**Approach:**
+- Add a compact operational panel near the top of `/admin` where the operator enters a Discogs username.
+- On lookup submit, fetch the admin lookup route and render one of the explicit states: loading, creatable preview, invalid/not found, API error, already active, or existing applicant.
+- Show only basic seller identity in the success preview: normalized username, seller display name, and avatar if available.
+- Render the create/onboard action only for the creatable preview state.
+- Submit confirmation through a Rails form or equivalent CSRF-safe mechanism to the direct admin onboarding route.
+- Keep the applicant onboarding cards unchanged.
+- Use existing local UI primitives and Tailwind token classes; avoid a modal/wizard unless implementation reveals inline layout is unworkable.
+- Ensure mobile layout keeps input, state message, and action buttons readable without horizontal scrolling.
+
+**Patterns to follow:**
+- Existing applicant onboarding form in `ApplicantCard`.
+- Existing dashboard flash rendering.
+- Existing local `Button`, `Card`, `CardHeader`, `CardContent`, and `SectionHeader` primitives.
+- `stores/invitation.tsx` for client-side lookup state shape, but do not copy its marketing UI or public copy.
+- `renderWithTier` pattern for compact/wide coverage.
+
+**Test scenarios:**
+- Happy path: dashboard renders the admin-created storefront panel with a username input and lookup button.
+- Happy path: successful creatable lookup renders seller name, username, optional avatar, and a separate confirm/onboard action.
+- Happy path: confirm action form posts the looked-up username to the direct admin onboarding route with authenticity token when available.
+- Error path: invalid/not-found lookup state renders a blocking message and no confirm action.
+- Error path: API-error lookup state renders a retryable or non-creatable error message and no confirm action.
+- Edge case: existing active store state blocks confirm action and points the operator toward the active store context.
+- Edge case: existing applicant state blocks confirm action and points the operator toward the applicant path.
+- Edge case: changing the username after a preview clears stale preview/confirmation state before a new lookup succeeds.
+- Integration: applicant onboarding cards and existing active-store cards still render as before.
+- Responsive: compact and wide tiers both render the lookup panel, preview state, and applicant onboarding controls without losing content.
+- Covers AE1: valid seller lookup produces minimal preview and separate confirmation action.
+- Covers AE2: active store duplicate blocks onboarding in the UI.
+- Covers AE3: existing applicant blocks direct onboarding in the UI.
+- Covers AE5: preview shows only basic identity, not inventory, notes, or application-style fields.
+
+**Verification:**
+- Frontend tests cover each lookup state with mocked `fetch`.
+- Existing admin dashboard tests continue to prove active stores, applicants, flash messages, and responsive content.
+
+---
+
+### U5. End-to-End Request and Regression Coverage
+
+**Goal:** Tie the new flow together with focused integration coverage and protect existing applicant/public lookup behavior.
+
+**Requirements:** R2, R7, R8, R9, R11, R12; F1, F2; AE1-AE5
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- Modify: `spec/requests/admin/dashboard_spec.rb`
+- Modify: `spec/requests/admin/onboardings_spec.rb`
+- Modify: `spec/requests/discogs_lookup_spec.rb`
+- Modify: `spec/services/store_onboarding_spec.rb`
+- Modify: `app/frontend/test/pages/admin_dashboard.test.tsx`
+
+**Approach:**
+- Add cross-layer request assertions only where unit tests cannot prove behavior: admin auth, redirect/flash, duplicate/applicant server guards, and public lookup contract preservation.
+- Keep service behavior in service specs and UI state behavior in frontend tests.
+- Avoid broad system/browser tests unless implementation introduces behavior that cannot be verified through request and component tests.
+
+**Patterns to follow:**
+- Existing request specs for admin auth and Inertia props.
+- Existing service specs using `instance_double(DiscogsClient)`.
+- Existing Vitest tests with React Testing Library.
+
+**Test scenarios:**
+- Integration: public Discogs lookup still returns the same fields for found/not found/API-error cases after admin lookup is added.
+- Integration: admin lookup plus direct onboarding can create a Store and enqueue `FullStoreSyncJob` without touching Waitlist when no applicant exists.
+- Integration: direct onboarding for a username with a Waitlist record is blocked even if the frontend could submit it.
+- Integration: applicant approval still works for Waitlist records and remains the intended path for already-applied sellers.
+- Regression: dashboard empty states, active store cards, applicant cards, and flash messages still render.
+- Regression: compact/wide dashboard test includes the new lookup panel without horizontal-scroll-prone assumptions.
+
+**Verification:**
+- The combined request, service, presenter, and frontend test set covers all origin acceptance examples.
+- No new test depends on a live Discogs API call.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `/admin` gains one lookup action and one direct onboarding action; both stay under existing admin HTTP Basic auth. Public unclaimed-slug lookup remains a separate surface.
+- **Error propagation:** Discogs lookup errors become non-creatable preview states; onboarding errors remain redirect alerts on `/admin`.
+- **State lifecycle risks:** Lookup success is not trusted as final authorization; confirmation re-checks Store/Waitlist state to prevent duplicates or applicant bypass after stale previews.
+- **API surface parity:** Public lookup and admin lookup share seller verification but intentionally do not share response responsibilities.
+- **Integration coverage:** Request specs should prove admin auth and server-side duplicate/applicant guards; frontend tests should prove the two-step operator flow.
+- **Unchanged invariants:** Applicant approval stays available and unchanged; no Waitlist record is created for admin-sourced stores; `StoreOnboarding` remains the single store creation/job enqueue path.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Admin preview gets stale before confirmation | Re-check Store and Waitlist state during the confirmation request. |
+| Public lookup accidentally exposes admin state | Keep admin Store/Waitlist checks in an admin controller instead of extending the public API contract. |
+| Duplicate onboarding paths diverge | Route applicant approval and direct admin confirmation through `StoreOnboarding`. |
+| UI preview grows into an applicant workflow | Limit preview state to basic identity and blocking state; defer notes, inventory, outreach, and CRM features. |
+| Discogs API failures confuse operators | Render a non-creatable error state in lookup and preserve redirect alerts for confirmation failures. |
+
+---
+
+## Documentation / Operational Notes
+
+- No external documentation update is required for customers or sellers.
+- Internal operator behavior changes: admins can source a store directly from `/admin`, but already-applied sellers should still be onboarded from the applicant list.
+- No rollout migration is required; this is additive to the existing admin dashboard and onboarding service.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-17-admin-discogs-storefront-onboarding-requirements.md](../brainstorms/2026-05-17-admin-discogs-storefront-onboarding-requirements.md)
+- Related requirements: [docs/brainstorms/2026-05-16-admin-dashboard-workflow-requirements.md](../brainstorms/2026-05-16-admin-dashboard-workflow-requirements.md)
+- Existing plan pattern: [docs/plans/2026-05-16-001-feat-admin-dashboard-workflow-plan.md](2026-05-16-001-feat-admin-dashboard-workflow-plan.md)
+- Related code: `app/services/discogs_seller_lookup.rb`
+- Related code: `app/services/store_onboarding.rb`
+- Related code: `app/controllers/admin/onboardings_controller.rb`
+- Related code: `app/presenters/admin/dashboard_presenter.rb`
+- Related code: `app/frontend/pages/admin/dashboard.tsx`

--- a/spec/presenters/admin/dashboard_presenter_spec.rb
+++ b/spec/presenters/admin/dashboard_presenter_spec.rb
@@ -54,4 +54,13 @@ RSpec.describe Admin::DashboardPresenter do
     )
     expect(applicant[:submitted_at]).to be_present
   end
+
+  it "includes Discogs onboarding action paths" do
+    props = described_class.new.props
+
+    expect(props[:discogs_onboarding]).to eq(
+      lookup_path: "/admin/discogs_lookup",
+      create_path: "/admin/onboarding"
+    )
+  end
 end

--- a/spec/requests/admin/discogs_lookups_spec.rb
+++ b/spec/requests/admin/discogs_lookups_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe "Admin::DiscogsLookups", type: :request do
+  around do |example|
+    ENV["ADMIN_HTTP_BASIC_USER"] = "admin"
+    ENV["ADMIN_HTTP_BASIC_PASSWORD"] = "secret"
+    example.run
+  ensure
+    ENV.delete("ADMIN_HTTP_BASIC_USER")
+    ENV.delete("ADMIN_HTTP_BASIC_PASSWORD")
+  end
+
+  describe "GET /admin/discogs_lookup" do
+    it "requires admin credentials" do
+      get "/admin/discogs_lookup", params: { username: "realseller" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns a creatable preview for a valid seller with no existing store or applicant" do
+      allow(DiscogsSellerLookup).to receive(:new).with("RealSeller").and_return(
+        lookup_result(found: true, seller_name: "Real Seller", avatar_url: "https://example.com/avatar.jpg")
+      )
+
+      get "/admin/discogs_lookup", params: { username: "RealSeller" }, headers: auth_headers("admin", "secret")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "status" => "creatable",
+        "creatable" => true,
+        "username" => "realseller",
+        "seller_name" => "Real Seller",
+        "avatar_url" => "https://example.com/avatar.jpg"
+      )
+    end
+
+    it "delegates Discogs validation to DiscogsSellerLookup" do
+      lookup = lookup_result(found: true, seller_name: "Real Seller")
+      allow(DiscogsSellerLookup).to receive(:new).with("realseller").and_return(lookup)
+
+      get "/admin/discogs_lookup", params: { username: "realseller" }, headers: auth_headers("admin", "secret")
+
+      expect(DiscogsSellerLookup).to have_received(:new).with("realseller")
+      expect(response.parsed_body["status"]).to eq("creatable")
+    end
+
+    it "returns an invalid state without checking stores or applicants" do
+      allow(DiscogsSellerLookup).to receive(:new).with("ab").and_return(lookup_result(found: false, reason: "invalid_slug"))
+      allow(Store).to receive(:with_discogs_username)
+      allow(Waitlist).to receive(:with_discogs_username)
+
+      get "/admin/discogs_lookup", params: { username: "ab" }, headers: auth_headers("admin", "secret")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "status" => "invalid",
+        "creatable" => false,
+        "reason" => "invalid_slug"
+      )
+      expect(Store).not_to have_received(:with_discogs_username)
+      expect(Waitlist).not_to have_received(:with_discogs_username)
+    end
+
+    it "returns a lookup-error state when Discogs lookup fails" do
+      allow(DiscogsSellerLookup).to receive(:new).with("broken-store").and_return(lookup_result(found: false, reason: "api_error"))
+
+      get "/admin/discogs_lookup", params: { username: "broken-store" }, headers: auth_headers("admin", "secret")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "status" => "lookup_error",
+        "creatable" => false,
+        "reason" => "api_error"
+      )
+    end
+
+    it "blocks usernames that already have an active store" do
+      store = create(:store, name: "Existing Store", discogs_username: "realseller")
+      allow(DiscogsSellerLookup).to receive(:new).with("RealSeller").and_return(lookup_result(found: true, seller_name: "Real Seller"))
+
+      get "/admin/discogs_lookup", params: { username: "RealSeller" }, headers: auth_headers("admin", "secret")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "status" => "already_active",
+        "creatable" => false,
+        "username" => "realseller"
+      )
+      expect(response.parsed_body["store"]).to include(
+        "id" => store.id,
+        "name" => "Existing Store",
+        "discogs_username" => "realseller"
+      )
+    end
+
+    it "blocks usernames that already have an applicant" do
+      applicant = create(:waitlist, name: "Applicant Store", discogs_username: "realseller")
+      allow(DiscogsSellerLookup).to receive(:new).with("RealSeller").and_return(lookup_result(found: true, seller_name: "Real Seller"))
+
+      get "/admin/discogs_lookup", params: { username: "RealSeller" }, headers: auth_headers("admin", "secret")
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include(
+        "status" => "existing_applicant",
+        "creatable" => false,
+        "username" => "realseller"
+      )
+      expect(response.parsed_body["applicant"]).to include(
+        "id" => applicant.id,
+        "name" => "Applicant Store",
+        "discogs_username" => "realseller"
+      )
+    end
+  end
+
+  def lookup_result(result)
+    instance_double(DiscogsSellerLookup, call: result)
+  end
+
+  def auth_headers(username, password)
+    credentials = Base64.strict_encode64("#{username}:#{password}")
+    { "HTTP_AUTHORIZATION" => "Basic #{credentials}" }
+  end
+end

--- a/spec/requests/admin/onboardings_spec.rb
+++ b/spec/requests/admin/onboardings_spec.rb
@@ -54,6 +54,109 @@ RSpec.describe "Admin::Onboardings", type: :request do
     end
   end
 
+  describe "POST /admin/onboarding" do
+    it "requires admin credentials" do
+      post "/admin/onboarding", params: { discogs_username: "new-store" }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "calls store onboarding with no waitlist and redirects to admin" do
+      result = StoreOnboarding::Result.new(store: build_stubbed(:store, name: "New Store", discogs_username: "new-store"))
+      allow(StoreOnboarding).to receive(:call).and_return(result)
+
+      post "/admin/onboarding",
+        params: { discogs_username: " New-Store " },
+        headers: auth_headers("admin", "secret")
+
+      expect(StoreOnboarding).to have_received(:call).with(discogs_username: "new-store", waitlist: nil)
+      expect(response).to redirect_to("/admin")
+      expect(flash[:notice]).to include("Onboarding queued for New Store")
+    end
+
+    it "does not call onboarding when matching store already exists" do
+      create(:store, discogs_username: "existing-store")
+      allow(StoreOnboarding).to receive(:call)
+
+      post "/admin/onboarding",
+        params: { discogs_username: "Existing-Store" },
+        headers: auth_headers("admin", "secret")
+
+      expect(StoreOnboarding).not_to have_received(:call)
+      expect(response).to redirect_to("/admin")
+      expect(flash[:alert]).to include("already exists")
+    end
+
+    it "does not call onboarding when matching applicant already exists" do
+      create(:waitlist, discogs_username: "applicant-store")
+      allow(StoreOnboarding).to receive(:call)
+
+      post "/admin/onboarding",
+        params: { discogs_username: "Applicant-Store" },
+        headers: auth_headers("admin", "secret")
+
+      expect(StoreOnboarding).not_to have_received(:call)
+      expect(response).to redirect_to("/admin")
+      expect(flash[:alert]).to include("already has an applicant")
+    end
+
+    it "does not call onboarding when username is blank" do
+      allow(StoreOnboarding).to receive(:call)
+
+      post "/admin/onboarding",
+        params: { discogs_username: " " },
+        headers: auth_headers("admin", "secret")
+
+      expect(StoreOnboarding).not_to have_received(:call)
+      expect(response).to redirect_to("/admin")
+      expect(flash[:alert]).to include("Discogs username is required")
+    end
+
+    it "shows an alert when direct onboarding fails" do
+      allow(StoreOnboarding).to receive(:call).and_raise(StoreOnboarding::Error, "Discogs lookup failed")
+
+      post "/admin/onboarding",
+        params: { discogs_username: "broken-store" },
+        headers: auth_headers("admin", "secret")
+
+      expect(response).to redirect_to("/admin")
+      expect(flash[:alert]).to include("Discogs lookup failed")
+    end
+
+    it "creates a store and queues sync work through the real onboarding operation" do
+      client = instance_double(DiscogsClient)
+      allow(DiscogsClient).to receive(:new).and_return(client)
+      allow(client).to receive(:seller_profile).with("direct-store").and_return({ "name" => "Direct Store" })
+
+      expect {
+        post "/admin/onboarding",
+          params: { discogs_username: "Direct-Store" },
+          headers: auth_headers("admin", "secret")
+      }.to change(Store, :count).by(1)
+        .and have_enqueued_job(FullStoreSyncJob)
+
+      expect(Store.last).to have_attributes(name: "Direct Store", discogs_username: "direct-store")
+      expect(response).to redirect_to("/admin")
+      expect(flash[:notice]).to include("Onboarding queued for Direct Store")
+    end
+
+    it "keeps applicant approval as the path for waitlist records" do
+      waitlist = create(:waitlist, discogs_username: "applicant-store")
+      client = instance_double(DiscogsClient)
+      allow(DiscogsClient).to receive(:new).and_return(client)
+      allow(client).to receive(:seller_profile).with("applicant-store").and_return({ "name" => "Applicant Store" })
+
+      expect {
+        post "/admin/waitlists/#{waitlist.id}/onboarding", headers: auth_headers("admin", "secret")
+      }.to change(Store, :count).by(1)
+        .and have_enqueued_job(FullStoreSyncJob)
+
+      expect(Store.last).to have_attributes(name: "Applicant Store", discogs_username: "applicant-store")
+      expect(response).to redirect_to("/admin")
+      expect(flash[:notice]).to include("Onboarding queued for Applicant Store")
+    end
+  end
+
   def auth_headers(username, password)
     credentials = Base64.strict_encode64("#{username}:#{password}")
     { "HTTP_AUTHORIZATION" => "Basic #{credentials}" }


### PR DESCRIPTION
## Summary
- Add an admin-only Discogs lookup endpoint that reuses DiscogsSellerLookup and blocks existing stores/applicants.
- Add a separate direct onboarding confirmation route that rechecks duplicate/applicant state and uses StoreOnboarding without a Waitlist.
- Add an inline /admin lookup and preview panel with explicit creatable, invalid, lookup-error, active-store, and existing-applicant states.
- Mark the execution plan completed.

## Testing
- bundle exec rspec
- bundle exec rubocop
- npm run test:components
- npm run test:frontend

## Evidence
Observable behavior is covered by request specs and React component tests. I did not capture a browser screenshot in this pass.

## Post-Deploy Monitoring & Validation
- Validation window: first admin-created onboarding after deploy; owner: admin/operator on duty.
- Watch Rails logs for POST /admin/onboarding, GET /admin/discogs_lookup, StoreOnboarding::Error, DiscogsClient::ApiError, DiscogsClient::RateLimitError, and FullStoreSyncJob enqueue/perform entries.
- Healthy signals: successful lookup returns creatable preview for a sourced seller, confirmation redirects to /admin with an onboarding notice, a Store row appears, and FullStoreSyncJob is queued.
- Failure signals: repeated lookup_error states, duplicate stores for the same discogs_username, direct onboarding for sellers with Waitlist records, or confirmation redirects with unexpected alerts.
- Rollback/mitigation trigger: disable operator use of the direct panel and onboard through applicant approval or existing operational tooling if duplicate/applicant guards fail or sync jobs are not enqueued.

🤖 Compound Engineered with Codex (GPT-5)