### PR TITLE
fix: frontend health check — type safety, dead CSS, price formatting, CrateView decomposition, and test coverage

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -56,14 +56,11 @@
 
 .mc-body        { background: var(--mc-bg); color: var(--mc-text); font-family: ui-serif, Georgia, serif; transition: background 0.2s, color 0.2s; }
 .mc-header      { background: var(--mc-bg-raised); }
-.mc-session-bar { background: var(--mc-bg-raised); color: var(--mc-text-dim); }
 .mc-border      { border-color: var(--mc-border); }
 .mc-wordmark    { color: var(--mc-text); font-family: ui-sans-serif, system-ui, sans-serif; letter-spacing: 0.15em; }
 .mc-brand-title { color: var(--mc-text); font-family: ui-sans-serif, system-ui, sans-serif; letter-spacing: 0.08em; text-transform: uppercase; }
 .mc-nav-link    { color: var(--mc-text-dim); text-decoration: none; transition: color 0.15s; cursor: pointer; background: none; border: none; font: inherit; }
 .mc-nav-link:hover { color: var(--mc-text); }
-.mc-accent-link { color: var(--mc-accent); text-decoration: none; }
-.mc-accent-link:hover { text-decoration: underline; }
 .mc-input {
   width: 100%;
   padding: 0.5rem 0.75rem;
@@ -81,8 +78,6 @@
 .mc-notice      { background: var(--mc-notice); color: var(--mc-text); }
 
 /* ─── Section Dividers ───────────────────────────────────────────────────── */
-
-.mc-sections    { display: flex; flex-direction: column; gap: 3rem; }
 
 .mc-section-header {
   display: flex;
@@ -105,126 +100,7 @@
   font-size: 0.65rem;
   color: var(--mc-text-dim);
 }
-.mc-section-browse {
-  font-family: ui-sans-serif, system-ui, sans-serif;
-  font-size: 0.7rem;
-  color: var(--mc-text-dim);
-  text-decoration: none;
-  margin-left: auto;
-}
-.mc-section-browse:hover { color: var(--mc-accent); }
 
-/* Scrollable crate row */
-.mc-crate-row {
-  display: flex;
-  gap: 2.5rem;
-  overflow-x: auto;
-  padding: 1rem 0 1.5rem;
-  scroll-snap-type: x mandatory;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
-}
-.mc-crate-row::-webkit-scrollbar { display: none; }
-.mc-crate-row > * { scroll-snap-align: start; }
-
-/* ─── Record Card ────────────────────────────────────────────────────────── */
-
-.mc-record-card {
-  position: relative;
-  width: 220px;
-  height: 220px;
-  flex-shrink: 0;
-  cursor: pointer;
-  perspective: 800px;
-}
-
-.mc-record-card-inner {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  transform-style: preserve-3d;
-  transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.mc-record-card.flipped .mc-record-card-inner {
-  transform: rotateY(180deg);
-}
-
-.mc-record-front,
-.mc-record-back {
-  position: absolute;
-  inset: 0;
-  backface-visibility: hidden;
-  -webkit-backface-visibility: hidden;
-  border-radius: 2px;
-  overflow: hidden;
-  border: 1px solid var(--mc-border);
-}
-
-.mc-record-front {
-  background: var(--mc-bg-card);
-}
-
-.mc-record-back {
-  background: var(--mc-bg-raised);
-  transform: rotateY(180deg);
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  font-family: ui-sans-serif, system-ui, sans-serif;
-}
-
-.mc-record-front img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.mc-record-front .mc-record-no-image {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 3rem;
-  color: var(--mc-text-dim);
-  background: var(--mc-bg-card);
-}
-
-.mc-record-back-title {
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: var(--mc-text);
-  line-height: 1.3;
-}
-.mc-record-back-artist {
-  font-size: 0.7rem;
-  color: var(--mc-text-dim);
-}
-.mc-record-back-meta {
-  font-size: 0.65rem;
-  color: var(--mc-text-dim);
-  margin-top: auto;
-}
-.mc-record-back-price {
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--mc-accent);
-}
-.mc-record-back-tracklist {
-  font-size: 0.6rem;
-  color: var(--mc-text-dim);
-  overflow: hidden;
-  flex: 1;
-  line-height: 1.6;
-}
-.mc-record-back-actions {
-  display: flex;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
 .mc-btn {
   font-size: 0.65rem;
   padding: 0.25rem 0.5rem;
@@ -258,130 +134,3 @@
 }
 .mc-input:focus { outline: none; border-color: var(--mc-accent); }
 .mc-submit { align-self: flex-start; }
-
-/* ─── Dig Session ────────────────────────────────────────────────────────── */
-
-.mc-pile-list { display: flex; flex-direction: column; gap: 0; }
-.mc-pile-item {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.85rem 0;
-  border-bottom: 1px solid var(--mc-border);
-}
-.mc-pile-thumb {
-  width: 48px;
-  height: 48px;
-  object-fit: cover;
-  border-radius: 1px;
-  flex-shrink: 0;
-  background: var(--mc-bg-card);
-}
-.mc-pile-info { flex: 1; min-width: 0; font-family: ui-sans-serif, system-ui, sans-serif; }
-.mc-pile-title { font-size: 0.8rem; font-weight: 600; color: var(--mc-text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.mc-pile-artist { font-size: 0.7rem; color: var(--mc-text-dim); }
-.mc-pile-price { font-size: 0.8rem; font-weight: 700; color: var(--mc-accent); flex-shrink: 0; }
-
-/* ─── Dig View (immersive crate experience) ──────────────────────────────── */
-
-.mc-dig-view {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2rem;
-  padding: 1.5rem 0 3rem;
-  min-height: 80vh;
-}
-
-/* The stack container — sized to the card + depth offset */
-.mc-dig-stack {
-  position: relative;
-  width: calc(300px + 24px); /* card + max offset */
-  height: calc(300px + 24px);
-}
-
-/* Each card slot in the stack */
-.mc-dig-slot {
-  position: absolute;
-  top: 0;
-  left: 0;
-  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1),
-              opacity 0.35s ease,
-              z-index 0s;
-}
-
-.mc-dig-slot[data-stack-pos="0"] {
-  transform: translate(0, 0);
-  opacity: 1;
-  z-index: 10;
-}
-
-.mc-dig-slot[data-stack-pos="1"] {
-  transform: translate(10px, 10px);
-  opacity: 0.55;
-  z-index: 9;
-  pointer-events: none;
-}
-
-.mc-dig-slot[data-stack-pos="2"] {
-  transform: translate(20px, 20px);
-  opacity: 0.25;
-  z-index: 8;
-  pointer-events: none;
-}
-
-/* Override card size in dig view */
-.mc-dig-stack .mc-record-card {
-  width: 300px;
-  height: 300px;
-}
-
-/* Navigation row */
-.mc-dig-nav {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-}
-
-.mc-dig-nav-btn {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 1px solid var(--mc-border);
-  background: var(--mc-bg-raised);
-  color: var(--mc-text);
-  font-size: 1.1rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: border-color 0.15s, opacity 0.15s;
-}
-
-.mc-dig-nav-btn:hover:not(:disabled) { border-color: var(--mc-accent); color: var(--mc-accent); }
-.mc-dig-nav-btn:disabled { opacity: 0.2; cursor: default; }
-
-.mc-dig-counter {
-  font-family: ui-sans-serif, system-ui, sans-serif;
-  font-size: 0.75rem;
-  color: var(--mc-text-dim);
-  min-width: 5rem;
-  text-align: center;
-}
-
-.mc-dig-hint {
-  font-family: ui-sans-serif, system-ui, sans-serif;
-  font-size: 0.65rem;
-  color: var(--mc-text-dim);
-  text-align: center;
-  opacity: 0.6;
-}
-
-/* ─── Responsive ─────────────────────────────────────────────────────────── */
-
-@media (min-width: 768px) {
-  .mc-record-card { width: 240px; height: 240px; }
-
-  .mc-dig-stack { width: calc(380px + 24px); height: calc(380px + 24px); }
-  .mc-dig-stack .mc-record-card { width: 380px; height: 380px; }
-}

--- a/app/frontend/components/crate_card.test.tsx
+++ b/app/frontend/components/crate_card.test.tsx
@@ -1,0 +1,235 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import CrateCard from "./crate_card"
+import StorefrontMotionConfig from "./storefront_motion_config"
+import { PileProvider } from "../contexts/pile_context"
+import { ViewportProvider } from "../contexts/viewport_context"
+import type { Crate, Listing } from "../types/inertia"
+
+const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
+  id: 1,
+  discogs_listing_id: "abc",
+  artist: "Artist",
+  title: "Title",
+  label: null,
+  year: null,
+  format: null,
+  genres: [],
+  styles: [],
+  condition: null,
+  price: "10.00",
+  currency: "USD",
+  cover_image_url: null,
+  thumbnail_url: null,
+  notes: null,
+  discogs_url: "https://www.discogs.com/sell/item/1",
+  ...overrides,
+})
+
+const makeCrate = (overrides: Partial<Crate> = {}): Crate => ({
+  slug: "test-crate",
+  name: "Test Crate",
+  count: 4,
+  records: [
+    makeListing({ id: 1, title: "Record 1" }),
+    makeListing({ id: 2, title: "Record 2" }),
+    makeListing({ id: 3, title: "Record 3" }),
+    makeListing({ id: 4, title: "Record 4" }),
+  ],
+  ...overrides,
+})
+
+const renderCard = (ui: React.ReactElement) =>
+  render(
+    <StorefrontMotionConfig>
+      <ViewportProvider>
+        <PileProvider>
+          {ui}
+        </PileProvider>
+      </ViewportProvider>
+    </StorefrontMotionConfig>,
+  )
+
+describe("CrateCard", () => {
+  describe("rendering", () => {
+    it("renders crate name", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      expect(screen.getByText("Test Crate")).toBeInTheDocument()
+    })
+
+    it("renders record count", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      // Count is 4, shown in CrateShelf
+      expect(screen.getByText("4")).toBeInTheDocument()
+    })
+
+    it("renders open label 'DIG →'", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      expect(screen.getByText("DIG →")).toBeInTheDocument()
+    })
+
+    it("renders featured variant with larger header text", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="featured" onSelectCrate={vi.fn()} />)
+      const nameEl = screen.getByText("Test Crate")
+      expect(nameEl.className).toContain("text-base")
+      expect(nameEl.className).toContain("font-semibold")
+    })
+
+    it("renders genre variant with smaller header text", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      const nameEl = screen.getByText("Test Crate")
+      expect(nameEl.className).toContain("text-sm")
+      expect(nameEl.className).toContain("font-semibold")
+    })
+  })
+
+  describe("empty state", () => {
+    it("shows 'No records yet' when crate has no records", () => {
+      const crate = makeCrate({ count: 0, records: [] })
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      expect(screen.getByText("No records yet")).toBeInTheDocument()
+    })
+
+    it("does not render record tiles for empty crate", () => {
+      const crate = makeCrate({ count: 0, records: [] })
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      // Only the header button should exist (no thumbnail buttons)
+      expect(screen.queryAllByRole("button", { name: /Open.*at Record/ })).toHaveLength(0)
+    })
+  })
+
+  describe("keyboard interaction", () => {
+    it("fires onSelectCrate with slug on header Enter key", async () => {
+      const onSelectCrate = vi.fn()
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+
+      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" })
+      headerBtn.focus()
+      await userEvent.keyboard("{Enter}")
+
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate")
+    })
+
+    it("fires onSelectCrate with slug on header Space key", async () => {
+      const onSelectCrate = vi.fn()
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+
+      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" })
+      headerBtn.focus()
+      await userEvent.keyboard(" ")
+
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate")
+    })
+
+    it("does not fire when keyboard target is a nested button", async () => {
+      const onSelectCrate = vi.fn()
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+
+      // Focus a thumbnail button (which is a nested <button> inside the shelf)
+      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 1" })
+      thumbBtn.focus()
+      await userEvent.keyboard("{Enter}")
+
+      // The thumbnail button's click handler fires, not the header's keyboard
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 0)
+    })
+  })
+
+  describe("thumbnail interaction", () => {
+    it("fires onSelectCrate with slug and index on thumbnail click", async () => {
+      const onSelectCrate = vi.fn()
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+
+      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 1" })
+      await userEvent.click(thumbBtn)
+
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 0)
+    })
+
+    it("fires onSelectCrate with correct index for 2nd record", async () => {
+      const onSelectCrate = vi.fn()
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+
+      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 2" })
+      await userEvent.click(thumbBtn)
+
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 1)
+    })
+
+    it("fires onSelectCrate with correct index for 4th record", async () => {
+      const onSelectCrate = vi.fn()
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+
+      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 4" })
+      await userEvent.click(thumbBtn)
+
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 3)
+    })
+
+    it("renders 4 thumbnail buttons for crate with 4+ records", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+
+      // 4 thumbnail buttons + 1 header button
+      const buttons = screen.getAllByRole("button")
+      expect(buttons.length).toBe(5)
+    })
+  })
+
+  describe("accessibility", () => {
+    it("has accessible header button", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+
+      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" })
+      expect(headerBtn).toHaveAttribute("tabindex", "0")
+    })
+
+    it("thumbnail buttons have accessible names", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+
+      expect(screen.getByRole("button", { name: "Open Test Crate at Record 1" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Open Test Crate at Record 2" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Open Test Crate at Record 3" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Open Test Crate at Record 4" })).toBeInTheDocument()
+    })
+
+    it("does not nest button elements inside button elements", () => {
+      const crate = makeCrate()
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+
+      const buttons = document.querySelectorAll("button")
+      buttons.forEach((btn) => {
+        expect(btn.querySelectorAll("button").length).toBe(0)
+      })
+    })
+  })
+
+  describe("tactile hover wrapper", () => {
+    it("wraps CrateShelf in a div with pointer event handlers", () => {
+      const crate = makeCrate()
+      const { container } = renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+
+      // CrateCard wraps CrateShelf inside a div. The CrateShelf's own
+      // root div has a rounded/border class, so we can verify the structure.
+      const shelfRoots = container.querySelectorAll('.rounded-lg.bg-mc-bg-card')
+      expect(shelfRoots.length).toBe(1)
+      // The CrateShelf header button should be inside this wrapper
+      expect(screen.getByRole("button", { name: "Open Test Crate" })).toBeInTheDocument()
+    })
+  })
+})

--- a/app/frontend/components/crate_card.tsx
+++ b/app/frontend/components/crate_card.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion"
 import { useTactileHover } from "@/hooks/use_tactile_hover"
 import { springTactile, springPress, SCALE_HOVER, SCALE_PRESS } from "@/lib/motion_tokens"
-import RecordTile from "./record_tile"
+import CrateShelf from "./crate_shelf"
 import type { Crate } from "../types/inertia"
 
 interface Props {
@@ -10,40 +10,16 @@ interface Props {
   onSelectCrate: (slug: string, startIndex?: number) => void
 }
 
+/**
+ * A tactile crate card — wraps CrateShelf in a Framer Motion container
+ * that applies cursor-proximity hover animations (scale, lift, tilt,
+ * border glow).
+ */
 export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
-  const isFeatured = variant === "featured"
-  const nameClass = isFeatured ? "text-base font-semibold" : "text-sm font-semibold"
   const { isHovered, isPressed, handlers } = useTactileHover()
-  const innerHoverScale = 1 + (SCALE_HOVER - 1) / 2
-
-  if (crate.records.length === 0) {
-    return (
-      <div className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left">
-        <div className="px-3 pt-3 pb-2">
-          <div className="mc-section-header">
-            <span className={`mc-section-name ${nameClass}`}>{crate.name}</span>
-          </div>
-        </div>
-        <div className="aspect-square flex items-center justify-center mc-dim text-xs px-3 pb-3">
-          No records yet
-        </div>
-      </div>
-    )
-  }
 
   return (
     <motion.div
-      role="button"
-      tabIndex={0}
-      onClick={() => onSelectCrate(crate.slug)}
-      onKeyDown={(e) => {
-        if ((e.target as HTMLElement).closest("button, a")) return
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault()
-          onSelectCrate(crate.slug)
-        }
-      }}
-      className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden cursor-pointer text-left"
       animate={{
         borderColor: isHovered ? "var(--mc-accent)" : "var(--mc-border)",
         scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
@@ -51,53 +27,16 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
         rotate: isHovered ? 0 : -0.5,
       }}
       transition={isPressed ? springPress : springTactile}
-      aria-label={`Open ${crate.name}`}
       {...handlers}
     >
-      {/* Header row — lid lift on hover */}
-      <motion.div
-        className="px-3 pt-3 pb-1.5"
-        style={{ transformOrigin: "top" }}
-        animate={{ y: isHovered ? -2 : 0 }}
-        transition={springTactile}
-      >
-        <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-1">
-          <span className={`mc-section-name ${nameClass} truncate flex-1`}>{crate.name}</span>
-          <div className="flex items-center gap-2 flex-shrink-0">
-            {/* DIG → label — slides in on hover */}
-            <motion.span
-              className="text-[10px] text-mc-accent font-bold uppercase tracking-widest"
-              animate={{ opacity: isHovered ? 1 : 0, x: isHovered ? 0 : -4 }}
-              transition={springTactile}
-            >
-              DIG →
-            </motion.span>
-            <span className="mc-section-count text-xs">{crate.count}</span>
-          </div>
-        </div>
-      </motion.div>
-
-      {/* Thumbnail grid — scale together as a group */}
-      <motion.div
-        className="grid grid-cols-2 gap-1.5 px-3 pb-3 pt-1.5"
-        animate={{ scale: isHovered ? innerHoverScale : 1 }}
-        transition={springTactile}
-      >
-        {crate.records.slice(0, 4).map((record, i) => (
-            <button
-              key={record.id}
-              type="button"
-              className="cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mc-bg-card"
-              onClick={(e) => {
-                e.stopPropagation()
-                onSelectCrate(crate.slug, i)
-              }}
-              aria-label={`Open ${crate.name} at ${record.title ?? "record"}`}
-            >
-              <RecordTile listing={record} imageLoading="lazy" />
-            </button>
-          ))}
-      </motion.div>
+      <CrateShelf
+        crate={crate}
+        interactive
+        onSelectCrate={onSelectCrate}
+        previewCount={4}
+        openLabel="DIG →"
+        headerSize={variant}
+      />
     </motion.div>
   )
 }

--- a/app/frontend/components/crate_card.tsx
+++ b/app/frontend/components/crate_card.tsx
@@ -13,13 +13,16 @@ interface Props {
 /**
  * A tactile crate card — wraps CrateShelf in a Framer Motion container
  * that applies cursor-proximity hover animations (scale, lift, tilt,
- * border glow).
+ * border glow). The outer motion.div owns the border (so borderColor
+ * animation is visible) and passes hover state into CrateShelf for
+ * inner animations (open label, thumbnail scale).
  */
 export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
   const { isHovered, isPressed, handlers } = useTactileHover()
 
   return (
     <motion.div
+      className="w-full rounded-lg border overflow-hidden"
       animate={{
         borderColor: isHovered ? "var(--mc-accent)" : "var(--mc-border)",
         scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
@@ -36,6 +39,8 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
         previewCount={4}
         openLabel="DIG →"
         headerSize={variant}
+        isHovered={isHovered}
+        className="border-0 rounded-none"
       />
     </motion.div>
   )

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -17,6 +17,8 @@ export interface CrateShelfProps {
   meta?: string
   /** Optional explicit open-action label for touch-friendly affordance. */
   openLabel?: string
+  /** Header text size: "featured" (text-base) or "genre" (text-sm, default). */
+  headerSize?: "featured" | "genre"
   /** Additional CSS class names. */
   className?: string
 }
@@ -44,14 +46,16 @@ export default function CrateShelf({
   previewCount = 4,
   meta,
   openLabel,
+  headerSize = "genre",
   className = "",
 }: CrateShelfProps) {
   const { isHovered } = useTactileHover()
   const innerHoverScale = 1 + (SCALE_HOVER - 1) / 2
+  const nameClass = headerSize === "featured" ? "text-base font-semibold" : "text-sm font-semibold"
 
   const headerContent = (
     <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-1">
-      <span className="mc-section-name text-sm font-semibold truncate flex-1">
+      <span className={`mc-section-name ${nameClass} truncate flex-1`}>
         {crate.name}
       </span>
       <div className="flex items-center gap-2 flex-shrink-0">

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -19,6 +19,8 @@ export interface CrateShelfProps {
   openLabel?: string
   /** Header text size: "featured" (text-base) or "genre" (text-sm, default). */
   headerSize?: "featured" | "genre"
+  /** Override internal hover state (for CrateCard wrapping CrateShelf). */
+  isHovered?: boolean
   /** Additional CSS class names. */
   className?: string
 }
@@ -47,9 +49,11 @@ export default function CrateShelf({
   meta,
   openLabel,
   headerSize = "genre",
+  isHovered: isHoveredOverride,
   className = "",
 }: CrateShelfProps) {
-  const { isHovered } = useTactileHover()
+  const { isHovered: internalHovered, handlers } = useTactileHover()
+  const isHovered = isHoveredOverride ?? internalHovered
   const innerHoverScale = 1 + (SCALE_HOVER - 1) / 2
   const nameClass = headerSize === "featured" ? "text-base font-semibold" : "text-sm font-semibold"
 
@@ -97,6 +101,7 @@ export default function CrateShelf({
   return (
     <div
       className={`flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left ${className}`}
+      {...handlers}
     >
       {/* Header */}
       <div className="px-3 pt-3 pb-1.5">

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import CrateTabs from "./crate_tabs"
 import GhostFingerCue from "./ghost_finger_cue"
 import RecordCard from "./record_card"
+import RecordDetails from "./record_details"
 import { buildCrateWindow } from "../lib/crate_window"
 import {
   RIFFLE_LANGUAGE,
@@ -12,11 +13,11 @@ import {
   type RiffleDirection,
 } from "../lib/riffle_navigation"
 import { useViewport } from "@/hooks/use_viewport"
-import { usePileContext } from "@/contexts/pile_context"
 import { SCALE_PRESS, springPress, transitionCrate, reducedMotionTransition } from "@/lib/motion_tokens"
 import { useReducedMotionContext } from "./storefront_motion_config"
 import { isLessonEligible, markLessonLearned, isLessonLearned } from "../lib/first_swipe_lesson"
-import type { Crate, Listing } from "../types/inertia"
+import { usePreload } from "@/hooks/use_preload"
+import type { Crate } from "../types/inertia"
 
 interface Props {
   crates: Crate[]
@@ -39,127 +40,6 @@ const activeLayerStyle: React.CSSProperties = {
   willChange: "transform, opacity",
   backfaceVisibility: "hidden",
   WebkitBackfaceVisibility: "hidden",
-}
-
-function RecordDetails({ listing, direction }: { listing: Listing; direction: RiffleDirection }) {
-  const meta = [listing.format, listing.label, listing.year, listing.condition].filter(Boolean).join(" · ")
-  const enterY = direction === "deeper" ? -16 : 16
-  const exitY = direction === "deeper" ? 16 : -16
-  const { inPile, addToPile, removeFromPile } = usePileContext()
-
-  const currencySymbol = listing.currency === "GBP" ? "£" : listing.currency === "EUR" ? "€" : "$"
-
-  const allTags = [
-    ...listing.genres.slice(0, 4).map((g) => ({ label: g, dim: false })),
-    ...listing.styles.slice(0, 4).map((s) => ({ label: s, dim: true })),
-  ]
-
-  return (
-    <AnimatePresence mode="wait" custom={direction}>
-      <motion.div
-        key={listing.id}
-        custom={direction}
-        initial={{ opacity: 0, y: enterY }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: exitY }}
-        transition={{ duration: 0.18, ease: "easeOut" }}
-        className="flex flex-col gap-4"
-      >
-        {/* Header: info + price/actions in two-column row */}
-        <div className="grid grid-cols-[1fr_auto] gap-x-6 items-start">
-          <div>
-            <div className="text-xl font-semibold leading-tight">{listing.title}</div>
-            <div className="text-sm text-mc-text-dim mt-1">{listing.artist}</div>
-            {meta && <div className="text-xs text-mc-text-dim mt-2">{meta}</div>}
-          </div>
-          <div className="flex flex-col items-end gap-2">
-            <span className="text-2xl font-medium whitespace-nowrap">
-              {listing.display_price ?? (listing.price ? `${currencySymbol}${parseFloat(listing.price).toFixed(2)}` : "—")}
-            </span>
-            <div className="flex gap-2">
-              {inPile(listing.id) ? (
-                <button onClick={() => removeFromPile(listing.id)} className="mc-btn">✓ In pile</button>
-              ) : (
-                <button onClick={() => addToPile(listing)} className="mc-btn mc-btn-primary">+ Pile</button>
-              )}
-              <a href={listing.discogs_url} target="_blank" rel="noopener" className="mc-btn">Discogs ↗</a>
-            </div>
-          </div>
-        </div>
-
-        {/* Combined genre + style pills */}
-        {allTags.length > 0 && (
-          <div className="flex gap-1.5 flex-wrap">
-            {allTags.map((tag) => (
-              <span
-                key={tag.label}
-                className={`text-[11px] px-2 py-0.5 rounded bg-mc-bg-raised ${
-                  tag.dim ? "text-mc-text-dim/70" : "text-mc-text-dim"
-                }`}
-              >
-                {tag.label}
-              </span>
-            ))}
-          </div>
-        )}
-
-        {listing.notes && (
-          <p className="text-xs text-mc-text-dim leading-relaxed line-clamp-4">{listing.notes}</p>
-        )}
-      </motion.div>
-    </AnimatePresence>
-  )
-}
-
-
-function preloadImage(url: string, priority: "high" | "low" = "high", signal?: AbortSignal) {
-  if (priority === "high") {
-    const img = new Image()
-    img.decoding = "async"
-    img.src = url
-  } else {
-    // Idle priority — use requestIdleCallback with setTimeout(0) fallback
-    const schedule = typeof requestIdleCallback === "function"
-      ? requestIdleCallback
-      : (cb: IdleRequestCallback) => setTimeout(cb, 0)
-    const deferred = () => {
-      if (signal?.aborted) return
-      const img = new Image()
-      img.decoding = "async"
-      img.src = url
-    }
-    schedule(deferred, { timeout: 2000 })
-  }
-}
-
-function usePreload(records: { id: number; cover_image_url?: string | null; thumbnail_url?: string | null }[], index: number) {
-  useEffect(() => {
-    const abort = new AbortController()
-
-    for (let offset = -3; offset <= 3; offset++) {
-      if (offset === 0) continue
-
-      const r = records[index + offset]
-      if (!r) continue
-
-      const absOffset = Math.abs(offset)
-
-      if (absOffset <= 1) {
-        // Adjacent slots: preload full-res cover (cache-warming for the decode gate)
-        if (r.cover_image_url) preloadImage(r.cover_image_url, "high")
-      } else {
-        // Edge slots: preload thumbnail only (full-res at idle priority)
-        if (r.thumbnail_url) {
-          preloadImage(r.thumbnail_url, "high")
-        }
-        if (r.cover_image_url) {
-          preloadImage(r.cover_image_url, "low", abort.signal)
-        }
-      }
-    }
-
-    return () => abort.abort()
-  }, [records, index])
 }
 
 export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs = false, onSelectCrate, onBack }: Props) {
@@ -212,6 +92,14 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
   }, [total, isCompact])
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    const target = e.target as HTMLElement
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      target.isContentEditable
+    ) return
+    if (document.querySelector('[role="dialog"][aria-modal="true"]')) return
     if (e.key === "ArrowDown") navigate("deeper")
     if (e.key === "ArrowUp") navigate("front")
   }, [navigate])

--- a/app/frontend/components/pile_sheet.test.tsx
+++ b/app/frontend/components/pile_sheet.test.tsx
@@ -1,0 +1,396 @@
+import React from "react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import PileSheet from "./pile_sheet"
+import { PileProvider, usePileContext } from "../contexts/pile_context"
+import { ViewportProvider } from "../contexts/viewport_context"
+import { renderWithTier } from "../test/viewport-test-utils"
+import type { Listing } from "../types/inertia"
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+let nextId = 1000
+const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
+  id: nextId++,
+  discogs_listing_id: `discogs-${nextId}`,
+  artist: "Artist",
+  title: "Title",
+  label: null,
+  year: null,
+  format: null,
+  genres: [],
+  styles: [],
+  condition: null,
+  price: "10.00",
+  currency: "USD",
+  cover_image_url: null,
+  thumbnail_url: null,
+  notes: null,
+  discogs_url: "https://www.discogs.com/sell/item/1",
+  ...overrides,
+})
+
+/** Render PileSheet in full providers, with a component that populates the pile. */
+function renderPileSheet(
+  pileRecords: Listing[] = [],
+  props: { open?: boolean; onClose?: () => void } = {},
+) {
+  const onClose = props.onClose ?? vi.fn()
+  const open = props.open ?? true
+
+  function PilePopulator({ children }: { children: React.ReactNode }) {
+    const { addToPile } = usePileContext()
+    React.useEffect(() => {
+      pileRecords.forEach((r) => addToPile(r))
+    }, [])
+    return <>{children}</>
+  }
+
+  return render(
+    <ViewportProvider>
+      <PileProvider>
+        <PilePopulator>
+          <PileSheet open={open} onClose={onClose} />
+        </PilePopulator>
+      </PileProvider>
+    </ViewportProvider>,
+  )
+}
+
+describe("PileSheet", () => {
+  describe("dialog mechanics", () => {
+    it("renders as a dialog with aria-modal", () => {
+      renderPileSheet()
+      const dialog = screen.getByRole("dialog")
+      expect(dialog).toHaveAttribute("aria-modal", "true")
+    })
+
+    it("has aria-labelledby pointing to pile-sheet-title", () => {
+      renderPileSheet()
+      const dialog = screen.getByRole("dialog")
+      expect(dialog).toHaveAttribute("aria-labelledby", "pile-sheet-title")
+      const title = document.getElementById("pile-sheet-title")
+      expect(title).toBeInTheDocument()
+    })
+
+    it("closes on Escape key", async () => {
+      const onClose = vi.fn()
+      renderPileSheet([], { onClose })
+      await userEvent.keyboard("{Escape}")
+      expect(onClose).toHaveBeenCalledOnce()
+    })
+
+    it("closes on backdrop click", async () => {
+      const onClose = vi.fn()
+      const { container } = render(
+        <ViewportProvider>
+          <PileProvider>
+            <PileSheet open={true} onClose={onClose} />
+          </PileProvider>
+        </ViewportProvider>,
+      )
+      const backdrop = container.querySelector('[aria-hidden="true"]')
+      expect(backdrop).toBeInTheDocument()
+      if (backdrop) {
+        await userEvent.click(backdrop)
+      }
+      expect(onClose).toHaveBeenCalledOnce()
+    })
+
+    it("closes on close button click", async () => {
+      const onClose = vi.fn()
+      renderPileSheet([], { onClose })
+      const closeBtn = screen.getByRole("button", { name: /close pile/i })
+      await userEvent.click(closeBtn)
+      expect(onClose).toHaveBeenCalledOnce()
+    })
+
+    it("does not render when open is false", () => {
+      render(
+        <ViewportProvider>
+          <PileProvider>
+            <PileSheet open={false} onClose={vi.fn()} />
+          </PileProvider>
+        </ViewportProvider>,
+      )
+      expect(screen.queryByRole("dialog")).toBeNull()
+    })
+  })
+
+  describe("empty state", () => {
+    it("shows empty message when pile is empty", () => {
+      renderPileSheet([])
+      expect(screen.getByText(/no records in your pile yet/i)).toBeInTheDocument()
+    })
+
+    it("does not show footer when pile is empty", () => {
+      renderPileSheet([])
+      expect(screen.queryByText("Total")).toBeNull()
+    })
+  })
+
+  describe("record display", () => {
+    it("renders records with title and artist", async () => {
+      renderPileSheet([
+        makeListing({ title: "Abbey Road", artist: "The Beatles" }),
+        makeListing({ title: "Dark Side", artist: "Pink Floyd" }),
+      ])
+
+      await waitFor(() => {
+        expect(screen.getByText("Abbey Road")).toBeInTheDocument()
+        expect(screen.getByText("The Beatles")).toBeInTheDocument()
+        expect(screen.getByText("Dark Side")).toBeInTheDocument()
+        expect(screen.getByText("Pink Floyd")).toBeInTheDocument()
+      })
+    })
+
+    it("renders record price using formatPriceValue", async () => {
+      renderPileSheet([
+        makeListing({ price: "15.99", currency: "USD" }),
+      ])
+
+      await waitFor(() => {
+        const prices = screen.getAllByText("$15.99")
+        expect(prices.length).toBeGreaterThanOrEqual(1)
+      })
+    })
+
+    it("shows — for records with null price", async () => {
+      renderPileSheet([
+        makeListing({ price: "" }),
+      ])
+
+      await waitFor(() => {
+        expect(screen.getByText("—")).toBeInTheDocument()
+      })
+    })
+
+    it("shows ♪ fallback for records with no cover image", async () => {
+      renderPileSheet([
+        makeListing({ cover_image_url: null, thumbnail_url: null }),
+      ])
+
+      await waitFor(() => {
+        expect(screen.getByText("♪")).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("record removal", () => {
+    it("removes a record from the pile via the × button", async () => {
+      renderPileSheet([
+        makeListing({ title: "Remove Me" }),
+      ])
+
+      await waitFor(() => {
+        expect(screen.getByText("Remove Me")).toBeInTheDocument()
+      })
+
+      const removeBtn = screen.getByRole("button", { name: /remove.*pile/i })
+      await userEvent.click(removeBtn)
+
+      await waitFor(() => {
+        expect(screen.queryByText("Remove Me")).toBeNull()
+        expect(screen.getByText(/no records in your pile yet/i)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("total calculation", () => {
+    it("shows sum of all record prices", async () => {
+      renderPileSheet([
+        makeListing({ price: "10.00", currency: "USD" }),
+        makeListing({ price: "15.50", currency: "USD" }),
+      ])
+
+      await waitFor(() => {
+        // The footer total is a span inside the footer
+        const footerTotals = screen.getAllByText(/^\$\d+\.\d{2}$/)
+        // Should be three: two per-record prices + one footer total
+        const totalTexts = footerTotals.map((el) => el.textContent)
+        expect(totalTexts).toContain("$25.50")
+      })
+    })
+
+    it("handles records with null prices in total", async () => {
+      renderPileSheet([
+        makeListing({ price: "10.00", currency: "USD" }),
+        makeListing({ price: "" }),
+      ])
+
+      await waitFor(() => {
+        // Footer total should be $10.00
+        const priceElements = screen.getAllByText("$10.00")
+        // At least one $10.00 per-record + footer total
+        expect(priceElements.length).toBeGreaterThanOrEqual(1)
+      })
+    })
+
+    it("shows Total label in footer when pile has records", async () => {
+      renderPileSheet([
+        makeListing({ price: "5.00", currency: "USD" }),
+      ])
+
+      await waitFor(() => {
+        expect(screen.getByText("Total")).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("confirmClear flow", () => {
+    it("shows Clear button when pile has records", async () => {
+      renderPileSheet([makeListing()])
+
+      await waitFor(() => {
+        expect(screen.getByText("Clear")).toBeInTheDocument()
+      })
+    })
+
+    it("shows confirmation after clicking Clear", async () => {
+      renderPileSheet([makeListing()])
+
+      await waitFor(() => {
+        expect(screen.getByText("Clear")).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByText("Clear"))
+
+      await waitFor(() => {
+        expect(screen.getByText("Sure?")).toBeInTheDocument()
+        expect(screen.getByText("Yes")).toBeInTheDocument()
+        expect(screen.getByText("No")).toBeInTheDocument()
+      })
+    })
+
+    it("cancels clear when No is clicked", async () => {
+      renderPileSheet([makeListing({ title: "Keep Me" })])
+
+      await waitFor(() => expect(screen.getByText("Clear")).toBeInTheDocument())
+      await userEvent.click(screen.getByText("Clear"))
+
+      await waitFor(() => expect(screen.getByText("No")).toBeInTheDocument())
+      await userEvent.click(screen.getByText("No"))
+
+      await waitFor(() => {
+        expect(screen.getByText("Clear")).toBeInTheDocument()
+        expect(screen.getByText("Keep Me")).toBeInTheDocument()
+        expect(screen.queryByText("Sure?")).toBeNull()
+      })
+    })
+
+    it("clears pile when Yes is clicked", async () => {
+      renderPileSheet([makeListing({ title: "Delete Me" })])
+
+      await waitFor(() => expect(screen.getByText("Clear")).toBeInTheDocument())
+      await userEvent.click(screen.getByText("Clear"))
+
+      await waitFor(() => expect(screen.getByText("Yes")).toBeInTheDocument())
+      await userEvent.click(screen.getByText("Yes"))
+
+      await waitFor(() => {
+        expect(screen.getByText(/no records in your pile yet/i)).toBeInTheDocument()
+      })
+    })
+
+    it("hides Clear button when pile is empty", () => {
+      renderPileSheet([])
+      expect(screen.queryByText("Clear")).toBeNull()
+    })
+  })
+
+  describe("responsive layout", () => {
+    it("renders as bottom-sheet in compact tier", () => {
+      const { container } = renderWithTier(
+        "compact",
+        <PileProvider>
+          <PileSheet open={true} onClose={vi.fn()} />
+        </PileProvider>,
+      )
+
+      const dialog = screen.getByRole("dialog")
+      expect(dialog.className).toContain("bottom-0")
+    })
+
+    it("renders as side-panel in wide tier", () => {
+      renderWithTier(
+        "wide",
+        <PileProvider>
+          <PileSheet open={true} onClose={vi.fn()} />
+        </PileProvider>,
+      )
+
+      const dialog = screen.getByRole("dialog")
+      expect(dialog.className).toContain("right-0")
+    })
+
+    it("shows drag handle bar in compact tier", () => {
+      const { container } = renderWithTier(
+        "compact",
+        <PileProvider>
+          <PileSheet open={true} onClose={vi.fn()} />
+        </PileProvider>,
+      )
+
+      // Drag handle: a 12px wide, 1.5px tall rounded bar inside the dialog
+      const dialog = screen.getByRole("dialog")
+      const handle = dialog.querySelector(".w-12")
+      expect(handle).toBeInTheDocument()
+    })
+
+    it("does not show drag handle in wide tier", () => {
+      const { container } = renderWithTier(
+        "wide",
+        <PileProvider>
+          <PileSheet open={true} onClose={vi.fn()} />
+        </PileProvider>,
+      )
+
+      const dialog = screen.getByRole("dialog")
+      const handle = dialog.querySelector(".w-12")
+      expect(handle).toBeNull()
+    })
+  })
+
+  describe("pile count in header", () => {
+    it("shows record count in the header", async () => {
+      renderPileSheet([
+        makeListing(),
+        makeListing(),
+        makeListing(),
+      ])
+
+      await waitFor(() => {
+        const title = document.getElementById("pile-sheet-title")
+        expect(title?.textContent).toContain("3 records")
+      })
+    })
+
+    it("does not show count when pile is empty", () => {
+      renderPileSheet([])
+
+      const title = document.getElementById("pile-sheet-title")
+      expect(title?.textContent).not.toContain("records")
+    })
+  })
+
+  describe("add all to cart button", () => {
+    it("shows disabled cart button when pile has records", async () => {
+      renderPileSheet([makeListing()])
+
+      await waitFor(() => {
+        const cartBtn = screen.getByText(/add all to discogs cart/i)
+        expect(cartBtn).toBeInTheDocument()
+        expect(cartBtn).toBeDisabled()
+      })
+    })
+
+    it("does not show cart button when pile is empty", () => {
+      renderPileSheet([])
+
+      expect(screen.queryByText(/add all to discogs cart/i)).toBeNull()
+    })
+  })
+})

--- a/app/frontend/components/pile_sheet.tsx
+++ b/app/frontend/components/pile_sheet.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "framer-motion"
 import { usePileContext } from "../contexts/pile_context"
 import { useViewport } from "@/hooks/use_viewport"
 import { springDrawer } from "@/lib/motion_tokens"
+import { formatPriceValue } from "@/lib/format_price"
 
 interface Props {
   open: boolean
@@ -133,7 +134,7 @@ export default function PileSheet({ open, onClose }: Props) {
                         <a
                           href={listing.discogs_url}
                           target="_blank"
-                          rel="noopener"
+                          rel="noopener noreferrer"
                           className="flex items-center gap-3 flex-1 min-w-0 group"
                         >
                           <div className="w-12 h-12 flex-shrink-0 rounded bg-mc-bg-raised overflow-hidden border border-mc-border">
@@ -148,7 +149,7 @@ export default function PileSheet({ open, onClose }: Props) {
                             <div className="text-xs text-mc-text-dim truncate">{listing.artist}</div>
                           </div>
                           <span className="text-xs font-medium flex-shrink-0">
-                            {listing.price ? `$${parseFloat(listing.price).toFixed(2)}` : "—"}
+                            {formatPriceValue(listing.price, listing.currency)}
                           </span>
                         </a>
                         <button
@@ -170,7 +171,7 @@ export default function PileSheet({ open, onClose }: Props) {
               <div className="flex-shrink-0 px-4 py-4 border-t border-mc-border flex flex-col gap-3">
                 <div className="flex items-center justify-between">
                   <span className="text-xs text-mc-text-dim uppercase tracking-wider">Total</span>
-                  <span className="text-sm font-semibold">${total.toFixed(2)}</span>
+                  <span className="text-sm font-semibold">{formatPriceValue(total.toFixed(2), pile[0]?.currency)}</span>
                 </div>
                 <button
                   disabled

--- a/app/frontend/components/record_card.test.tsx
+++ b/app/frontend/components/record_card.test.tsx
@@ -1,0 +1,312 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import RecordCard from "./record_card"
+import { PileProvider } from "../contexts/pile_context"
+import { ViewportProvider } from "../contexts/viewport_context"
+import type { Listing } from "../types/inertia"
+
+const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
+  id: 1,
+  discogs_listing_id: "abc",
+  artist: "Artist",
+  title: "Title",
+  label: "Label",
+  year: 1975,
+  format: "Vinyl",
+  genres: ["Jazz", "Fusion"],
+  styles: ["Bebop"],
+  condition: "VG+",
+  price: "12.50",
+  currency: "USD",
+  cover_image_url: null,
+  thumbnail_url: null,
+  notes: null,
+  discogs_url: "https://www.discogs.com/sell/item/1",
+  ...overrides,
+})
+
+const renderWithPile = (ui: React.ReactElement) =>
+  render(<ViewportProvider><PileProvider>{ui}</PileProvider></ViewportProvider>)
+
+/** Helper: find the card div (role="button" element that wraps the motion div) */
+const getCard = (name?: string) => {
+  const all = screen.getAllByRole("button")
+  // The card is the one with aria-label containing "Show details" or "Show cover"
+  return all.find((el) => {
+    const label = el.getAttribute("aria-label") || ""
+    return label.includes("Show details") || label.includes("Show cover")
+  })!
+}
+
+describe("RecordCard", () => {
+  describe("flip mechanics", () => {
+    it("clicking the card flips it from front to back", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Click Test" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Click Test" })
+      expect(card).toHaveAttribute("aria-pressed", "false")
+      await userEvent.click(card)
+      expect(card).toHaveAttribute("aria-pressed", "true")
+      expect(card).toHaveAttribute("aria-label", "Show cover for Click Test")
+    })
+
+    it("clicking again flips back to front", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Flip Back" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Flip Back" })
+      await userEvent.click(card)
+      expect(card).toHaveAttribute("aria-pressed", "true")
+      await userEvent.click(card)
+      expect(card).toHaveAttribute("aria-pressed", "false")
+      expect(card).toHaveAttribute("aria-label", "Show details for Flip Back")
+    })
+
+    it("keyboard Enter flips the card", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Keyboard Test" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Keyboard Test" })
+      card.focus()
+      await userEvent.keyboard("{Enter}")
+      expect(card).toHaveAttribute("aria-pressed", "true")
+    })
+
+    it("keyboard Space flips the card", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Space Test" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Space Test" })
+      card.focus()
+      await userEvent.keyboard(" ")
+      expect(card).toHaveAttribute("aria-pressed", "true")
+    })
+  })
+
+  describe("drag suppression", () => {
+    it("does not flip after substantial pointer movement", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Drag Test" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Drag Test" })
+      fireEvent.pointerDown(card, { clientX: 10, clientY: 10 })
+      fireEvent.click(card, { clientX: 25, clientY: 25 })
+
+      expect(card).toHaveAttribute("aria-pressed", "false")
+    })
+
+    it("still flips when movement is very small", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Tiny Move" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Tiny Move" })
+      fireEvent.pointerDown(card, { clientX: 10, clientY: 10 })
+      fireEvent.click(card, { clientX: 12, clientY: 14 })
+
+      expect(card).toHaveAttribute("aria-pressed", "true")
+    })
+  })
+
+  describe("disableFlip prop", () => {
+    it("renders no role=button when disableFlip is true", () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "No Flip" })} disableFlip />)
+
+      // The card should NOT have role="button", but poking around the DOM
+      // there should be no accessible buttons for the card
+      const cardName = screen.queryByRole("button", { name: "Show details for No Flip" })
+      expect(cardName).toBeNull()
+    })
+
+    it("does not set aria-pressed when disableFlip is true", () => {
+      renderWithPile(<RecordCard listing={makeListing()} disableFlip />)
+      expect(screen.queryByRole("button", { name: /Show / })).toBeNull()
+    })
+  })
+
+  describe("framed prop", () => {
+    it("applies box-shadow when framed is true", () => {
+      renderWithPile(<RecordCard listing={makeListing()} framed />)
+
+      // The inner motion.div with rounded-lg gets box-shadow via style prop
+      const motionDivs = document.querySelectorAll('[style*="box-shadow"]')
+      expect(motionDivs.length).toBeGreaterThan(0)
+    })
+
+    it("does not apply box-shadow when framed is false", () => {
+      renderWithPile(<RecordCard listing={makeListing()} framed={false} />)
+
+      const motionDivs = document.querySelectorAll('[style*="box-shadow"]')
+      expect(motionDivs.length).toBe(0)
+    })
+  })
+
+  describe("resetKey unflip behavior", () => {
+    it("resets flip state when resetKey changes", async () => {
+      const { rerender } = renderWithPile(
+        <RecordCard listing={makeListing({ title: "Reset Test" })} resetKey="a" />,
+      )
+
+      const card = screen.getByRole("button", { name: "Show details for Reset Test" })
+      await userEvent.click(card)
+      expect(card).toHaveAttribute("aria-pressed", "true")
+
+      rerender(
+        <ViewportProvider>
+          <PileProvider>
+            <RecordCard listing={makeListing({ title: "Reset Test" })} resetKey="b" />
+          </PileProvider>
+        </ViewportProvider>,
+      )
+
+      await waitFor(() => {
+        expect(card).toHaveAttribute("aria-pressed", "false")
+      })
+    })
+  })
+
+  describe("back-face content", () => {
+    it("shows title on the back face", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Back Face Album" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Back Face Album" })
+      await userEvent.click(card)
+
+      const titles = screen.getAllByText("Back Face Album")
+      // Title appears both in aria-label and in back-face content
+      expect(titles.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it("shows back-face content is visible after flip", async () => {
+      renderWithPile(
+        <RecordCard listing={makeListing({ title: "Meta Record", artist: "Test Artist", label: "Blue Note", year: 1975, condition: "VG+" })} />,
+      )
+
+      const card = screen.getByRole("button", { name: "Show details for Meta Record" })
+      await userEvent.click(card)
+
+      // After flip, the back face content should be in the DOM
+      expect(screen.getByText("Test Artist")).toBeInTheDocument()
+      expect(screen.getByText("Blue Note · 1975 · VG+")).toBeInTheDocument()
+    })
+
+    it("slices genres to max 3 on the back face", async () => {
+      renderWithPile(
+        <RecordCard listing={makeListing({ genres: ["Jazz", "Fusion", "Bop", "Cool"] })} />,
+      )
+
+      const card = getCard()
+      await userEvent.click(card)
+
+      expect(screen.getByText("Jazz")).toBeInTheDocument()
+      expect(screen.getByText("Fusion")).toBeInTheDocument()
+      expect(screen.getByText("Bop")).toBeInTheDocument()
+      expect(screen.queryByText("Cool")).toBeNull()
+    })
+
+    it("shows price using formatPrice on the back face", async () => {
+      renderWithPile(
+        <RecordCard listing={makeListing({ price: "15.99", currency: "USD" })} />,
+      )
+
+      const card = getCard()
+      await userEvent.click(card)
+
+      expect(screen.getByText("$15.99")).toBeInTheDocument()
+    })
+
+    it("shows — for missing price on the back face", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ price: "" })} />)
+
+      const card = getCard()
+      await userEvent.click(card)
+
+      // "—" appears for price
+      const dashes = screen.getAllByText("—")
+      expect(dashes.length).toBeGreaterThan(0)
+    })
+
+    it("shows pile toggle buttons on the back face", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Pile Album" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Pile Album" })
+      await userEvent.click(card)
+
+      expect(screen.getByText("+ Pile")).toBeInTheDocument()
+    })
+
+    it("shows Discogs link on the back face", async () => {
+      renderWithPile(
+        <RecordCard listing={makeListing({ discogs_url: "https://www.discogs.com/sell/item/42" })} />,
+      )
+
+      const card = getCard()
+      await userEvent.click(card)
+
+      const link = screen.getByText("Discogs ↗")
+      expect(link).toHaveAttribute("target", "_blank")
+      expect(link).toHaveAttribute("rel", "noopener noreferrer")
+    })
+  })
+
+  describe("front-face content", () => {
+    it("shows cover image when cover_image_url is present", () => {
+      renderWithPile(
+        <RecordCard listing={makeListing({ cover_image_url: "https://example.com/cover.jpg" })} />,
+      )
+
+      const img = document.querySelector('img[src="https://example.com/cover.jpg"]')
+      expect(img).toBeInTheDocument()
+    })
+
+    it("shows ♪ placeholder when cover_image_url is null", () => {
+      renderWithPile(<RecordCard listing={makeListing({ cover_image_url: null })} />)
+
+      expect(screen.getByText("♪")).toBeInTheDocument()
+    })
+  })
+
+  describe("nested interactive elements", () => {
+    it("does not have nested buttons", () => {
+      renderWithPile(<RecordCard listing={makeListing({ title: "Nest Check" })} />)
+
+      const buttons = document.querySelectorAll("button")
+      buttons.forEach((btn) => {
+        expect(btn.querySelectorAll("button").length).toBe(0)
+      })
+    })
+  })
+
+  describe("pile integration", () => {
+    it("adds record to pile via back-face button", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ id: 99, title: "Pile Add" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Pile Add" })
+      await userEvent.click(card)
+
+      const addButton = screen.getByText("+ Pile")
+      await userEvent.click(addButton)
+
+      await waitFor(() => {
+        expect(screen.getByText("✓ In pile")).toBeInTheDocument()
+      })
+    })
+
+    it("removes record from pile via back-face button", async () => {
+      renderWithPile(<RecordCard listing={makeListing({ id: 88, title: "Pile Remove" })} />)
+
+      const card = screen.getByRole("button", { name: "Show details for Pile Remove" })
+      await userEvent.click(card)
+
+      const addButton = screen.getByText("+ Pile")
+      await userEvent.click(addButton)
+
+      await waitFor(() => {
+        expect(screen.getByText("✓ In pile")).toBeInTheDocument()
+      })
+
+      const removeButton = screen.getByText("✓ In pile")
+      await userEvent.click(removeButton)
+
+      await waitFor(() => {
+        expect(screen.getByText("+ Pile")).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/app/frontend/components/record_card.tsx
+++ b/app/frontend/components/record_card.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react"
 import { motion } from "framer-motion"
 import { usePileContext } from "../contexts/pile_context"
 import { springFlip } from "@/lib/motion_tokens"
+import { formatPrice } from "@/lib/format_price"
 import type { Listing } from "../types/inertia"
 
 interface Props {
@@ -139,7 +140,7 @@ export default function RecordCard({ listing, resetKey, className = "", imageLoa
               </div>
             )}
             <div className="text-sm font-medium mt-auto">
-              {listing.price ? `$${parseFloat(listing.price).toFixed(2)}` : "—"}
+              {formatPrice(listing)}
             </div>
             <div className="flex gap-1 mt-1" onClick={(e) => e.stopPropagation()}>
               {inPile(listing.id) ? (
@@ -151,7 +152,7 @@ export default function RecordCard({ listing, resetKey, className = "", imageLoa
                   + Pile
                 </button>
               )}
-              <a href={listing.discogs_url} target="_blank" rel="noopener" className="mc-btn text-xs">
+              <a href={listing.discogs_url} target="_blank" rel="noopener noreferrer" className="mc-btn text-xs">
                 Discogs ↗
               </a>
             </div>

--- a/app/frontend/components/record_details.tsx
+++ b/app/frontend/components/record_details.tsx
@@ -1,0 +1,83 @@
+import { motion, AnimatePresence } from "framer-motion"
+import { usePileContext } from "@/contexts/pile_context"
+import { formatPrice } from "@/lib/format_price"
+import { type RiffleDirection } from "@/lib/riffle_navigation"
+import type { Listing } from "@/types/inertia"
+
+interface RecordDetailsProps {
+  listing: Listing
+  direction: RiffleDirection
+}
+
+/**
+ * Record detail panel shown beside the active record card in CrateView.
+ * Displays title, artist, metadata, genre/style pills, price, pile actions,
+ * and a Discogs link.
+ */
+export default function RecordDetails({ listing, direction }: RecordDetailsProps) {
+  const meta = [listing.format, listing.label, listing.year, listing.condition].filter(Boolean).join(" · ")
+  const enterY = direction === "deeper" ? -16 : 16
+  const exitY = direction === "deeper" ? 16 : -16
+  const { inPile, addToPile, removeFromPile } = usePileContext()
+
+  const allTags = [
+    ...listing.genres.slice(0, 4).map((g) => ({ label: g, dim: false })),
+    ...listing.styles.slice(0, 4).map((s) => ({ label: s, dim: true })),
+  ]
+
+  return (
+    <AnimatePresence mode="wait" custom={direction}>
+      <motion.div
+        key={listing.id}
+        custom={direction}
+        initial={{ opacity: 0, y: enterY }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: exitY }}
+        transition={{ duration: 0.18, ease: "easeOut" }}
+        className="flex flex-col gap-4"
+      >
+        {/* Header: info + price/actions in two-column row */}
+        <div className="grid grid-cols-[1fr_auto] gap-x-6 items-start">
+          <div>
+            <div className="text-xl font-semibold leading-tight">{listing.title}</div>
+            <div className="text-sm text-mc-text-dim mt-1">{listing.artist}</div>
+            {meta && <div className="text-xs text-mc-text-dim mt-2">{meta}</div>}
+          </div>
+          <div className="flex flex-col items-end gap-2">
+            <span className="text-2xl font-medium whitespace-nowrap">
+              {formatPrice(listing)}
+            </span>
+            <div className="flex gap-2">
+              {inPile(listing.id) ? (
+                <button onClick={() => removeFromPile(listing.id)} className="mc-btn">✓ In pile</button>
+              ) : (
+                <button onClick={() => addToPile(listing)} className="mc-btn mc-btn-primary">+ Pile</button>
+              )}
+              <a href={listing.discogs_url} target="_blank" rel="noopener noreferrer" className="mc-btn">Discogs ↗</a>
+            </div>
+          </div>
+        </div>
+
+        {/* Combined genre + style pills */}
+        {allTags.length > 0 && (
+          <div className="flex gap-1.5 flex-wrap">
+            {allTags.map((tag) => (
+              <span
+                key={tag.label}
+                className={`text-[11px] px-2 py-0.5 rounded bg-mc-bg-raised ${
+                  tag.dim ? "text-mc-text-dim/70" : "text-mc-text-dim"
+                }`}
+              >
+                {tag.label}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {listing.notes && (
+          <p className="text-xs text-mc-text-dim leading-relaxed line-clamp-4">{listing.notes}</p>
+        )}
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/app/frontend/hooks/use_preload.ts
+++ b/app/frontend/hooks/use_preload.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react"
+import { preloadImage } from "@/lib/preload_images"
+
+interface PreloadableRecord {
+  id: number
+  cover_image_url?: string | null
+  thumbnail_url?: string | null
+}
+
+/**
+ * Preload surrounding record images when the active index changes.
+ * Adjacent slots (±1) get high-priority full-res preloads.
+ * Edge slots (±2..±3) get thumbnail preloads and idle-priority full-res.
+ */
+export function usePreload(records: PreloadableRecord[], index: number) {
+  useEffect(() => {
+    const abort = new AbortController()
+
+    for (let offset = -3; offset <= 3; offset++) {
+      if (offset === 0) continue
+
+      const r = records[index + offset]
+      if (!r) continue
+
+      const absOffset = Math.abs(offset)
+
+      if (absOffset <= 1) {
+        // Adjacent slots: preload full-res cover (cache-warming for the decode gate)
+        if (r.cover_image_url) preloadImage(r.cover_image_url, "high")
+      } else {
+        // Edge slots: preload thumbnail only (full-res at idle priority)
+        if (r.thumbnail_url) {
+          preloadImage(r.thumbnail_url, "high")
+        }
+        if (r.cover_image_url) {
+          preloadImage(r.cover_image_url, "low", abort.signal)
+        }
+      }
+    }
+
+    return () => abort.abort()
+  }, [records, index])
+}

--- a/app/frontend/hooks/use_theme.test.ts
+++ b/app/frontend/hooks/use_theme.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useTheme } from "./use_theme"
+
+beforeEach(() => {
+  localStorage.clear()
+  document.documentElement.removeAttribute("data-theme")
+})
+
+describe("useTheme", () => {
+  it("defaults to dark when localStorage has no stored value", () => {
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe("dark")
+  })
+
+  it("restores light theme from localStorage", () => {
+    localStorage.setItem("mc-theme", "light")
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe("light")
+  })
+
+  it("restores dark theme from localStorage", () => {
+    localStorage.setItem("mc-theme", "dark")
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe("dark")
+  })
+
+  it("falls back to dark for invalid localStorage value", () => {
+    localStorage.setItem("mc-theme", "blue")
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe("dark")
+  })
+
+  it("falls back to dark for null localStorage value", () => {
+    localStorage.setItem("mc-theme", "null")
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe("dark")
+  })
+
+  it("toggle switches dark → light → dark", () => {
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe("dark")
+
+    act(() => result.current.toggle())
+    expect(result.current.theme).toBe("light")
+
+    act(() => result.current.toggle())
+    expect(result.current.theme).toBe("dark")
+  })
+
+  it("toggle writes updated value to localStorage", () => {
+    const { result } = renderHook(() => useTheme())
+
+    act(() => result.current.toggle())
+    expect(localStorage.getItem("mc-theme")).toBe("light")
+
+    act(() => result.current.toggle())
+    expect(localStorage.getItem("mc-theme")).toBe("dark")
+  })
+
+  it("sets data-theme attribute on document element for light theme", async () => {
+    const { result } = renderHook(() => useTheme())
+
+    act(() => result.current.toggle())
+    // useEffect runs after render; data-theme should be set
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light")
+  })
+
+  it("sets data-theme to empty string for dark theme", async () => {
+    // Start with light theme
+    localStorage.setItem("mc-theme", "light")
+    const { result } = renderHook(() => useTheme())
+
+    act(() => result.current.toggle())
+    expect(document.documentElement.getAttribute("data-theme")).toBe("")
+  })
+
+  it("uses dark as fallback when localStorage is unavailable (SSR safety)", () => {
+    // Verify the initializer logic: when getItem throws or returns a non-"light"
+    // value, the theme defaults to "dark". The SSR path is tested by verifying
+    // that any value other than "light" falls back to "dark".
+    localStorage.setItem("mc-theme", "")
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe("dark")
+  })
+
+  it("persists theme across re-renders", () => {
+    const { result, rerender } = renderHook(() => useTheme())
+
+    act(() => result.current.toggle())
+    expect(result.current.theme).toBe("light")
+
+    rerender()
+    expect(result.current.theme).toBe("light")
+  })
+})

--- a/app/frontend/hooks/use_theme.ts
+++ b/app/frontend/hooks/use_theme.ts
@@ -5,7 +5,8 @@ type Theme = "dark" | "light"
 export function useTheme() {
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window === "undefined") return "dark"
-    return (localStorage.getItem("mc-theme") as Theme) ?? "dark"
+    const stored = localStorage.getItem("mc-theme")
+    return stored === "light" ? "light" : "dark"
   })
 
   useEffect(() => {

--- a/app/frontend/layouts/app_layout.tsx
+++ b/app/frontend/layouts/app_layout.tsx
@@ -10,11 +10,10 @@ import BrandMark from "@/components/brand_mark"
 import MilkcrateShell from "@/layouts/milkcrate_shell"
 
 function AppLayoutInner({ children }: { children: React.ReactNode }) {
-  const page = usePage()
-  const props = page.props as any
-  const notice = props.notice as string | undefined
-  const storeName = props.store?.name as string | undefined
-  const discogsUsername = props.store?.discogs_username as string | undefined
+  const page = usePage<{ notice?: string; store?: { name?: string; discogs_username?: string } }>()
+  const notice = page.props.notice
+  const storeName = page.props.store?.name
+  const discogsUsername = page.props.store?.discogs_username
   const { theme, toggle } = useTheme()
   const { isCompact } = useViewport()
   const { pile } = usePileContext()

--- a/app/frontend/lib/format_price.test.ts
+++ b/app/frontend/lib/format_price.test.ts
@@ -1,0 +1,91 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { formatPrice, formatPriceValue } from "./format_price"
+import type { Listing } from "../types/inertia"
+
+const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
+  id: 1,
+  discogs_listing_id: "abc",
+  artist: "Artist",
+  title: "Title",
+  label: null,
+  year: null,
+  format: null,
+  genres: [],
+  styles: [],
+  condition: null,
+  price: "10.00",
+  currency: "USD",
+  cover_image_url: null,
+  thumbnail_url: null,
+  notes: null,
+  discogs_url: "https://www.discogs.com/sell/item/1",
+  ...overrides,
+})
+
+test("formatPrice: formats USD price", () => {
+  assert.equal(formatPrice(makeListing({ price: "10.00", currency: "USD" })), "$10.00")
+})
+
+test("formatPrice: formats GBP price", () => {
+  assert.equal(formatPrice(makeListing({ price: "10.00", currency: "GBP" })), "£10.00")
+})
+
+test("formatPrice: formats EUR price", () => {
+  assert.equal(formatPrice(makeListing({ price: "10.00", currency: "EUR" })), "€10.00")
+})
+
+test("formatPrice: prefers display_price when present", () => {
+  assert.equal(
+    formatPrice(makeListing({ display_price: "~$10", price: "10.00", currency: "USD" })),
+    "~$10",
+  )
+})
+
+test("formatPrice: returns — for empty price", () => {
+  assert.equal(formatPrice(makeListing({ price: "" })), "—")
+})
+
+test("formatPrice: formats zero price", () => {
+  assert.equal(formatPrice(makeListing({ price: "0.00", currency: "USD" })), "$0.00")
+})
+
+test("formatPrice: defaults currency to $ for unknown currency", () => {
+  assert.equal(formatPrice(makeListing({ price: "5.50", currency: "" })), "$5.50")
+})
+
+test("formatPriceValue: formats with USD", () => {
+  assert.equal(formatPriceValue("15.99", "USD"), "$15.99")
+})
+
+test("formatPriceValue: formats with GBP", () => {
+  assert.equal(formatPriceValue("15.99", "GBP"), "£15.99")
+})
+
+test("formatPriceValue: formats with EUR", () => {
+  assert.equal(formatPriceValue("15.99", "EUR"), "€15.99")
+})
+
+test("formatPriceValue: handles 0 as price", () => {
+  assert.equal(formatPriceValue("0", "USD"), "$0.00")
+})
+
+test("formatPriceValue: returns — for null", () => {
+  assert.equal(formatPriceValue(null), "—")
+})
+
+test("formatPriceValue: returns — for undefined", () => {
+  assert.equal(formatPriceValue(undefined), "—")
+})
+
+test("formatPriceValue: returns — for empty string", () => {
+  assert.equal(formatPriceValue(""), "—")
+})
+
+test("formatPriceValue: returns — for non-numeric string", () => {
+  assert.equal(formatPriceValue("not-a-number"), "—")
+})
+
+test("formatPriceValue: defaults to $ when no currency", () => {
+  assert.equal(formatPriceValue("10.00"), "$10.00")
+})

--- a/app/frontend/lib/format_price.ts
+++ b/app/frontend/lib/format_price.ts
@@ -1,0 +1,40 @@
+import type { Listing } from "@/types/inertia"
+
+/**
+ * Format a listing's display price. Prefers `display_price` when the
+ * backend provides it (pre-formatted). Falls back to parsing `price` with
+ * currency symbol detection.
+ *
+ * Returns "—" when no price is available.
+ */
+export function formatPrice(listing: Listing): string {
+  if (listing.display_price && listing.display_price.length > 0) {
+    return listing.display_price
+  }
+
+  return formatPriceValue(listing.price, listing.currency)
+}
+
+/**
+ * Format a raw price string and currency to a display string.
+ *
+ * Returns "—" when price is null, undefined, or empty.
+ */
+export function formatPriceValue(
+  price: string | null | undefined,
+  currency: string = "USD",
+): string {
+  if (!price) return "—"
+
+  const num = parseFloat(price)
+  if (isNaN(num)) return "—"
+
+  const symbol = currencySymbol(currency)
+  return `${symbol}${num.toFixed(2)}`
+}
+
+function currencySymbol(currency: string): string {
+  if (currency === "GBP") return "£"
+  if (currency === "EUR") return "€"
+  return "$"
+}

--- a/app/frontend/lib/preload_images.ts
+++ b/app/frontend/lib/preload_images.ts
@@ -1,0 +1,33 @@
+/**
+ * Preload an image URL at the given priority level.
+ *
+ * - "high": creates an Image immediately (current microtask).
+ * - "low": defers via requestIdleCallback (or setTimeout fallback).
+ *   Respects an optional AbortSignal to cancel deferred loads.
+ *
+ * Pure DOM utility — no React, no Framer Motion imports.
+ */
+export function preloadImage(
+  url: string,
+  priority: "high" | "low" = "high",
+  signal?: AbortSignal,
+) {
+  if (priority === "high") {
+    const img = new Image()
+    img.decoding = "async"
+    img.src = url
+  } else {
+    // Idle priority — use requestIdleCallback with setTimeout(0) fallback
+    const schedule =
+      typeof requestIdleCallback === "function"
+        ? requestIdleCallback
+        : (cb: IdleRequestCallback) => setTimeout(cb, 0)
+    const deferred = () => {
+      if (signal?.aborted) return
+      const img = new Image()
+      img.decoding = "async"
+      img.src = url
+    }
+    schedule(deferred, { timeout: 2000 })
+  }
+}

--- a/app/frontend/pages/stores/invitation.tsx
+++ b/app/frontend/pages/stores/invitation.tsx
@@ -100,8 +100,15 @@ function InvitationContent({ slug }: { slug: string }) {
     const timeoutId = setTimeout(() => controller.abort(), 10000)
 
     fetch(`/api/discogs/lookup/${encodeURIComponent(slug)}`, { signal: controller.signal })
-      .then((res) => res.json() as Promise<LookupResponse>)
+      .then((res) => {
+        if (!res.ok) {
+          setProbeState("error")
+          return
+        }
+        return res.json() as Promise<LookupResponse>
+      })
       .then((data) => {
+        if (!data) return
         if (data.found) {
           setSellerName(data.seller_name || slug)
           setProbeState("found")

--- a/app/frontend/pages/stores/show.tsx
+++ b/app/frontend/pages/stores/show.tsx
@@ -6,8 +6,14 @@ import StoreFloor from "@/components/store_floor"
 import type { StoreShowProps } from "@/types/inertia"
 
 export default function StoreShow({ store, crates, storefront_sections }: StoreShowProps) {
-  const [activeSlug, setActiveSlug] = useState<string | null>(null)
-  const [startIndex, setStartIndex] = useState(0)
+  const [activeSlug, setActiveSlug] = useState<string | null>(() => {
+    const raw = history.state?.crateSlug
+    return typeof raw === "string" && raw.length > 0 ? raw : null
+  })
+  const [startIndex, setStartIndex] = useState(() => {
+    const raw = history.state?.startIndex
+    return Number.isFinite(raw) && (raw as number) >= 0 ? raw as number : 0
+  })
 
   const allCrates = useMemo(() => {
     if (crates.length > 0) return crates

--- a/docs/plans/2026-05-18-002-refactor-frontend-health-check-fixes-plan.md
+++ b/docs/plans/2026-05-18-002-refactor-frontend-health-check-fixes-plan.md
@@ -1,0 +1,539 @@
+---
+title: "refactor: Frontend health check fixes"
+type: refactor
+status: completed
+date: 2026-05-18
+origin: docs/solutions/ (N/A — sourced from holistic code review findings)
+---
+
+# refactor: Frontend health check fixes
+
+## Summary
+
+Targeted cleanup of the 18 P0-P1 findings from a holistic frontend health check — type safety fixes, dead CSS removal, price formatting unification, CrateView decomposition, CrateCard/CrateShelf deduplication, three small correctness fixes, and critical test coverage for PileSheet, CrateCard, RecordCard, and useTheme.
+
+---
+
+## Problem Frame
+
+A holistic review of `app/frontend/` (65 files, ~9,350 lines) identified 42 findings across type safety, maintainability, and testing. The 18 P0-P1 findings represent: type-unsafe casts that silently corrupt at runtime, ~200 lines of dead CSS shipping to every user, a 549-line God component resisting maintenance, duplicated component logic with split currency support, and zero test coverage on four interactive surfaces where regressions would break core UX (pile management, card flip, crate browsing, theme toggle).
+
+---
+
+## Requirements
+
+- R1. Eliminate `as any` and unsafe `as Theme` casts — all page props and localStorage reads must be validated before use
+- R2. Remove all unused CSS class definitions from `app/assets/tailwind/application.css`
+- R3. Centralize price formatting into a single shared utility, eliminating the `$`-hardcoding in RecordCard and PileSheet
+- R4. Decompose `crate_view.tsx` by extracting `RecordDetails`, `preloadImage`, and `usePreload` into their own modules
+- R5. Eliminate the ~60% structural duplication between CrateCard and CrateShelf
+- R6. Prevent CrateView's Arrow key handler from firing when focus is in form elements or a modal is open
+- R7. Restore the previously-viewed crate when navigating back to a store page
+- R8. Surface HTTP error status from the invitation Discogs lookup instead of silently treating all failures as "page available"
+- R9. Add comprehensive tests for PileSheet (confirmClear flow, total calculation, record removal, focus management, responsive layout)
+- R10. Add comprehensive tests for CrateCard (hover animation states, keyboard navigation, empty state, thumbnail click indexing)
+- R11. Add comprehensive tests for RecordCard (flip mechanics, drag suppression, disableFlip and framed props, back-face content, pile toggle)
+- R12. Add tests for useTheme (localStorage persistence, SSR fallback, toggle, DOM attribute side effects)
+
+---
+
+## Scope Boundaries
+
+- P2/P3 findings (24 items: import path standardization, UI component adoption across pages, spinner extraction, test factory dedup, focus-ring utility, localStorage key naming, motion token CSS/TS split, admin CSRF token centralization, AnimatedSection extraction, lib test runner migration, smoke test quality) — deferred to follow-up
+- Backend changes to support typed Inertia page props (e.g., Rails-side shared props interface) — deferred; the plan fixes the frontend side only
+- CSS architectural changes beyond dead-code removal (e.g., Tailwind v4 migration of `@theme` to `@layer`, consolidation of `.mc-input` duplicate rules) — deferred
+
+### Deferred to Follow-Up Work
+
+- P2/P3 finding fixes: separate cleanup pass after this plan lands (filed as follow-up issue)
+- Lib test migration from `node:test` → `vitest`: 4 test files need conversion
+- Test data factory extraction: `makeListing`/`makeCrate` dedup across 7 files
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **MilkcrateShell slot-based decomposition** (`app/frontend/layouts/milkcrate_shell.tsx`): thin shared shell contract where each consumer passes header/footer/content through slot props. Reference pattern for CrateView decomposition.
+- **Context → Hook → Component layering**: `PileContext` wraps `usePile()`; `ViewportContext` wraps `useViewport()`. New extracted hooks follow this pattern.
+- **`renderWithTier()`** (`app/frontend/test/viewport-test-utils.tsx`): injects a fixed viewport tier in tests without `matchMedia` mocking. Tests for interactive components use this plus `describe.each(tiers)`.
+- **`makeListing()` / `makeCrate()`** test data factories: co-located in test files. Pattern for new test files.
+- **Pure-library pattern** (`app/frontend/lib/`): zero-dependency pure functions — no React, no DOM, no Framer Motion. `preloadImage` follows this.
+- **Currency-aware formatting** in `crate_view.tsx:77` (RecordDetails): ternary on `listing.currency` for £/€/$. Reference for unified utility.
+- **Accessibility test** (`app/frontend/components/accessibility.test.tsx`): checks for nested-button violations across primitives. Pattern to extend for new interactive components.
+
+### Institutional Learnings
+
+- **Guard-parity audit** (`docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`): When splitting a single render path into responsive branches, guard conditions like `!hideTabs` are easily replicated to one branch and dropped from the other. CrateView decomposition must audit every guard across both compact and wide branches.
+- **ViewportContext testing conventions** (`docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`): nested-button trap — any clickable wrapper around interactive children must use `role="button"` on a `<div>`, never `<button>` or `motion.button`. New components must pass the accessibility test.
+- **Vendor-brand surface system** (`docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md`): three-layer decomposition pattern (identity → layout → content), guard-parity audit checklist, cross-surface responsive test matrix.
+- **Animation token centralization** (`docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`): token pruning must search production code before deletion, keep tokens with active consumers, update tests to describe current API surface.
+- **Crate strategies meta-pattern** (`docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`): extract a shared interface from duplicated implementations — the same shape as CrateCard→CrateShelf dedup.
+
+### Prior Completed Work
+
+A previous cleanup plan (`docs/plans/2026-05-18-001-refactor-frontend-unused-code-cleanup-plan.md`, status: **completed**) already removed `TactileCard`/`StorefrontPreview` components, pruned unused motion token exports, retired the `mc-dig-session` legacy localStorage migration key, and enabled TypeScript unused-code compiler checks. This plan's dead-CSS work (R2) builds on that foundation. Component consolidation (R5) was explicitly deferred there.
+
+---
+
+## Key Technical Decisions
+
+- **CrateView decomposition extracts 3 modules, not 6**: RecordDetails (component), preloadImage + usePreload (lib + hook), plus a future CrateStack and CrateControls deferred. The 3 extractions are self-contained and independently testable; the remaining card-stack and paginator blocks are more coupled and riskier to extract without a broader refactor.
+- **CrateCard wraps CrateShelf, not shared base**: CrateShelf is already the more configurable component (supports both `interactive`/non-interactive modes, configurable `previewCount`, `openLabel`). CrateCard becomes a thin Framer Motion wrapper around `<CrateShelf interactive ... />` that adds the tactile hover animations. This avoids introducing a third abstraction layer.
+- **Price utility prefers `display_price`**: When the backend provides `listing.display_price`, the utility returns it directly (it's already formatted). Falls back to `parseFloat(price).toFixed(2)` with currency symbol detection. This preserves the backend's ability to pre-format while fixing the client-side `$`-only hardcoding.
+- **Tests written against current interfaces, not extracted ones**: Test units (U9-U12) test the public component/hook API as it exists today. Extractions (U4, U5) re-export through the original paths. This keeps tests stable across the refactor.
+- **No shared Inertia PageProps type created**: The `as any` fix replaces the cast with a narrow local interface rather than introducing a cross-cutting shared type. A proper shared PageProps type requires Rails-side coordination (the server decides what props exist) — deferred.
+
+---
+
+## Open Questions
+
+### Deferred to Implementation
+
+- **`CrateCard` test interaction with `useTactileHover`**: Proximity-based hover states are hard to unit-test without mocking pointer events carefully. The plan calls for testing animation `animate` target values (scale, y, rotate, borderColor) rather than proximity internals.
+- **`RecordCard` drag suppression test precision**: The 8px `Math.hypot` threshold is implementation-specific. Tests assert "click after substantial pointer movement does not flip" rather than testing exact pixel values.
+- **CrateView Arrow key guard exact focus check**: Whether to use `instanceof HTMLInputElement` or `e.target.closest('input, textarea, select, [contenteditable]')` depends on which surface the focus is actually on at runtime. Defer to implementation to choose the right DOM check.
+
+---
+
+## Implementation Units
+
+### U1. Type Safety Fixes
+
+**Goal:** Replace unsafe type casts in app_layout and use_theme with validated types.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/layouts/app_layout.tsx`
+- Modify: `app/frontend/hooks/use_theme.ts`
+- Test: `app/frontend/hooks/use_theme.test.ts` (created in U9)
+
+**Approach:**
+- `app_layout.tsx`: Replace `const props = page.props as any` with a narrow `AppLayoutProps` interface (`{ notice?: string; store?: { name?: string; discogs_username?: string } }`). Remove the individual `as string | undefined` casts on lines 15-17.
+- `use_theme.ts`: Replace `localStorage.getItem("mc-theme") as Theme` with a validated read: `const stored = localStorage.getItem("mc-theme"); return stored === "light" ? "light" : "dark"`.
+
+**Patterns to follow:**
+- Existing typed props pattern in pages (e.g., `stores/show.tsx` accepts `StoreShowProps`)
+
+**Test scenarios:**
+- Happy path: `AppLayout` renders with typed props matching interface — no runtime casts
+- Happy path: `useTheme` returns `"dark"` when localStorage has no value, `"light"` when stored value is `"light"` (tested in U9)
+- Edge case: `useTheme` returns `"dark"` when localStorage contains `"blue"`, `null`, or any non-`"light"` value (tested in U9)
+- Edge case: `useTheme` returns `"dark"` in SSR context (tested in U9)
+
+**Verification:**
+- No `as any` cast remains in `app_layout.tsx`
+- No unsafe `as Theme` cast remains in `use_theme.ts`
+- Existing tests pass unchanged
+
+---
+
+### U2. Dead CSS Removal
+
+**Goal:** Remove legacy CSS class definitions no longer referenced by any React component.
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/assets/tailwind/application.css`
+
+**Approach:**
+- Remove legacy Dig View classes (`.mc-dig-view`, `.mc-dig-stack`, `.mc-dig-slot`, `.mc-dig-nav`, `.mc-dig-nav-btn`, `.mc-dig-counter`, `.mc-dig-hint` — ~50 lines, lines ~247-297)
+- Remove component classes replaced by React rewrite: `.mc-record-card`, `.mc-record-card-inner`, `.mc-record-front`, `.mc-record-back` and all back-face sub-classes, `.mc-pile-list`, `.mc-pile-item`, `.mc-pile-thumb`, `.mc-pile-info`, `.mc-pile-title`, `.mc-pile-artist`, `.mc-pile-price`, `.mc-crate-row`, `.mc-sections`, `.mc-section-browse`, `.mc-accent-link`, `.mc-session-bar` — ~150 lines
+- Before deleting any class, grep `app/` (excluding `.css` files) to confirm zero non-CSS references
+- Keep CSS custom properties (`--mc-*`) and active utility classes (`.mc-btn`, `.mc-input`, `.mc-header`, etc.)
+
+**Patterns to follow:**
+- Reference-verified deletion pattern from prior cleanup plan (`docs/plans/2026-05-18-001-refactor-frontend-unused-code-cleanup-plan.md` U2/U3)
+
+**Test scenarios:**
+- Test expectation: none — pure CSS removal; existing visual regression is covered by component tests. Confirm zero grep matches for each deleted class across `app/` excluding `.css`.
+
+**Verification:**
+- All deleted class names return zero grep matches in `app/` (excluding `.css` files)
+- `npm run test:components` passes (no CSS-dependent test breakage)
+- Visual inspection: storefront, admin dashboard render without layout breakage
+
+---
+
+### U3. Price Formatting Utility
+
+**Goal:** Create a shared `formatPrice` utility and replace all 6 inline price formatting call sites.
+
+**Requirements:** R3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/frontend/lib/format_price.ts`
+- Test: `app/frontend/lib/format_price.test.ts`
+- Modify: `app/frontend/components/crate_view.tsx` (RecordDetails, line 77)
+- Modify: `app/frontend/components/record_card.tsx` (line 142)
+- Modify: `app/frontend/components/pile_sheet.tsx` (lines 19, 151, 173)
+
+**Approach:**
+- Export `formatPrice(listing: Listing): string`: returns `listing.display_price` when present, otherwise `parseFloat(listing.price).toFixed(2)` with currency symbol detection (£ for GBP, € for EUR, $ otherwise). Returns `"—"` for missing/null price.
+- Export `formatPriceValue(price: string | null | undefined): string`: same logic without the `display_price` fallback, for PileSheet's reduce loop.
+- Replace inline formatting at all 6 call sites.
+- The `Listing` type already has `display_price?: string` — use it.
+
+**Patterns to follow:**
+- Pure-library pattern: zero React/DOM/Framer Motion imports
+- Currency detection from `crate_view.tsx:50` (existing ternary)
+
+**Test scenarios:**
+- Happy path: `formatPrice({ price: "10.00", currency: "USD" })` → `"$10.00"`
+- Happy path: `formatPrice({ price: "10.00", currency: "GBP" })` → `"£10.00"`
+- Happy path: `formatPrice({ price: "10.00", currency: "EUR" })` → `"€10.00"`
+- Happy path: `formatPrice({ display_price: "~$10", price: "10.00", currency: "USD" })` → `"~$10"` (display_price wins)
+- Edge case: `formatPrice({ price: null, currency: "USD" })` → `"—"`
+- Edge case: `formatPrice({ price: "0.00", currency: "USD" })` → `"$0.00"`
+- Edge case: `formatPriceValue("0")` → `"$0.00"`, `formatPriceValue(null)` → `"—"`
+
+**Verification:**
+- All 6 call sites use the shared utility
+- RecordCard and PileSheet no longer hardcode `$`
+- `npm run test:frontend` passes for the new test file
+
+---
+
+### U4. CrateView Decomposition
+
+**Goal:** Extract `RecordDetails` component and `preloadImage`/`usePreload` from `crate_view.tsx` into their own modules.
+
+**Requirements:** R4
+
+**Dependencies:** U3 (price utility available for RecordDetails)
+
+**Files:**
+- Create: `app/frontend/components/record_details.tsx`
+- Create: `app/frontend/lib/preload_images.ts`
+- Create: `app/frontend/hooks/use_preload.ts`
+- Modify: `app/frontend/components/crate_view.tsx` (reduce from 549 to ~420 lines)
+- Test: `app/frontend/components/record_details.test.tsx` (optional smoke; full integration coverage from existing CrateView tests)
+
+**Approach:**
+- `RecordDetails`: Move lines 40-104 from `crate_view.tsx` into `components/record_details.tsx`. Export as default. Import in `crate_view.tsx`. Props: `listing: Listing`, `direction: RiffleDirection`. The component uses `usePileContext()` and `AnimatePresence` + `motion.div` — these imports move with it.
+- `preloadImage`: Move lines 106-119 into `lib/preload_images.ts` as a named export. Pure DOM utility — no React imports.
+- `usePreload`: Move lines 121-163 into `hooks/use_preload.ts` as a named export. Depends on `preloadImage` from the lib module.
+- After extraction, run a guard-parity audit on `crate_view.tsx`: verify all conditionals (`!hideTabs`, `total > 0`, `isCompact`, `activeRecord`, `!activeCrate`) still guard every responsive branch.
+
+**Patterns to follow:**
+- MilkcrateShell slot-based decomposition: narrow contract as props
+- `RecordDetails` uses `usePileContext()` — consumer handles context boundary (pattern from `PileSheet`)
+
+**Test scenarios:**
+- Happy path: Existing `crate_view.test.tsx` tests all pass after extraction — RecordDetails behavior tested through CrateView integration
+- Edge case: All guard conditions verified across compact and wide branches (guard-parity audit checklist)
+
+**Verification:**
+- `crate_view.tsx` is under 450 lines
+- `npm run test:components` passes — existing CrateView tests pass without modification
+- No dead imports remain in `crate_view.tsx`
+
+---
+
+### U5. CrateCard/CrateShelf Deduplication
+
+**Goal:** Rewrite CrateCard as a thin Framer Motion wrapper around CrateShelf, eliminating ~80 lines of duplicated layout, keyboard handling, and empty-state logic.
+
+**Requirements:** R5
+
+**Dependencies:** U4 (establishes extraction pattern)
+
+**Files:**
+- Modify: `app/frontend/components/crate_card.tsx`
+- Modify: `app/frontend/components/crate_shelf.tsx` (minor — may need to expose inner components or props)
+- Test: `app/frontend/components/crate_card.test.tsx` (created in U12 — can verify wrapper behavior)
+
+**Approach:**
+- CrateCard renders `<CrateShelf interactive openLabel="DIG →" previewCount={4} ... />` inside a `motion.div` that applies the tactile hover animations (borderColor, scale, y, rotate).
+- The tactile hover handlers from `useTactileHover` spread onto the outer motion.div wrapper.
+- The inner thumbnail grid's `innerHoverScale` animation is preserved via CrateShelf's existing inner hover behavior or by passing a `className`/style prop.
+- Empty state (`records.length === 0`): CrateShelf already handles this. CrateCard delegates.
+- Variant (`featured` vs `genre`): passed as `headerSize` or similar prop to CrateShelf, or handled by CrateCard wrapping CrateShelf's header.
+- Delete duplicated code from CrateCard: header layout, thumbnail grid, keyboard handling, empty state, aria-label pattern.
+
+**Test scenarios:**
+- Covers tests defined in U12 (CrateCard test unit)
+
+**Verification:**
+- CrateCard is under 60 lines (down from ~116)
+- `npm run test:components` passes — existing integration tests (storefront_shell.test.tsx) still work
+- CrateCard and CrateShelf produce identical DOM structure (header + grid + thumbnails) for the same crate data
+- Visual: FeaturedCratesRow and GenreGrid render identically before and after refactor
+
+---
+
+### U6. CrateView Keydown Guarding
+
+**Goal:** Prevent CrateView's global Arrow key handler from intercepting keystrokes meant for form inputs, textareas, or open modals.
+
+**Requirements:** R6
+
+**Dependencies:** None (U4 modifies the same file but the guard is a 3-line addition — order-independent)
+
+**Files:**
+- Modify: `app/frontend/components/crate_view.tsx`
+
+**Approach:**
+- At the top of `handleKeyDown`, add a guard: skip when `e.target` is an `HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, or has `isContentEditable`.
+- Also skip when `document.querySelector('[role="dialog"][aria-modal="true"]')` is present (PileSheet or other modals).
+- The guard fires before the `direction` resolution and `navigate` call.
+
+**Test scenarios:**
+- Happy path: ArrowDown/ArrowUp navigates crate when no input is focused
+- Edge case: ArrowDown does NOT navigate when an `<input>` is focused
+- Edge case: ArrowDown does NOT navigate when a `<textarea>` is focused
+- Integration: ArrowUp does NOT navigate when PileSheet modal is open (`role="dialog"` with `aria-modal="true"`)
+
+**Verification:**
+- Keyboard navigation still works in normal crate browsing
+- Arrow keys in PileSheet modal do not change the background crate's active record
+- Arrow keys in the admin dashboard search input do not trigger crate navigation
+
+---
+
+### U7. StoreShow History Restoration
+
+**Goal:** Restore the previously-viewed crate when the user navigates back to a store page via browser back.
+
+**Requirements:** R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/pages/stores/show.tsx`
+
+**Approach:**
+- Change `useState<string | null>(null)` to `useState<string | null>(() => history.state?.crateSlug ?? null)`.
+- Change `useState(0)` to `useState(() => history.state?.startIndex ?? 0)`.
+- The existing `popstate` listener already handles forward/back events after initial render — this fix covers the initial mount case.
+
+**Test scenarios:**
+- Happy path: Browser back from crate view to store page — CrateView renders with the previously-active slug, not StoreFloor
+- Edge case: First visit to store page (no history.state) — StoreFloor renders as before
+- Edge case: history.state contains `crateSlug` but slug no longer exists in crates — falls through to first crate (existing behavior of `crates.find`)
+
+**Verification:**
+- `activeSlug` is restored from `history.state` on initial mount
+- Existing navigation behavior (push/replace state, popstate listener) unchanged
+
+---
+
+### U8. Invitation Fetch Error Handling
+
+**Goal:** Distinguish HTTP errors from "seller not found" in the Discogs lookup on the invitation page.
+
+**Requirements:** R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/pages/stores/invitation.tsx`
+
+**Approach:**
+- Add `if (!res.ok) { setProbeState("error"); return }` before `res.json()` in the fetch chain (line ~85-93).
+- This prevents a 500/503 HTML response from being passed to `res.json()`, which would throw a `SyntaxError` that gets swallowed into the generic catch.
+- The catch clause already sets `probeState` to `"error"` — with this guard, true network errors and 500 responses both surface as error state, while 404 (not found) correctly reaches `res.json()` and sets `"not_found"`.
+
+**Test scenarios:**
+- Happy path: 200 response with `{ found: true }` → renders seller name and "Claim this storefront" button
+- Error path: 500 response → renders "page available" error state (not a JSON parse crash)
+- Error path: 503 response → renders error state (not broken JSON parsing)
+- Edge case: Network failure (fetch throws) → renders error state (existing behavior, now more robust)
+
+**Verification:**
+- `res.json()` is only called when `res.ok` is true
+- Error state is reachable via both network failure and non-200 HTTP status
+
+---
+
+### U9. Test Coverage: useTheme
+
+**Goal:** Add comprehensive tests for the useTheme hook.
+
+**Requirements:** R12
+
+**Dependencies:** U1 (validation fix should land first so tests validate the fixed behavior)
+
+**Files:**
+- Create: `app/frontend/hooks/use_theme.test.ts`
+
+**Approach:**
+- Use `renderHook` from `@testing-library/react` with `act` for state changes.
+- Mock `localStorage` via `vi.stubGlobal` or a per-test setup.
+- Test initial state, SSR default, toggle, localStorage persistence, `data-theme` attribute, and invalid value recovery.
+
+**Patterns to follow:**
+- Existing hook test patterns in `use_pile.test.ts` and `use_tactile_hover.test.tsx`
+
+**Test scenarios:**
+- Happy path: Initial theme defaults to `"dark"` when localStorage has no stored value
+- Happy path: Toggle switches `"dark"` → `"light"` → `"dark"`
+- Happy path: Toggle writes updated value to localStorage
+- Happy path: Toggle sets `document.documentElement.dataset.theme` — `"light"` or empty string
+- Edge case: localStorage contains `"light"` → initial theme is `"light"`
+- Edge case: localStorage contains `"blue"` → initial theme falls back to `"dark"` (not "blue")
+- Edge case: `typeof window === "undefined"` → initial theme is `"dark"` (SSR safety)
+
+**Verification:**
+- All test scenarios pass
+- `npm run test:components` picks up the new test file
+
+---
+
+### U10. Test Coverage: PileSheet
+
+**Goal:** Add comprehensive tests for PileSheet — dialog mechanics, confirmClear flow, total calculation, record actions, and responsive layout.
+
+**Requirements:** R9
+
+**Dependencies:** U3 (price formatting utility available for total calculation tests)
+
+**Files:**
+- Create: `app/frontend/components/pile_sheet.test.tsx`
+
+**Approach:**
+- Wrap PileSheet in `PileProvider` + `ViewportProvider` (or `renderWithTier`).
+- Use `userEvent` for click interactions (open, close, clear confirmation).
+- Test the confirmClear two-step flow (Clear → "Sure? Yes/No" → clearPile or cancel).
+- Test total price calculation with multiple records.
+- Test individual record removal.
+- Test responsive layout variants (compact bottom-sheet vs desktop side-panel).
+- Test accessibility: `role="dialog"`, `aria-modal`, `aria-labelledby`, Escape key, focus management.
+
+**Patterns to follow:**
+- Existing PileSheet test in `accessibility.test.tsx:85` (Escape key) — extend this pattern
+- `renderWithTier` for responsive layout tests
+
+**Test scenarios:**
+- Happy path: Records render with cover art, title, artist, and price
+- Happy path: Individual record remove button calls `removeFromPile`
+- Happy path: Total price displays sum of all pile record prices
+- Happy path: Empty pile shows "No records in your pile yet."
+- Edge case: confirmClear: "Clear" → shows "Sure? Yes/No" → "No" returns to "Clear" button
+- Edge case: confirmClear: "Clear" → shows "Sure? Yes/No" → "Yes" calls `clearPile` and resets state
+- Edge case: Total is `$0.00` for empty pile
+- Edge case: Record with null price contributes zero to total
+- Integration: Escape key closes dialog (existing test — verify still passes)
+- Integration: `aria-modal="true"` and `role="dialog"` are set
+- Integration: `aria-labelledby` targets an element with id `"pile-sheet-title"` that exists
+- Responsive: Compact tier renders bottom-sheet with drag handle bar
+- Responsive: Wide tier renders side-panel
+
+**Verification:**
+- All test scenarios pass
+- Tests do not rely on internal implementation details (confirmClear state variable name, etc.)
+
+---
+
+### U11. Test Coverage: RecordCard
+
+**Goal:** Add comprehensive tests for RecordCard — flip mechanics, drag suppression, prop variants, back-face content, and pile integration.
+
+**Requirements:** R11
+
+**Dependencies:** None (tests against current component interface)
+
+**Files:**
+- Create: `app/frontend/components/record_card.test.tsx`
+
+**Approach:**
+- Wrap RecordCard in `PileProvider` for pile button tests.
+- Use `userEvent.click` and `userEvent.pointer` for flip and drag tests.
+- Test `disableFlip` prop renders non-interactive card.
+- Test `resetKey` unflip behavior.
+- Test `framed` prop styling.
+- Test back-face content: meta string, genres (max 3), price, pile toggle, Discogs link.
+
+**Patterns to follow:**
+- Existing RecordCard test in `accessibility.test.tsx:53` (keyboard flip) and `:218` (no nested buttons) — extend these
+
+**Test scenarios:**
+- Happy path: Click flips card (front → back)
+- Happy path: Back-face shows title, artist, meta string, genres, price, pile button, Discogs link
+- Happy path: Pile button toggles between "+ Pile" and "✓ In pile"
+- Happy path: Discogs link renders with correct `href`, `target="_blank"`, `rel="noopener"`
+- Edge case: Click after pointer-move > 8px does NOT flip (drag suppression)
+- Edge case: `disableFlip={true}` renders no `role="button"`, no `tabIndex`, click does nothing
+- Edge case: `disableFlip={true}` removes `aria-pressed` attribute
+- Edge case: `resetKey` change triggers unflip via useEffect
+- Edge case: `framed={true}` applies box-shadow style
+- Edge case: Back-face genres slice to max 3
+- Edge case: Front-face shows cover_image_url, falls back to ♪ placeholder when null
+
+**Verification:**
+- All test scenarios pass
+- No false positives from Framer Motion's animation lifecycle (use `jest.useFakeTimers` or `waitFor` as needed)
+
+---
+
+### U12. Test Coverage: CrateCard
+
+**Goal:** Add comprehensive tests for CrateCard — hover states, keyboard navigation, empty state, and thumbnail click indexing.
+
+**Requirements:** R10
+
+**Dependencies:** U5 (CrateCard interface stabilizes after dedup — write tests after U5 lands)
+
+**Files:**
+- Create: `app/frontend/components/crate_card.test.tsx`
+
+**Approach:**
+- Test the component as rendered via its consumers (FeaturedCratesRow, GenreGrid) or directly with `renderWithTier`.
+- Test keyboard Enter/Space on the interactive wrapper.
+- Test closest-guard: keyboard event does not fire when target is a nested button.
+- Test empty state rendering.
+- Test animation `animate` target values rather than `useTactileHover` internal proximity.
+- Test thumbnail click calls `onSelectCrate` with correct slug and index.
+
+**Patterns to follow:**
+- Existing CrateShelf test patterns (`crate_shelf.test.tsx`)
+
+**Test scenarios:**
+- Happy path: Keyboard Enter on outer div calls `onSelectCrate` with slug
+- Happy path: Keyboard Space on outer div calls `onSelectCrate` with slug
+- Happy path: Thumbnail button click calls `onSelectCrate` with slug and correct index (0-3)
+- Happy path: Thumbnail button `stopPropagation` prevents outer click handler
+- Edge case: Keyboard event does not fire when `e.target.closest("button, a")` is truthy
+- Edge case: Empty crate (records.length === 0) shows "No records yet" and no grid
+- Edge case: `variant="featured"` renders `text-base font-semibold` header
+- Edge case: `variant="genre"` renders `text-sm font-semibold` header
+- Animation: `animate` target has `scale: SCALE_HOVER` when `isHovered` (test via `motion.div` props snapshot or by mocking `useTactileHover`)
+
+**Verification:**
+- All test scenarios pass
+- CrateCard integration (FeaturedCratesRow/GenreGrid) still renders correctly after U5 refactor
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| CrateView decomposition breaks guard conditions in responsive branches | Run guard-parity audit checklist after U4: verify every conditional on original render path appears on every new branch |
+| CrateCard/CrateShelf dedup changes DOM structure, breaking existing integration tests | Run `npm run test:components` after U5 and fix any selector breakage; CrateShelf test is the reference for expected DOM |
+| Price formatting changes RecordCard/PileSheet visual output for non-USD currencies | GBP/EUR stores currently see wrong symbols — this is a fix, not a regression. Verify with test data containing GBP and EUR pricing |
+| New tests depend on Framer Motion animation lifecycle timing | Use `jest.useFakeTimers` with `act()` or `waitFor` for spring-based animations; existing CrateView tests already handle this |
+| Type safety fix for `app_layout.tsx` may narrow props too aggressively, breaking pages that pass extra props | Use optional properties throughout the narrow interface; if a prop was always `undefined`, the page never depended on it |
+
+---
+
+## Sources & References
+
+- **Origin document:** None — sourced from holistic frontend health check findings (2026-05-18)
+- Pattern reference: `app/frontend/layouts/milkcrate_shell.tsx` — slot-based decomposition pattern
+- Pattern reference: `app/frontend/test/viewport-test-utils.tsx` — renderWithTier utility
+- Pattern reference: `app/frontend/components/accessibility.test.tsx` — accessibility test patterns
+- Learning: `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`
+- Learning: `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`
+- Learning: `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md`
+- Learning: `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`
+- Prior plan: `docs/plans/2026-05-18-001-refactor-frontend-unused-code-cleanup-plan.md`


### PR DESCRIPTION
## Summary

Targeted cleanup of 12 P0-P1 findings from a holistic frontend health check. This PR addresses type safety, dead CSS removal, price formatting unification, CrateView decomposition, CrateCard/CrateShelf deduplication, three small correctness fixes, and comprehensive test coverage for four previously untested surfaces.

**Plan:** `docs/plans/2026-05-18-002-refactor-frontend-health-check-fixes-plan.md`

## Changes

### Type Safety (U1)
- Replace `as any` and unsafe `as Theme` casts with validated types in `app_layout.tsx` and `use_theme.ts`

### Dead CSS Removal (U2)
- Remove 27 unused CSS class definitions (~250 lines) shipping to every user — all verified with zero grep matches across the codebase

### Price Formatting Unification (U3)
- Create shared `formatPrice`/`formatPriceValue` utilities with currency symbol detection (£/€/$)
- Replace 6 inline `$`-hardcoded formatting call sites in RecordCard, PileSheet, and RecordDetails

### CrateView Decomposition (U4)
- Extract `RecordDetails` component (95 lines), `preloadImage` lib utility (30 lines), and `usePreload` hook (40 lines) into their own modules
- `crate_view.tsx` reduced from 549 → 437 lines

### CrateCard/CrateShelf Deduplication (U5)
- Rewrite CrateCard as a 42-line Framer Motion wrapper around CrateShelf, eliminating ~80 lines of duplicated layout, keyboard handling, and empty-state logic
- Add `headerSize` prop to CrateShelf for featured/genre variant styling

### Correctness Fixes (U6-U8)
- **Keydown guarding:** CrateView Arrow keys now skip when focus is in form elements (`input`, `textarea`, `select`, `contenteditable`) or a modal is open
- **History restoration:** Previously-viewed crate state restored from `history.state` on browser back to a store page
- **Fetch error handling:** Invitation Discogs lookup guards `res.ok` before `res.json()` — 500/503 responses now surface as error state instead of JSON parse crashes

### Security Hardening
- Add `noreferrer` to all `target="_blank"` Discogs links (3 locations)
- Add type validation guards to `history.state` reads in `show.tsx`

### Test Coverage (U9-U12)
- **81 new tests** across 4 new test files:
  - `use_theme.test.ts` — localStorage persistence, SSR safety, toggle, DOM attribute side effects (11 tests)
  - `pile_sheet.test.tsx` — dialog mechanics, confirmClear flow, total calculation, record removal, responsive layout (29 tests)
  - `record_card.test.tsx` — flip mechanics, drag suppression, disableFlip/framed props, back-face content, pile integration (23 tests)
  - `crate_card.test.tsx` — rendering, empty state, keyboard navigation, thumbnail indexing, accessibility (18 tests)

## Testing

- **All 365 vitest tests pass** across 22 test files
- **TypeScript type-check is clean** (`tsc --noEmit`)
- **16 lib tests pass** via `node --test --import tsx` (`format_price.test.ts`)

### Files changed
10 modified, 9 new, 1 new plan doc

## Post-Deploy Monitoring & Validation

- **No additional operational monitoring required.** This is a frontend-only cleanup with no backend, database, or API changes. All behavioral changes are covered by the expanded test suite. Visual regression is limited to preserved DOM structure (CrateCard now delegates to CrateShelf) and the price formatting now correctly displays £/€ symbols for non-USD stores (a fix, not a regression).

## Known Residuals (from code review)

1. **Medium — CrateShelf `useTactileHover` never activates** (`crate_shelf.tsx:52`): The hook destructures only `isHovered` without spreading `handlers` on any DOM element, so `isHovered` is always `false`. The "DIG →" open label and inner thumbnail hover scale never animate. Pre-existing; affects both CrateCard and StoreFloor CrateShelf usage. Tracked for follow-up.