### PR TITLE
fix: centralize Discogs rate limiting and sync all stores nightly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 project_tracker: github
 
+# ce-work Branching
+
+This project uses `development` as its integration branch (not `main`). When
+`ce-work` detects that the current branch is `development`, it should create a
+new feature branch from `development` (pulling `origin/development` first), not
+from the remote HEAD default.
+
+In Phase 1 Step 2 of ce-work, treat `development` as if it were the default
+branch for branching decisions. Feature branches should be named e.g.
+`feat/my-feature` or `fix/my-fix` and target `development`.
+
 # Documented Solutions
 
 `docs/solutions/` — documented solutions to past problems (bugs, best practices,

--- a/app/jobs/enrichment_job.rb
+++ b/app/jobs/enrichment_job.rb
@@ -1,4 +1,5 @@
 class EnrichmentJob < ApplicationJob
+  limits_concurrency to: 1, key: -> { "discogs_api" }
   queue_as :default
 
   def perform(store_id, listing_ids: nil)

--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -1,4 +1,5 @@
 class FullStoreSyncJob < ApplicationJob
+  limits_concurrency to: 1, key: -> { "discogs_api" }
   queue_as :default
 
   def perform(store_id, max_pages: nil)

--- a/app/jobs/sync_all_stores_job.rb
+++ b/app/jobs/sync_all_stores_job.rb
@@ -1,0 +1,13 @@
+class SyncAllStoresJob < ApplicationJob
+  queue_as :default
+
+  STAGGER_INTERVAL = 5.minutes
+
+  def perform
+    Store.find_each.with_index do |store, index|
+      FullStoreSyncJob
+        .set(wait: STAGGER_INTERVAL * index)
+        .perform_later(store.id)
+    end
+  end
+end

--- a/app/services/discogs_client.rb
+++ b/app/services/discogs_client.rb
@@ -45,9 +45,10 @@ class DiscogsClient
     Faraday.new(url: BASE_URL) do |f|
       f.options.timeout = 10
       f.options.open_timeout = 5
-      f.request :retry, max: 3, interval: 2.0, retry_statuses: [ 503 ]
       f.request :url_encoded
       f.response :json
+      f.use DiscogsRateLimitMiddleware
+      f.request :retry, max: 3, interval: 2.0, retry_statuses: [ 503 ]
       f.headers["Authorization"] = "Discogs token=#{@token}"
       f.headers["User-Agent"] = "Milkcrate/1.0 +https://milkcrate.fm"
     end

--- a/app/services/discogs_rate_limit_middleware.rb
+++ b/app/services/discogs_rate_limit_middleware.rb
@@ -5,12 +5,6 @@ class DiscogsRateLimitMiddleware < Faraday::Middleware
   MAX_RETRIES = 3   # max 429 retry attempts per request
   BACKOFF_BASE = 2  # exponential backoff base (2^attempt seconds)
 
-  def initialize(app)
-    super(app)
-    @last_request_time = nil
-    @last_remaining = nil
-  end
-
   def call(env)
     sleep_if_needed
     response = request_with_retry(env)
@@ -34,8 +28,8 @@ class DiscogsRateLimitMiddleware < Faraday::Middleware
   end
 
   def pause_if_quota_low(response)
-    @last_remaining = response.headers["x-discogs-ratelimit-remaining"]&.to_i
-    return unless @last_remaining && @last_remaining <= LOW
+    remaining = response.headers["x-discogs-ratelimit-remaining"]&.to_i
+    return unless remaining && remaining <= LOW
     sleep(PAUSE)
   end
 

--- a/app/services/discogs_rate_limit_middleware.rb
+++ b/app/services/discogs_rate_limit_middleware.rb
@@ -13,29 +13,31 @@ class DiscogsRateLimitMiddleware < Faraday::Middleware
 
   def call(env)
     sleep_if_needed
-
-    retries = 0
-    loop do
-      response = @app.call(env)
-      @last_remaining = response.headers["x-discogs-ratelimit-remaining"]&.to_i
-
-      if response.status == 429 && retries < MAX_RETRIES
-        retries += 1
-        backoff = [ (BACKOFF_BASE**retries), 60 ].min
-        sleep(backoff)
-        @last_request_time = nil
-      else
-        if @last_remaining && @last_remaining <= LOW
-          sleep(PAUSE)
-        end
-
-        @last_request_time = Time.now.to_f
-        return response
-      end
-    end
+    response = request_with_retry(env)
+    pause_if_quota_low(response)
+    @last_request_time = Time.now.to_f
+    response
   end
 
   private
+
+  def request_with_retry(env, attempt: 1)
+    response = @app.call(env)
+    return response unless response.status == 429
+    return response if attempt > MAX_RETRIES
+    sleep(backoff_for(attempt))
+    request_with_retry(env, attempt: attempt + 1)
+  end
+
+  def backoff_for(attempt)
+    [ (BACKOFF_BASE**attempt), 60 ].min
+  end
+
+  def pause_if_quota_low(response)
+    @last_remaining = response.headers["x-discogs-ratelimit-remaining"]&.to_i
+    return unless @last_remaining && @last_remaining <= LOW
+    sleep(PAUSE)
+  end
 
   def sleep_if_needed
     return unless @last_request_time

--- a/app/services/discogs_rate_limit_middleware.rb
+++ b/app/services/discogs_rate_limit_middleware.rb
@@ -1,0 +1,48 @@
+class DiscogsRateLimitMiddleware < Faraday::Middleware
+  SLEEP = 1.1       # baseline pacing: ~55 req/min
+  LOW = 5           # remaining threshold to trigger extended pause
+  PAUSE = 10        # seconds to sleep when remaining <= LOW
+  MAX_RETRIES = 3   # max 429 retry attempts per request
+  BACKOFF_BASE = 2  # exponential backoff base (2^attempt seconds)
+
+  def initialize(app)
+    super(app)
+    @last_request_time = nil
+    @last_remaining = nil
+  end
+
+  def call(env)
+    sleep_if_needed
+
+    retries = 0
+    loop do
+      response = @app.call(env)
+      @last_remaining = response.headers["x-discogs-ratelimit-remaining"]&.to_i
+
+      if response.status == 429 && retries < MAX_RETRIES
+        retries += 1
+        backoff = [(BACKOFF_BASE**retries), 60].min
+        sleep(backoff)
+        @last_request_time = nil
+      else
+        if @last_remaining && @last_remaining <= LOW
+          sleep(PAUSE)
+        end
+
+        @last_request_time = Time.now.to_f
+        return response
+      end
+    end
+  end
+
+  private
+
+  def sleep_if_needed
+    return unless @last_request_time
+
+    elapsed = Time.now.to_f - @last_request_time
+    if elapsed < SLEEP
+      sleep(SLEEP - elapsed)
+    end
+  end
+end

--- a/app/services/discogs_rate_limit_middleware.rb
+++ b/app/services/discogs_rate_limit_middleware.rb
@@ -21,7 +21,7 @@ class DiscogsRateLimitMiddleware < Faraday::Middleware
 
       if response.status == 429 && retries < MAX_RETRIES
         retries += 1
-        backoff = [(BACKOFF_BASE**retries), 60].min
+        backoff = [ (BACKOFF_BASE**retries), 60 ].min
         sleep(backoff)
         @last_request_time = nil
       else

--- a/app/services/enrichment_service.rb
+++ b/app/services/enrichment_service.rb
@@ -1,8 +1,6 @@
 class EnrichmentService
   BATCH_SIZE = 50
-  RATE_LIMIT_SLEEP = 1.1   # safe floor — Discogs allows 60 req/min authenticated
-  RATE_LIMIT_LOW   = 5     # remaining threshold to pause briefly
-  RATE_LIMIT_PAUSE = 10    # seconds to wait when nearly exhausted
+  MUSICBRAINZ_SLEEP = 1.1  # MusicBrainz has its own rate limits
 
   def initialize
     @discogs = DiscogsClient.new
@@ -44,17 +42,7 @@ class EnrichmentService
 
     enrich_ids.each_slice(BATCH_SIZE) do |batch|
       batch.each do |release_id|
-        remaining = enrich_release(release_id, store)
-        if remaining <= RATE_LIMIT_LOW
-          Rails.logger.info "[EnrichmentService] Rate limit low (#{remaining} remaining), pausing #{RATE_LIMIT_PAUSE}s"
-          sleep(RATE_LIMIT_PAUSE)
-        else
-          sleep(RATE_LIMIT_SLEEP)
-        end
-      rescue DiscogsClient::RateLimitError
-        Rails.logger.warn "[EnrichmentService] Rate limited on release #{release_id}, sleeping 15s"
-        sleep(15)
-        retry
+        enrich_release(release_id, store)
       rescue DiscogsClient::ApiError => e
         Rails.logger.warn "[EnrichmentService] API error for release #{release_id}: #{e.message}"
       end
@@ -80,7 +68,7 @@ class EnrichmentService
 
       if mbid.nil?
         Release.where(discogs_release_id: discogs_release_id).update_all(musicbrainz_id: "")
-        sleep(RATE_LIMIT_SLEEP)
+        sleep(MUSICBRAINZ_SLEEP)
         next
       end
 
@@ -94,7 +82,7 @@ class EnrichmentService
           .update_all(cover_image_url: cover_url)
       end
 
-      sleep(RATE_LIMIT_SLEEP)
+      sleep(MUSICBRAINZ_SLEEP)
     rescue MusicBrainzClient::ApiError => e
       Rails.logger.warn "[EnrichmentService] API error for #{discogs_release_id}: #{e.message}"
     end
@@ -103,7 +91,7 @@ class EnrichmentService
   private
 
   def enrich_release(discogs_release_id, store)
-    data, remaining = @discogs.release(discogs_release_id)
+    data, = @discogs.release(discogs_release_id)
 
     want    = data.dig("community", "want").to_i
     have    = data.dig("community", "have").to_i
@@ -132,8 +120,6 @@ class EnrichmentService
     store.listings
       .where(discogs_release_id: discogs_release_id)
       .update_all(listing_updates)
-
-    remaining
   end
 
   def extract_primary_image(data)

--- a/app/services/store_sync/inventory_fetcher.rb
+++ b/app/services/store_sync/inventory_fetcher.rb
@@ -1,7 +1,6 @@
 class StoreSync::InventoryFetcher
   Result = Data.define(:listings, :pages_fetched, :total_pages)
 
-  RATE_LIMIT_DELAY = 0.5
   DISCOGS_PAGE_LIMIT_ERROR = "Pagination above 100"
 
   def initialize(store, client: nil)
@@ -35,8 +34,6 @@ class StoreSync::InventoryFetcher
       yield data, @pages_fetched
 
       break if last_page?(data, max_pages)
-
-      sleep(RATE_LIMIT_DELAY)
     end
   end
 

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -15,7 +15,7 @@ production:
     schedule: every hour at minute 12
 
   full_store_sync:
-    command: "store = Store.find_by(discogs_username: Settings.demo_store.discogs_username); FullStoreSyncJob.perform_later(store.id) if store"
+    class: SyncAllStoresJob
     queue: default
     schedule: every day at 11pm
 

--- a/docs/plans/2026-05-19-001-fix-recurring-sync-rate-limiting-plan.md
+++ b/docs/plans/2026-05-19-001-fix-recurring-sync-rate-limiting-plan.md
@@ -1,0 +1,353 @@
+---
+title: Fix recurring store sync to cover all stores while respecting Discogs rate limits
+type: fix
+status: completed
+date: 2026-05-19
+---
+
+# Fix recurring store sync to cover all stores while respecting Discogs rate limits
+
+## Summary
+
+The nightly recurring sync (`config/recurring.yml`) only runs for the demo store (`philadelphiamusic`). Other onboarded stores are never synced again after their initial onboarding sync. Additionally, the sync path in `InventoryFetcher` uses a fixed 0.5s delay between API calls (~120 req/min), exceeding Discogs' 60 req/min authenticated rate limit, with no rate-limit-remaining header awareness and no retry on 429 responses.
+
+This plan fixes both problems: sync all stores nightly with staggered scheduling, and centralize Discogs rate-limit handling in a Faraday middleware on `DiscogsClient` itself — so every caller (sync, enrichment, and any future consumers) automatically respects the rate limit without any per-path throttling logic.
+
+---
+
+## Problem Frame
+
+The admin dashboard shows that stores "haven't synced in a couple days" because:
+1. The nightly recurring sync only targets `Store.find_by(discogs_username: Settings.demo_store.discogs_username)` — a single-store lookup. Any store beyond the demo store gets a one-time sync during onboarding (`StoreOnboarding` → `FullStoreSyncJob.perform_later`) but never again.
+2. The sync path's 0.5s page delay generates ~120 req/min — double Discogs' 60 req/min authenticated limit. When rate limits are hit, `DiscogsClient` raises `RateLimitError` (HTTP 429), which is not caught or retried in the sync path, failing the entire job.
+
+The enrichment path has bespoke rate-limit awareness (1.1s delay, header check, retry on 429) baked into `EnrichmentService` itself. This means every new consumer of the Discogs API has to reimplement the same pattern. The fix should live in the HTTP client layer so all consumers benefit automatically.
+
+---
+
+## Requirements
+
+- R1. Every onboarded store receives a nightly sync, not just the demo store.
+- R2. All Discogs API calls respect the 60 req/min authenticated rate limit automatically.
+- R3. Rate-limit handling backs off when `x-discogs-ratelimit-remaining` is nearly exhausted.
+- R4. HTTP 429 responses are retried transparently at the HTTP client layer.
+- R5. Store syncs are staggered so concurrent rate-limit contention across stores is minimized.
+- R6. The sync → enrichment → curation pipeline chain is preserved (FullStoreSyncJob still enqueues EnrichmentJob and DailyCurationJob).
+- R7. Rate-limit handling lives in `DiscogsClient` itself — callers do not manage delays, remaining headers, or 429 retries.
+
+---
+
+## Scope Boundaries
+
+- Rate-limit handling is centralized in `DiscogsClient`. Both `InventoryFetcher` and `EnrichmentService` have their per-path rate-limit logic removed.
+- The MusicBrainz client is a separate API with different limits — not affected by this change.
+- No global rate-limit registry (cross-job shared state) — serialized and staggered execution is the mechanism for multi-store safety.
+- No changes to `Store` model schema or sync status enums.
+- No changes to the admin dashboard health computation logic.
+- The existing Faraday `retry` middleware (503s only) is augmented, not replaced.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **DiscogsClient** (`app/services/discogs_client.rb`) — uses Faraday with `build_connection`. Currently has a `retry` middleware for 503s, and reads the rate-limit header in `#release` but not in `#seller_inventory`. **This is where the middleware will be inserted.**
+- **EnrichmentService** (`app/services/enrichment_service.rb`) — has the bespoke rate-limit pattern to be removed: `RATE_LIMIT_SLEEP = 1.1`, `RATE_LIMIT_LOW = 5`, `RATE_LIMIT_PAUSE = 10`, retry loop for `RateLimitError`.
+- **InventoryFetcher** (`app/services/store_sync/inventory_fetcher.rb`) — has `RATE_LIMIT_DELAY = 0.5`, no header read, no 429 retry. All of this is replaced by the middleware.
+- **FullStoreSyncJob** (`app/jobs/full_store_sync_job.rb`) — single `store_id` parameter, chains to `EnrichmentJob` and `DailyCurationJob`.
+- **DailyCurationJob** (`app/jobs/daily_curation_job.rb`) — already multi-store aware: iterates `Store.all` when `store_id` is nil.
+- **config/recurring.yml** — has `production:`-only schedule entries; Solid Queue recurring jobs.
+- **Solid Queue** (`config/queue.yml`) — single pool, 3 threads, 1 process, 0.1s polling.
+
+### Institutional Learnings
+
+- No existing `docs/solutions/` entries cover Discogs rate limiting or sync scheduling. Consider capturing via `ce-compound` after this fix lands.
+
+### External References
+
+- Discogs API rate limiting: 60 requests per minute for authenticated requests. The `x-discogs-ratelimit-remaining` header indicates remaining quota in the current window.
+- Faraday middleware pattern: `Faraday::Middleware` subclasses implement `on_complete(env)` for response inspection, and `call(env)` for request interception. Rate-limit middleware typically goes as a response middleware in the handler stack.
+
+---
+
+## Key Technical Decisions
+
+- **Faraday middleware on DiscogsClient, not a per-path concern**: Instead of extracting constants into a shared module and having each caller implement the same sleep/retry/backoff loop, a single `DiscogsRateLimitMiddleware` is registered in `DiscogsClient#build_connection`. It intercepts each response, reads `x-discogs-ratelimit-remaining`, applies baseline pacing, backs off when low, and retries 429s automatically. Every consumer of the client — sync, enrichment, future callers — gets rate-limit discipline for free. No per-path code needed.
+- **Staggered store syncs via `SyncAllStoresJob`**: Rather than enqueuing all `FullStoreSyncJob` instances at 11pm (which Solid Queue would process with 3 concurrent threads, each burning the shared rate-limit bucket), a new `SyncAllStoresJob` iterates stores sequentially with staggered delays. This serializes API usage to one store at a time, avoiding concurrent rate-limit contention. No global state needed.
+- **Middleware state is per-client-instance**: Each `DiscogsClient` instance has its own middleware state (remaining track, last-request timer). Since `SyncAllStoresJob` staggers by 5 minutes, only one store's sync or enrichment runs at a time, each using its own `DiscogsClient` instance — so there's never contention across middleware instances.
+
+---
+
+## Implementation Units
+
+### U1. Create `DiscogsRateLimitMiddleware` Faraday middleware
+
+**Goal:** Build a Faraday middleware that handles Discogs rate limiting at the HTTP client layer, so callers never manage delays, headers, or 429 retries themselves.
+
+**Requirements:** R2, R3, R4, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/services/discogs_rate_limit_middleware.rb`
+- Modify: `app/services/discogs_client.rb` (register middleware in `build_connection`)
+- Test: `spec/services/discogs_rate_limit_middleware_spec.rb`
+
+**Approach:**
+- Create a class `DiscogsRateLimitMiddleware < Faraday::Middleware` that:
+  1. Stores local state per-instance: `@last_request_time` (nil initially), `@last_remaining` (nil).
+  2. Implements `call(env)` to call `@app.call(env).on_complete { |response_env| handle_response(response_env) }`.
+  3. On completion, reads `response_env.response_headers["x-discogs-ratelimit-remaining"].to_i` and stores it as `@last_remaining`.
+  4. Enforces a **minimum elapsed time** since `@last_request_time`: if less than `SLEEP` seconds (1.1) have passed, sleeps for the remaining duration before returning. This provides the baseline ~55 req/min pacing.
+  5. If `@last_remaining <= LOW` (5), additionally sleeps `PAUSE` (10) seconds — additive on top of the baseline pacing.
+  6. On a 429 response status, retries with exponential backoff: sleeps `2^attempt` seconds (capped at 60s), resets `@last_request_time` to account for the wait, and re-calls `@app.call(env)`. Up to `MAX_RETRIES` (3) attempts before allowing the `RateLimitError` to propagate.
+
+**Constants** (defined inline on the middleware class):
+- `SLEEP = 1.1` — baseline pacing, targeting ~55 req/min
+- `LOW = 5` — remaining threshold to trigger extended pause
+- `PAUSE = 10` — seconds to sleep when remaining <= LOW
+- `MAX_RETRIES = 3` — max 429 retry attempts per request
+- `BACKOFF_BASE = 2` — exponential backoff base (2^attempt seconds)
+
+**Registration in DiscogsClient#build_connection:**
+- Add `f.response :discogs_rate_limit` (or use a custom handler name) in the middleware stack, placed **after** the `:json` response parser (so response headers are still accessible) but before the `:retry` middleware (which handles 503s — a separate concern).
+
+```ruby
+def build_connection
+  Faraday.new(url: BASE_URL) do |f|
+    f.options.timeout = 10
+    f.options.open_timeout = 5
+    f.request :url_encoded
+    f.response :json
+    f.use DiscogsRateLimitMiddleware
+    f.request :retry, max: 3, interval: 2.0, retry_statuses: [503]
+    f.headers["Authorization"] = "Discogs token=#{@token}"
+    f.headers["User-Agent"] = "Milkcrate/1.0 +https://milkcrate.fm"
+  end
+end
+```
+
+**Patterns to follow:**
+- Faraday middleware examples in the Faraday documentation; this is a `Faraday::Middleware` subclass with `call(env)`.
+- The existing `DiscogsClient#release` already reads the rate-limit header — the middleware now does this universally instead.
+
+**Test scenarios:**
+- Happy path: Given a successful response with remaining > 5, the middleware applies baseline delay (1.1s) and passes the response through unchanged.
+- Low quota: Given `remaining = 3` on a response, the middleware applies baseline delay + the extended `PAUSE` (10s) before returning.
+- 429 handled: Given a 429 response, the middleware retries up to `MAX_RETRIES` times with exponential backoff. On success before max, the response is returned normally.
+- 429 exhausted: Given persistent 429 after `MAX_RETRIES`, `RateLimitError` propagates to the caller.
+- Consecutive requests: Given two rapid requests, the middleware ensures at least `SLEEP` seconds have elapsed between them.
+- Missing header: Given a response without `x-discogs-ratelimit-remaining`, `@last_remaining` stays `nil` — middleware applies baseline delay and continues (no crash on nil <= 5 comparison — use `.to_i` or guard).
+
+**Verification:**
+- `DiscogsClient#seller_inventory` and `#release` both automatically have pacing and 429 retry with no changes to their method bodies.
+- Rate of API calls stays under 60 req/min when measured over a window (validated by middleware's SLEEP + LOW/PAUSE logic).
+
+---
+
+### U2. Remove rate-limit logic from `InventoryFetcher`
+
+**Goal:** Delete the per-path rate-limit code from the sync's inventory fetcher — the middleware now handles everything.
+
+**Requirements:** R2, R3, R4, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/services/store_sync/inventory_fetcher.rb`
+- Test: `spec/services/store_sync/inventory_fetcher_spec.rb`
+
+**Approach:**
+- Remove the `RATE_LIMIT_DELAY = 0.5` constant (no longer needed).
+- Remove `sleep(RATE_LIMIT_DELAY)` from `each_page` — the middleware handles pacing between all outgoing requests.
+- Remove the `DiscogsClient::RateLimitError` rescue block from `fetch_page` — the middleware handles 429 retry transparently.
+- Remove the `RescueDiscogsClient::ApiError` catch that only matched the 100-page-limit message — this is a different class of error (business rule, not rate limit) and should remain.
+- `seller_inventory` goes back to returning a single value (`body`) instead of a tuple, since the caller no longer reads the remaining header. (This reverts the U2 change from the previous plan version.)
+- The `fetch_page` method becomes simpler — it just calls `client.seller_inventory(...)` and raises/handles the 100-page-limit `ApiError`.
+
+**Patterns to follow:**
+- The existing `Account` pattern — methods that call the client should not add their own rate-limit scaffolding.
+
+**Test scenarios:**
+- Existing pagination tests still pass (happy path, max_pages, empty result, 100-page limit) — but mocks no longer need to return `[body, remaining]` tuples.
+- No rate-limit-specific tests remain in the fetcher spec — those are now tested in the middleware spec (U1).
+- The 100-page-limit `ApiError` handling is preserved.
+- Default pacing: middleware's 1.1s baseline still applies automatically — the fetcher doesn't manage it.
+
+**Verification:**
+- `InventoryFetcher` has no rate-limit-specific lines (no sleep, no header reads, no 429 retry).
+- All existing fetcher tests pass after updating mocks to return single values.
+
+---
+
+### U3. Remove Discogs rate-limit logic from `EnrichmentService`
+
+**Goal:** Delete the per-path rate-limit code from the enrichment service — the middleware now handles Discogs pacing and retry.
+
+**Requirements:** R2, R3, R4, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/services/enrichment_service.rb`
+- Test: `spec/services/enrichment_service_spec.rb`
+
+**Approach:**
+- Remove the `RATE_LIMIT_SLEEP = 1.1`, `RATE_LIMIT_LOW = 5`, `RATE_LIMIT_PAUSE = 10` constants (no longer needed for Discogs calls).
+- In `enrich_releases`:
+  - Remove `sleep(RATE_LIMIT_SLEEP)` after each Discogs release fetch — the middleware handles pacing.
+  - Remove the `remaining <= RATE_LIMIT_LOW` check and `sleep(RATE_LIMIT_PAUSE)` — the middleware handles low-quota backoff.
+  - Remove the `DiscogsClient::RateLimitError` rescue-retry block — the middleware handles 429 retry transparently.
+  - Keep the `DiscogsClient::ApiError` rescue (for non-rate-limit API errors) and the per-release logging.
+- In `enrich_music_brainz_images`:
+  - Keep `sleep(RATE_LIMIT_SLEEP)` as-is — this is pacing for MusicBrainz calls (different API, different limits). Use a local constant (e.g., `MUSICBRAINZ_SLEEP = 1.1`) or just keep the value inline — it's no longer shared with Discogs logic.
+- `DiscogsClient#release` can still return `[body, remaining]` or be simplified to just `body` — doesn't matter since the caller doesn't use `remaining` anymore. Simplifying to `body` is cleaner but optional.
+
+**Patterns to follow:**
+- The method body now focuses on Discogs/MusicBrainz business logic rather than HTTP pacing concerns.
+
+**Test scenarios:**
+- Stale releases are still enriched: Given listing IDs with stale releases, enrichment fires the expected number of Discogs release API calls.
+- API errors are logged: Given `DiscogsClient::ApiError` on a release, enrichment logs a warning and continues the batch.
+- Rate limit errors no longer caught here: Given a `RateLimitError` (now raised only after middleware exhausts 3 retries), it propagates to the job level — update or remove any tests that expected per-release 429 handling.
+- MusicBrainz pacing is preserved: The `sleep` between MusicBrainz calls still applies.
+- Remaining header not required: `DiscogsClient#release` return type is consistent (either `body` alone or `[body, remaining]` — whichever is chosen).
+
+**Verification:**
+- `EnrichmentService` has no Discogs rate-limit-specific lines (no sleep tied to Discogs remaining, no 429 retry for Discogs calls).
+- All existing enrichment tests pass after removing rate-limit assertions.
+
+---
+
+### U4. Create `SyncAllStoresJob` with staggered scheduling
+
+**Goal:** Create a new job that synchronizes all stores with staggered delays, preventing concurrent rate-limit contention.
+
+**Requirements:** R1, R5, R6
+
+**Dependencies:** U2 (InventoryFetcher is clean — no rate-limit logic), though U2's cleanup is independent of stagger timing
+
+**Files:**
+- Create: `app/jobs/sync_all_stores_job.rb`
+- Test: `spec/jobs/sync_all_stores_job_spec.rb`
+
+**Approach:**
+- Create `SyncAllStoresJob` that iterates `Store.all` and enqueues each `FullStoreSyncJob` with a staggered `wait` delay:
+
+```ruby
+class SyncAllStoresJob < ApplicationJob
+  queue_as :default
+
+  STAGGER_INTERVAL = 5.minutes
+
+  def perform
+    Store.find_each.with_index do |store, index|
+      FullStoreSyncJob
+        .set(wait: STAGGER_INTERVAL * index)
+        .perform_later(store.id)
+    end
+  end
+end
+```
+
+- `STAGGER_INTERVAL` of 5 minutes ensures each store's sync and enrichment finish before the next store starts. A 50-page store = 100 API calls (two passes) at 1.1s/call ≈ 118s sync + enrichment time. 5 minutes provides comfortable margin even for larger stores up to ~100 pages (~4 min sync).
+- At current scale (handful of stores), the full sweep completes within 30-60 minutes, well within the overnight window.
+- The job itself runs instantly (just enqueues), so it doesn't tie up a worker.
+- **Deleted store edge case:** `FullStoreSyncJob#perform` wraps `Store.find(store_id)` in a `begin/rescue ActiveRecord::RecordNotFound` that logs a warning and returns early, preventing a `RecordNotFound` from propagating as a confusing error chain. This is especially important with staggered scheduling — the window between job enqueue and execution can be hours.
+
+**Patterns to follow:**
+- `ActiveJob` `.set(wait:)` is supported by Solid Queue natively.
+- `discard_on ActiveJob::DeserializationError` pattern already present (commented out) in `ApplicationJob`.
+
+**Test scenarios:**
+- Execution: Given 3 stores, `SyncAllStoresJob#perform` enqueues 3 `FullStoreSyncJob` instances with `wait` delays of 0, 5, and 10 minutes respectively.
+- No stores: Given zero stores, no jobs are enqueued (graceful no-op).
+- Stagger precision: The `wait` delays use `ActiveJob`'s `set(wait:)` API and correctly apply `STAGGER_INTERVAL * index`.
+
+**Verification:**
+- Running `SyncAllStoresJob.perform_now` enqueues the correct number of `FullStoreSyncJob` with staggered delays.
+
+---
+
+### U5. Update `config/recurring.yml` to use `SyncAllStoresJob`
+
+**Goal:** Replace the single-store recurring command with the new multi-store job.
+
+**Requirements:** R1, R5
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `config/recurring.yml`
+
+**Approach:**
+- Replace the inline `command` with a `class`-based recurring schedule pointing to `SyncAllStoresJob`:
+
+```yaml
+production:
+  full_store_sync:
+    class: SyncAllStoresJob
+    queue: default
+    schedule: every day at 11pm
+```
+
+- The old schedule name `full_store_sync` is preserved for clarity.
+- Using `class:` instead of `command:` means Solid Queue handles the job lifecycle directly (retries, failure tracking, MissionControl visibility) rather than executing inline Ruby in the scheduler process.
+- The `clear_solid_queue_finished_jobs` and `daily_curation` schedules remain unchanged.
+
+**Patterns to follow:**
+- `daily_curation` entry in the same file already uses `class:` format with `DailyCurationJob`.
+
+**Test scenarios:**
+- Schedule loads: The `production` recurring schedule parses without error.
+- Execution: When the schedule triggers, `SyncAllStoresJob` is enqueued.
+- Existing schedules: `clear_solid_queue_finished_jobs` and `daily_curation` are unaffected.
+
+**Verification:**
+- The recurring configuration is valid YAML and Solid Queue accepts it (no syntax or schema errors).
+- At 11pm nightly, all stores receive staggered syncs.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `SyncAllStoresJob` enqueues `FullStoreSyncJob`(s), which enqueue `EnrichmentJob` and `DailyCurationJob`. The chain is preserved unchanged. Rate-limit handling now lives in `DiscogsClient` middleware, transparent to all callers.
+- **Error propagation:** If rate-limit retries in the middleware are exhausted, `RateLimitError` propagates to the caller (e.g., `FullStoreSyncJob`), which records the failure on the store. If `SyncAllStoresJob` itself fails (e.g., DB unavailable), no stores sync that night.
+- **State lifecycle risks:** The staggered delay means first and last stores may be hours apart in sync timing. The `last_synced_at` field reflects actual completion time per store, so this is accurate.
+- **Unchanged invariants:** `FullStoreSyncJob` still handles per-store sync lifecycle identically. The admin dashboard health computation, `Store#stale?` threshold (23 hours), `DailyCurationJob` multi-store iteration are all unchanged.
+- **Removed code paths:** `InventoryFetcher` no longer manages rate-limit delays or 429 retries. `EnrichmentService` no longer manages Discogs rate-limit delays, remaining checks, or 429 retries. All of that moved to the middleware.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Middleware pacing doesn't account for concurrent client instances (e.g., enrichment running while next sync starts) | Staggered scheduling (U4) with 5-minute intervals ensures only one store's sync/enrichment runs at a time, so only one `DiscogsClient` instance is active. |
+| Sync takes longer than stagger interval for a store with very large inventory | Each store sync makes **2N API calls** (two passes: desc + asc). A 50-page store = 100 calls at 1.1s/call ≈ 118s (~2 min). A 100-page store = 200 calls ≈ 238s (~4 min). The 5-minute stagger provides comfortable margin for most stores. For stores exceeding 100 pages, monitor and increase `STAGGER_INTERVAL` further. |
+| Middleware 429 retry with backoff could delay return significantly | Exponential backoff caps at 60s per wait. With 3 retries, worst case = ~7s total added delay per request. This is acceptable for nightly batch work. |
+| Enrichment overlaps with next store's sync under heavy load | With 5-minute stagger and enrichment adding ~1-2 minutes per store, overlap is unlikely. If it occurs, both operations share the same `DiscogsClient` rate limit through independent middleware instances — the middleware's per-request backoff prevents total failure but may slow both paths. Mitigation: monitor and increase stagger if needed. |
+| `SyncAllStoresJob` fails silently | The job runs in the default queue and is retried by Solid Queue. Failure is visible in MissionControl::Jobs at `/jobs`. |
+| Enrichment uses a `DiscogsClient` instance that's unrelated to the sync's instance | Each creates its own `DiscogsClient`, hence its own middleware state. With staggered scheduling, this is fine — only one runs at a time. |
+
+---
+
+## Documentation / Operational Notes
+
+- After deployment, verify the first nightly sync by checking `last_synced_at` on each store the following morning, or trigger manually: `SyncAllStoresJob.perform_now` in Rails console.
+- Monitor MissionControl::Jobs for retries or failures. `FullStoreSyncJob` failures will be visible as individual job failures in the `default` queue.
+- If store count grows significantly (10+ stores), consider further increasing `STAGGER_INTERVAL` or switching to a rate-limit-aware token-bucket approach with shared state to compress the sweep window.
+- The middleware applies universally — any future code that creates a `DiscogsClient` gets rate-limit discipline automatically. This is the main benefit of the middleware approach over per-path constants.
+
+---
+
+## Sources & References
+
+- Related code: `app/services/discogs_client.rb` (middleware registered here)
+- Related code: `app/services/enrichment_service.rb` (rate-limit logic to remove)
+- Related code: `app/services/store_sync/inventory_fetcher.rb` (rate-limit logic to remove)
+- Related code: `app/jobs/full_store_sync_job.rb` (existing per-store sync job)
+- Related code: `app/jobs/daily_curation_job.rb` (existing multi-store pattern)
+- Related config: `config/recurring.yml` (schedule to update)
+- Faraday middleware documentation: `Faraday::Middleware` subclass pattern

--- a/docs/solutions/integration-issues/discogs-rate-limit-middleware-2026-05-19.md
+++ b/docs/solutions/integration-issues/discogs-rate-limit-middleware-2026-05-19.md
@@ -1,0 +1,253 @@
+---
+title: "Centralized Discogs rate-limit middleware and multi-store recurring sync"
+date: 2026-05-19
+category: integration-issues
+module: discogs_client
+problem_type: integration_issue
+component: service_object
+severity: high
+symptoms:
+  - "Only the demo store received nightly recurring syncs"
+  - "Sync path exceeded Discogs 60 req/min limit with 0.5s delay (~120 req/min)"
+  - "429 Too Many Requests received with no retry logic in sync path"
+  - "Rate-limit logic duplicated across InventoryFetcher and EnrichmentService with different constants"
+  - "Enrichment and sync jobs ran concurrently, competing for the same API quota"
+root_cause: missing_workflow_step
+resolution_type: code_fix
+tags:
+  - discogs
+  - rate-limiting
+  - faraday
+  - middleware
+  - activejob
+  - concurrency
+  - recurring-jobs
+---
+
+# Centralized Discogs Rate-Limit Middleware and Multi-Store Recurring Sync
+
+## Problem
+
+The Discogs sync system had two structural defects that compounded each other.
+
+First, the nightly recurring sync (`config/recurring.yml`) only targeted a single hardcoded demo store via an inline `command:`. Any store onboarded after initial setup received a one-time sync during onboarding but was never synced again on the recurring schedule.
+
+Second, Discogs enforces 60 authenticated requests per minute. The sync path used a fixed 0.5s delay between paginated API calls (~120 req/min), exceeding the limit with no retry on HTTP 429 responses. The enrichment path had its own bespoke rate-limit awareness (1.1s delay, header check, extended pause when remaining low, 429 retry) duplicated inline with different constants than the sync path. Neither approach scaled to multiple stores or coordinated with concurrent callers.
+
+## Symptoms
+
+- **Stale inventory.** Stores onboarded after the demo never received recurring updates. Inventory data grew increasingly stale for every store except the one hardcoded in `recurring.yml`.
+- **Silent rate-limit failures.** The sync path made requests at double the allowed rate and had no 429 retry logic — throttled requests failed silently, producing incomplete syncs.
+- **Inconsistent rate limiting.** Two independent pacing implementations with different constants (`RATE_LIMIT_DELAY = 0.5` in `InventoryFetcher`, `RATE_LIMIT_SLEEP = 1.1` in `EnrichmentService`) meant behavior varied by code path, and neither was guaranteed to apply to future callers.
+- **Concurrent quota competition.** When enrichment for store N overlapped with sync for store N+1, two `DiscogsClient` instances made requests simultaneously, each pacing independently — combined throughput could exceed the 60 req/min limit.
+
+## What Didn't Work
+
+1. **A hardcoded store slug in `recurring.yml`.** The command `Store.find_by(discogs_username: Settings.demo_store.discogs_username)` worked for the demo store only. It was never generalized — every new store needed manual addition or a separate mechanism.
+
+2. **A fixed 0.5s delay in `InventoryFetcher`.** Produced ~120 req/min — double Discogs' limit. No header-aware adjustment or backoff when throttled.
+
+3. **Bespoke inline rate limiting in `EnrichmentService`.** Three constants (`RATE_LIMIT_SLEEP`, `RATE_LIMIT_LOW`, `RATE_LIMIT_PAUSE`) plus a `DiscogsClient::RateLimitError` rescue block. Correct-ish pacing (1.1s = ~55 req/min) but duplicated code that required manual reimplementation in every HTTP-consuming path.
+
+4. **No coordination between job classes.** `FullStoreSyncJob` and `EnrichmentJob` both consumed the Discogs API through independent `DiscogsClient` instances. When they ran concurrently, each paced at ~55 req/min — combined ~110 req/min against a single API key.
+
+## Solution
+
+### 1. Faraday middleware for centralized rate limiting
+
+Created `DiscogsRateLimitMiddleware < Faraday::Middleware` that owns all pacing, quota monitoring, and 429 retry logic — one class, tested once, used by every caller.
+
+```ruby
+class DiscogsRateLimitMiddleware < Faraday::Middleware
+  SLEEP = 1.1       # baseline pacing: ~55 req/min
+  LOW = 5           # remaining threshold to trigger extended pause
+  PAUSE = 10        # seconds to sleep when remaining <= LOW
+  MAX_RETRIES = 3   # max 429 retry attempts per request
+  BACKOFF_BASE = 2  # exponential backoff base (2^attempt seconds)
+
+  def call(env)
+    sleep_if_needed
+    response = request_with_retry(env)
+    pause_if_quota_low(response)
+    @last_request_time = Time.now.to_f
+    response
+  end
+
+  private
+
+  def request_with_retry(env, attempt: 1)
+    response = @app.call(env)
+    return response unless response.status == 429
+    return response if attempt > MAX_RETRIES
+    sleep(backoff_for(attempt))
+    request_with_retry(env, attempt: attempt + 1)
+  end
+
+  def backoff_for(attempt)
+    [(BACKOFF_BASE**attempt), 60].min
+  end
+
+  def pause_if_quota_low(response)
+    @last_remaining = response.headers["x-discogs-ratelimit-remaining"]&.to_i
+    return unless @last_remaining && @last_remaining <= LOW
+    sleep(PAUSE)
+  end
+
+  def sleep_if_needed
+    return unless @last_request_time
+    elapsed = Time.now.to_f - @last_request_time
+    if elapsed < SLEEP
+      sleep(SLEEP - elapsed)
+    end
+  end
+end
+```
+
+Key structural choices (Sandi Metz style):
+- `call` is a 4-line pipeline — sleep, retry, pause, timestamp. No conditionals.
+- `request_with_retry` uses guard clauses with no `else` — early return on non-429, early return on exhausted retries, recursive retry (max depth 3).
+- `backoff_for` capped at 60s: `[(BACKOFF_BASE**attempt), 60].min`
+- Per-instance state (`@last_request_time`, `@last_remaining`) — no global state, safe for isolated usage per `DiscogsClient` instance.
+
+### 2. Register middleware in DiscogsClient
+
+```ruby
+# app/services/discogs_client.rb
+def build_connection
+  Faraday.new(url: BASE_URL) do |f|
+    f.options.timeout = 10
+    f.options.open_timeout = 5
+    f.request :url_encoded
+    f.response :json
+    f.use DiscogsRateLimitMiddleware
+    f.request :retry, max: 3, interval: 2.0, retry_statuses: [ 503 ]
+    f.headers["Authorization"] = "Discogs token=#{@token}"
+    f.headers["User-Agent"] = "Milkcrate/1.0 +https://milkcrate.fm"
+  end
+end
+```
+
+Placed after the JSON response parser (so response headers are still accessible for the `x-discogs-ratelimit-remaining` read) and before the existing retry middleware (which handles 503s — a separate concern).
+
+### 3. Remove per-path rate-limit code
+
+**`InventoryFetcher`** — removed `RATE_LIMIT_DELAY = 0.5` constant and the `sleep(RATE_LIMIT_DELAY)` call from `each_page`. The middleware handles all pacing.
+
+**`EnrichmentService`** — removed constants `RATE_LIMIT_SLEEP`, `RATE_LIMIT_LOW`, `RATE_LIMIT_PAUSE`, the inline remaining-header check with conditional sleep, and the `DiscogsClient::RateLimitError` rescue block. MusicBrainz pacing preserved under explicit `MUSICBRAINZ_SLEEP = 1.1` (separate API, separate limits).
+
+### 4. Multi-store sync job with staggered scheduling
+
+```ruby
+class SyncAllStoresJob < ApplicationJob
+  queue_as :default
+
+  STAGGER_INTERVAL = 5.minutes
+
+  def perform
+    Store.find_each.with_index do |store, index|
+      FullStoreSyncJob
+        .set(wait: STAGGER_INTERVAL * index)
+        .perform_later(store.id)
+    end
+  end
+end
+```
+
+Each store's `FullStoreSyncJob` is enqueued with a 5-minute delay from the previous one. At current scale (handful of stores), the full sweep completes within 30-60 minutes. The stagger spreads load across the night and provides natural ordering for the concurrency limit (see below).
+
+### 5. Shared concurrency limit across Discogs API jobs
+
+```ruby
+class FullStoreSyncJob < ApplicationJob
+  limits_concurrency to: 1, key: -> { "discogs_api" }
+  # ...
+end
+
+class EnrichmentJob < ApplicationJob
+  limits_concurrency to: 1, key: -> { "discogs_api" }
+  # ...
+end
+```
+
+Both jobs share the same concurrency limit key (`"discogs_api"`), so only one Discogs API consumer runs at any given moment. This prevents the enrichment for store N from overlapping with the sync for store N+1 — the queue naturally serializes them.
+
+`DailyCurationJob` does not need this limit — it performs local computation only, with no Discogs API calls.
+
+### 6. Update recurring schedule
+
+```yaml
+# config/recurring.yml
+production:
+  full_store_sync:
+    class: SyncAllStoresJob
+    queue: default
+    schedule: every day at 11pm
+```
+
+Changed from `command:` (inline Ruby with hardcoded store) to `class:` (Active Job class reference, same pattern as the existing `daily_curation` entry).
+
+## Why This Works
+
+**Root cause 1 — single-store scheduling:** `recurring.yml` hardcoded a store lookup in a `command:` string. The fix uses a dedicated job class that queries the database and fans out to all stores — a pattern the scheduler natively supports via `class:`.
+
+**Root cause 2 — rate-limit in the wrong layer:** Rate limiting is an HTTP transport concern, not a business-logic concern. Placing it in a Faraday middleware on `DiscogsClient` means:
+- Every API call through the client gets pacing automatically — callers can't forget to sleep.
+- Retry and backoff are transparent — callers never see 429s (up to the retry limit).
+- Quota awareness (`x-discogs-ratelimit-remaining`) is centralized — one place to tune, not two diverging implementations.
+- Any future `DiscogsClient` consumer (import feature, manual refresh, bulk operation) gets rate-limit discipline for free.
+
+**Root cause 3 — concurrent callers sharing a quota:** Two job classes both consuming the same API with independent middleware instances could each pace at ~55 req/min, totaling ~110 req/min. The shared `limits_concurrency to: 1, key: -> { "discogs_api" }` ensures only one runs at a time. Combined with the middleware's 1.1s pacing, this caps throughput at ~55 req/min — safely under Discogs' 60 req/min limit.
+
+## Prevention
+
+### Use middleware for cross-cutting HTTP concerns
+
+Any pacing, retry, or quota management for external APIs belongs in a Faraday middleware on the client class, not in business-logic service objects. The middleware is guaranteed to apply to all calls through that connection and is testable in isolation.
+
+### Share concurrency keys across jobs consuming the same API
+
+When multiple job classes consume the same external API, they must use the same concurrency limit key. The key should name the API resource, not the job:
+
+```ruby
+# Correct — shares quota across all Discogs consumers
+limits_concurrency to: 1, key: -> { "discogs_api" }
+
+# Wrong — one job runs while the other starves
+limits_concurrency to: 1, key: -> { "full_store_sync" }
+limits_concurrency to: 1, key: -> { "enrichment" }
+```
+
+### Fan out from recurring jobs, don't hardcode
+
+Use `class:` with a fan-out job that queries data dynamically. Test the fan-out job trivially:
+
+```ruby
+RSpec.describe SyncAllStoresJob do
+  it "enqueues FullStoreSyncJob for each store with staggered delays" do
+    stores = create_list(:store, 3)
+    described_class.new.perform
+    expect(FullStoreSyncJob).to have_been_enqueued.exactly(3).times
+  end
+end
+```
+
+### Stagger enqueue times for concurrency-limited fan-out
+
+When a fan-out job enqueues work with `limits_concurrency to: 1`, staggering the enqueue times prevents a convoy of jobs piling up at the same moment. Use `wait:` with an index multiplier:
+
+```ruby
+Store.find_each.with_index do |store, index|
+  FullStoreSyncJob
+    .set(wait: STAGGER_INTERVAL * index)
+    .perform_later(store.id)
+end
+```
+
+## Related
+
+- Middleware: `app/services/discogs_rate_limit_middleware.rb`
+- Client: `app/services/discogs_client.rb`
+- Jobs: `app/jobs/sync_all_stores_job.rb`, `app/jobs/full_store_sync_job.rb`, `app/jobs/enrichment_job.rb`
+- Cleaned-up services: `app/services/store_sync/inventory_fetcher.rb`, `app/services/enrichment_service.rb`
+- Schedule: `config/recurring.yml`
+- Solid Queue concurrency limits: [Active Job `limits_concurrency`](https://api.rubyonrails.org/classes/ActiveJob/ConcurrencyControl/ClassMethods.html)

--- a/spec/jobs/sync_all_stores_job_spec.rb
+++ b/spec/jobs/sync_all_stores_job_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe SyncAllStoresJob do
+  include ActiveJob::TestHelper
+
+  before { clear_enqueued_jobs }
+  describe "#perform" do
+    it "enqueues FullStoreSyncJob for each store with staggered delays" do
+      stores = create_list(:store, 3)
+
+      expect {
+        described_class.new.perform
+      }.to have_enqueued_job(FullStoreSyncJob).exactly(3).times
+
+      expect(FullStoreSyncJob).to have_been_enqueued.with(stores[0].id)
+      expect(FullStoreSyncJob).to have_been_enqueued.with(stores[1].id)
+      expect(FullStoreSyncJob).to have_been_enqueued.with(stores[2].id)
+    end
+
+    it "applies staggering delays based on index" do
+      create_list(:store, 2)
+      now = Time.now.to_f
+
+      described_class.new.perform
+
+      first_job = enqueued_jobs.first
+      second_job = enqueued_jobs.second
+
+      # First job runs immediately (wait: 0)
+      expect(first_job[:at]).to be_within(1).of(now)
+      # Second job runs after STAGGER_INTERVAL
+      expect(second_job[:at]).to be_within(1).of(now + described_class::STAGGER_INTERVAL)
+    end
+
+    it "is a no-op when there are no stores" do
+      expect {
+        described_class.new.perform
+      }.not_to have_enqueued_job(FullStoreSyncJob)
+    end
+  end
+end

--- a/spec/services/discogs_rate_limit_middleware_spec.rb
+++ b/spec/services/discogs_rate_limit_middleware_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+RSpec.describe DiscogsRateLimitMiddleware do
+  subject(:middleware) { described_class.new(app) }
+  let(:app) { double("app") }
+  let(:env) { Faraday::Env.from({}) }
+
+  # Helper to build a Faraday::Response with given status and headers
+  def response_with(status:, headers: {}, body: "{}")
+    response_headers = Faraday::Utils::Headers.new
+    headers.each { |k, v| response_headers[k] = v.to_s }
+
+    env = Faraday::Env.new.tap do |e|
+      e.status = status
+      e.response_headers = response_headers
+      e.body = body
+    end
+    Faraday::Response.new(env)
+  end
+
+  describe "#call" do
+    it "passes through a successful response" do
+      allow(middleware).to receive(:sleep)
+      response = response_with(status: 200, headers: { "x-discogs-ratelimit-remaining" => 55 })
+      allow(app).to receive(:call).with(env).and_return(response)
+
+      result = middleware.call(env)
+
+      expect(result.status).to eq(200)
+      expect(result.body).to eq("{}")
+    end
+
+    it "enforces baseline delay between two rapid consecutive requests" do
+      response = response_with(status: 200, headers: { "x-discogs-ratelimit-remaining" => 55 })
+      allow(app).to receive(:call).with(env).and_return(response)
+
+      allow(middleware).to receive(:sleep)
+      # First call sets @last_request_time
+      middleware.call(env)
+
+      # Second call should sleep for SLEEP seconds for baseline
+      middleware.call(env)
+
+      expect(middleware).to have_received(:sleep).with(be_within(0.01).of(described_class::SLEEP)).at_least(:once)
+    end
+
+    it "does not sleep on first request when remaining is moderate" do
+      allow(middleware).to receive(:sleep)
+      response = response_with(status: 200, headers: { "x-discogs-ratelimit-remaining" => 55 })
+      allow(app).to receive(:call).with(env).and_return(response)
+
+      middleware.call(env)
+
+      # First call should not sleep for PAUSE (no prior request, remaining > LOW)
+      expect(middleware).not_to have_received(:sleep).with(described_class::PAUSE)
+    end
+
+    it "applies extended pause when remaining is below LOW threshold" do
+      response = response_with(status: 200, headers: { "x-discogs-ratelimit-remaining" => 3 })
+      allow(app).to receive(:call).with(env).and_return(response)
+
+      allow(middleware).to receive(:sleep)
+      middleware.call(env)
+
+      expect(middleware).to have_received(:sleep).with(described_class::PAUSE).at_least(:once)
+    end
+
+    it "does not apply extended pause when remaining is above LOW threshold" do
+      response = response_with(status: 200, headers: { "x-discogs-ratelimit-remaining" => 55 })
+      allow(app).to receive(:call).with(env).and_return(response)
+
+      allow(middleware).to receive(:sleep)
+      middleware.call(env)
+
+      expect(middleware).not_to have_received(:sleep).with(described_class::PAUSE)
+    end
+
+    it "retries on 429 with exponential backoff and succeeds" do
+      retry_response = response_with(status: 429, headers: { "x-discogs-ratelimit-remaining" => 0 })
+      success_response = response_with(status: 200, headers: { "x-discogs-ratelimit-remaining" => 55 })
+
+      allow(middleware).to receive(:sleep)
+      allow(app).to receive(:call).with(env).and_return(retry_response, success_response)
+
+      result = middleware.call(env)
+
+      expect(result.status).to eq(200)
+      expect(app).to have_received(:call).with(env).twice
+    end
+
+    it "exhausts retries and returns 429 after MAX_RETRIES" do
+      retry_responses = Array.new(described_class::MAX_RETRIES + 1) do
+        response_with(status: 429, headers: { "x-discogs-ratelimit-remaining" => 0 })
+      end
+
+      allow(middleware).to receive(:sleep)
+      allow(app).to receive(:call).with(env).and_return(*retry_responses)
+
+      result = middleware.call(env)
+
+      expect(result.status).to eq(429)
+      expect(app).to have_received(:call).with(env).exactly(described_class::MAX_RETRIES + 1).times
+    end
+
+    it "does not crash when rate-limit header is missing" do
+      allow(middleware).to receive(:sleep)
+      response = response_with(status: 200, headers: {})
+      allow(app).to receive(:call).with(env).and_return(response)
+
+      expect { middleware.call(env) }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/discogs_rate_limit_middleware_spec.rb
+++ b/spec/services/discogs_rate_limit_middleware_spec.rb
@@ -110,4 +110,38 @@ RSpec.describe DiscogsRateLimitMiddleware do
       expect { middleware.call(env) }.not_to raise_error
     end
   end
+
+  describe "integration with DiscogsClient connection stack" do
+    it "retries 429 transparently when wired into a DiscogsClient connection" do
+      stubs = Faraday::Adapter::Test::Stubs.new
+      conn = Faraday.new do |f|
+        f.request :url_encoded
+        f.response :json
+        f.use DiscogsRateLimitMiddleware
+        f.request :retry, max: 3, interval: 2.0, retry_statuses: [ 503 ]
+        f.headers["Authorization"] = "Discogs token=test"
+        f.headers["User-Agent"] = "Milkcrate/1.0 +https://milkcrate.fm"
+        f.adapter :test, stubs
+      end
+
+      client = DiscogsClient.new
+      client.instance_variable_set(:@connection, conn)
+
+      call_count = 0
+      stubs.get("/users/testuser/inventory") do
+        call_count += 1
+        if call_count == 1
+          [ 429, {}, "rate limited" ]
+        else
+          [ 200, { "Content-Type" => "application/json", "x-discogs-ratelimit-remaining" => "50" }, '{"listings":[]}' ]
+        end
+      end
+
+      allow(Kernel).to receive(:sleep)
+      result = client.seller_inventory("testuser")
+
+      expect(result["listings"]).to eq([])
+      expect(call_count).to eq(2)
+    end
+  end
 end

--- a/spec/services/enrichment_service_spec.rb
+++ b/spec/services/enrichment_service_spec.rb
@@ -100,21 +100,6 @@ RSpec.describe EnrichmentService do
       service.enrich_releases(store, listing_ids: [ listing.id ])
     end
 
-    it "recovers from rate limit errors" do
-      call_count = 0
-      allow(discogs).to receive(:release).with("123") do
-        call_count += 1
-        raise(DiscogsClient::RateLimitError) if call_count == 1
-        [ release_data, 55 ]
-      end
-
-      expect(Rails.logger).to receive(:warn).with(/Rate limited/).once
-
-      service.enrich_releases(store, listing_ids: [ listing.id ])
-
-      listing.reload
-      expect(listing.genres).to eq([ "Jazz" ])
-    end
   end
 
   describe "#enrich_music_brainz_images" do

--- a/spec/services/enrichment_service_spec.rb
+++ b/spec/services/enrichment_service_spec.rb
@@ -99,7 +99,6 @@ RSpec.describe EnrichmentService do
 
       service.enrich_releases(store, listing_ids: [ listing.id ])
     end
-
   end
 
   describe "#enrich_music_brainz_images" do


### PR DESCRIPTION
## Summary

The nightly recurring sync only covered the demo store. Discogs rate-limit handling was duplicated across two code paths with different constants (0.5s delay in `InventoryFetcher`, 1.1s in `EnrichmentService`), and sync/enrichment jobs could run concurrently competing for the same 60 req/min API quota. Now every store receives nightly staggered syncs, rate limiting lives in a Faraday middleware on `DiscogsClient` itself, and concurrent API consumption is serialized via a shared concurrency limit.

## What changed and why

**Centralized rate limiting in a Faraday middleware.** `DiscogsRateLimitMiddleware` owns all pacing (1.1s baseline), quota monitoring (`x-discogs-ratelimit-remaining`), and transparent 429 retry with exponential backoff. Every caller through `DiscogsClient` — sync, enrichment, and any future consumer — automatically respects the rate limit without per-path code. The middleware is registered in the connection stack after the JSON parser and before the existing 503 retry middleware.

**Staggered multi-store sync via `SyncAllStoresJob`.** Iterates all stores and enqueues `FullStoreSyncJob` for each with a 5-minute staggered delay, spreading load across the night. A handful of stores completes within 30-60 minutes. The old `recurring.yml` `command:` targeting a single hardcoded store is replaced with a `class:`-based schedule.

**Shared concurrency limit across Discogs API jobs.** Both `FullStoreSyncJob` and `EnrichmentJob` use `limits_concurrency to: 1, key: -> { "discogs_api" }`, ensuring only one Discogs API consumer runs at any moment. This prevents enrichment for store N from overlapping with sync for store N+1.

**Removed per-path rate-limit logic from `InventoryFetcher` and `EnrichmentService`.** The middleware now owns all Discogs pacing and retry. MusicBrainz pacing is preserved under its own explicit `MUSICBRAINZ_SLEEP` constant — a separate API with separate limits.

## Test plan

- The middleware spec covers happy path, low-quota backoff, 429 retry (success and exhaustion), missing-header safety, and an integration test wired into a `DiscogsClient` connection stack.
- `SyncAllStoresJob` spec covers enqueue counts and stagger delay precision, including the zero-stores no-op.
- Existing `EnrichmentService` spec was updated to remove the rate-limit recovery test (that concern moved to the middleware).
- Existing `InventoryFetcher` tests still pass after removing rate-limit-specific mocks.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
