### PR TITLE
fix: include listing scope in curation cache key

### DIFF
--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -3,13 +3,13 @@ require "set"
 class StorefrontCuration
   CURATION_CACHE_TTL = 36.hours
   CURATION_CACHE_RACE_TTL = 30.seconds
-  CURATION_CACHE_KEY = "storefront/curation/v1/%<store_id>s/%<date>s"
+  CURATION_CACHE_KEY = "storefront/curation/v1/%<store_id>s/%<date>s/%<scope>s"
 
   # Returns { sections: [...], crates: [...] } — plain hashes, cache-safe.
   # On cache miss, runs curation + presentation, writes to cache, returns payload.
   # On cache hit, returns cached payload without instantiating curation or presenter.
   def self.cached_curation(store, filter_available: true, cache: Rails.cache)
-    key = CURATION_CACHE_KEY % { store_id: store.id, date: Date.current.iso8601 }
+    key = curation_cache_key(store, filter_available:)
     cache.fetch(key, expires_in: CURATION_CACHE_TTL, race_condition_ttl: CURATION_CACHE_RACE_TTL) do
       curation  = new(store, filter_available:)
       presenter = CratePresenter.new(store)
@@ -22,10 +22,20 @@ class StorefrontCuration
 
   # Writes the fully-serialized curation payload to cache.
   # Used by DailyCurationService for pre-warming.
-  def self.write_curation_cache(store, curation_payload, cache: Rails.cache)
-    key = CURATION_CACHE_KEY % { store_id: store.id, date: Date.current.iso8601 }
+  def self.write_curation_cache(store, curation_payload, filter_available: true, cache: Rails.cache)
+    key = curation_cache_key(store, filter_available:)
     cache.write(key, curation_payload, expires_in: CURATION_CACHE_TTL)
   end
+
+  # Builds the cache key incorporating store, date, and listing scope.
+  # When filter_available is true the scope is "available"; when false it's "all".
+  # This prevents scope collisions — e.g. DailyCurationService pre-warms with
+  # filter_available: true while development storefronts use filter_available: false.
+  def self.curation_cache_key(store, filter_available: true)
+    scope = filter_available ? "available" : "all"
+    CURATION_CACHE_KEY % { store_id: store.id, date: Date.current.iso8601, scope: }
+  end
+  private_class_method :curation_cache_key
 
   def initialize(store, filter_available: true)
     @store = store

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -261,10 +261,11 @@ RSpec.describe StorefrontCuration do
       expect(result[:crates]).to be_present
     end
 
-    it "cache key includes store id and current date" do
+    it "cache key includes store id, current date, and scope" do
       key = described_class::CURATION_CACHE_KEY % {
         store_id: store.id,
-        date: Date.current.iso8601
+        date: Date.current.iso8601,
+        scope: "available"
       }
 
       described_class.cached_curation(store, cache: cache)
@@ -273,9 +274,31 @@ RSpec.describe StorefrontCuration do
       # Different date should result in a different (empty) cache
       other_key = described_class::CURATION_CACHE_KEY % {
         store_id: store.id,
-        date: (Date.current + 1.day).iso8601
+        date: (Date.current + 1.day).iso8601,
+        scope: "available"
       }
       expect(cache.exist?(other_key)).to be false
+    end
+
+    it "uses different cache keys for different filter_available scopes" do
+      available_key = described_class::CURATION_CACHE_KEY % {
+        store_id: store.id,
+        date: Date.current.iso8601,
+        scope: "available"
+      }
+      all_key = described_class::CURATION_CACHE_KEY % {
+        store_id: store.id,
+        date: Date.current.iso8601,
+        scope: "all"
+      }
+
+      described_class.cached_curation(store, cache: cache)
+      expect(cache.exist?(available_key)).to be true
+      expect(cache.exist?(all_key)).to be false
+
+      described_class.cached_curation(store, filter_available: false, cache: cache)
+      expect(cache.exist?(all_key)).to be true
+      expect(cache.exist?(available_key)).to be true  # still present from first call
     end
 
     it "returns sections and crates with matching data" do
@@ -301,16 +324,36 @@ RSpec.describe StorefrontCuration do
     let(:store) { create(:store) }
     let(:cache) { ActiveSupport::Cache::MemoryStore.new }
 
-    it "writes the payload to cache with the correct key" do
+    it "writes the payload to cache with the correct key including scope" do
       payload = { sections: [], crates: [] }
       key = described_class::CURATION_CACHE_KEY % {
         store_id: store.id,
-        date: Date.current.iso8601
+        date: Date.current.iso8601,
+        scope: "available"
       }
 
       described_class.write_curation_cache(store, payload, cache: cache)
 
       expect(cache.read(key)).to eq(payload)
+    end
+
+    it "writes to a different key when filter_available is false" do
+      payload = { sections: [], crates: [] }
+      available_key = described_class::CURATION_CACHE_KEY % {
+        store_id: store.id,
+        date: Date.current.iso8601,
+        scope: "available"
+      }
+      all_key = described_class::CURATION_CACHE_KEY % {
+        store_id: store.id,
+        date: Date.current.iso8601,
+        scope: "all"
+      }
+
+      described_class.write_curation_cache(store, payload, filter_available: false, cache: cache)
+
+      expect(cache.read(all_key)).to eq(payload)
+      expect(cache.exist?(available_key)).to be false
     end
 
     it "does not raise with an empty payload" do


### PR DESCRIPTION
The curation cache key was `store+date` only, so DailyCurationService (which pre-warms with `filter_available: true`) and development storefront reads (which use `filter_available: false`) would collide on the same key. In development, the warm cache from the daily job would serve the filtered payload to a scope expecting all listings, hiding unavailable records.

The key now includes a scope segment — `storefront/curation/v1/{store_id}/{date}/available` for filtered reads, `.../all` for unfiltered. Extracted `curation_cache_key(store, filter_available:)` as a private class method used by both `cached_curation` and `write_curation_cache`.
