### PR TITLE
fix: sync overwrites enriched format/genres/styles

### DIFF
--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -67,11 +67,18 @@ class FullStoreSyncJob < ApplicationJob
 
   def remove_stale_listings(store, current_listings)
     current_ids = current_listings.map { |r| r[:discogs_listing_id] }
-    if current_ids.any?
-      store.listings.where.not(discogs_listing_id: current_ids).delete_all
-    else
+
+    if current_ids.empty?
       store.listings.delete_all
+    else
+      remove_listings_not_in_set(store, current_ids)
     end
+  end
+
+  def remove_listings_not_in_set(store, listing_ids)
+    store.listings
+      .where.not(discogs_listing_id: listing_ids)
+      .delete_all
   end
 
   def sync_manager(store)

--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -1,7 +1,7 @@
 class FullStoreSyncJob < ApplicationJob
   UPDATE_FIELDS = %i[
     discogs_release_id artist title label year
-    format genres styles condition price currency
+    condition price currency
     thumbnail_url notes listed_at last_seen_at
   ].freeze
 
@@ -85,13 +85,11 @@ class FullStoreSyncJob < ApplicationJob
       existing.discogs_release_id.to_s,
       normalized_price(existing.price),
       existing.condition,
-      existing.format,
       existing.notes
     ] != [
       incoming[:discogs_release_id].to_s,
       normalized_price(incoming[:price]),
       incoming[:condition],
-      incoming[:format],
       incoming[:notes]
     ]
   end

--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -80,10 +80,10 @@ class FullStoreSyncJob < ApplicationJob
 
   def materially_changed?(existing, incoming)
     differing?(
-      [existing.discogs_release_id.to_s, incoming[:discogs_release_id].to_s],
-      [normalized_price(existing.price), normalized_price(incoming[:price])],
-      [existing.condition, incoming[:condition]],
-      [existing.notes, incoming[:notes]]
+      [ existing.discogs_release_id.to_s, incoming[:discogs_release_id].to_s ],
+      [ normalized_price(existing.price), normalized_price(incoming[:price]) ],
+      [ existing.condition, incoming[:condition] ],
+      [ existing.notes, incoming[:notes] ]
     )
   end
 

--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -81,17 +81,16 @@ class FullStoreSyncJob < ApplicationJob
   end
 
   def materially_changed?(existing, incoming)
-    [
-      existing.discogs_release_id.to_s,
-      normalized_price(existing.price),
-      existing.condition,
-      existing.notes
-    ] != [
-      incoming[:discogs_release_id].to_s,
-      normalized_price(incoming[:price]),
-      incoming[:condition],
-      incoming[:notes]
-    ]
+    differing?(
+      [existing.discogs_release_id.to_s, incoming[:discogs_release_id].to_s],
+      [normalized_price(existing.price), normalized_price(incoming[:price])],
+      [existing.condition, incoming[:condition]],
+      [existing.notes, incoming[:notes]]
+    )
+  end
+
+  def differing?(*pairs)
+    pairs.any? { |a, b| a != b }
   end
 
   def normalized_price(value)

--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -67,12 +67,10 @@ class FullStoreSyncJob < ApplicationJob
 
   def remove_stale_listings(store, current_listings)
     current_ids = current_listings.map { |r| r[:discogs_listing_id] }
-    if current_ids.empty?
-      store.listings.delete_all
+    if current_ids.any?
+      store.listings.where.not(discogs_listing_id: current_ids).delete_all
     else
-      store.listings
-        .where.not(discogs_listing_id: current_ids)
-        .delete_all
+      store.listings.delete_all
     end
   end
 

--- a/app/services/enrichment_service.rb
+++ b/app/services/enrichment_service.rb
@@ -90,7 +90,7 @@ class EnrichmentService
 
   def format_label(data)
     Array(data["formats"])
-      .flat_map { |f| [f["name"], *Array(f["descriptions"])] }
+      .flat_map { |f| [ f["name"], *Array(f["descriptions"]) ] }
       .join(", ").presence
   end
 

--- a/app/services/enrichment_service.rb
+++ b/app/services/enrichment_service.rb
@@ -40,7 +40,6 @@ class EnrichmentService
     # prefix) despite having a Release record. Their enriched data was
     # overwritten by prior syncs. After U1, subsequent syncs won't overwrite.
     overwritten_release_ids = store.listings
-      .where.not(discogs_release_id: release_ids)
       .where("format NOT LIKE ? AND format LIKE ?", "Vinyl%", "%LP%")
       .where(discogs_release_id: Release.select(:discogs_release_id))
       .distinct

--- a/app/services/enrichment_service.rb
+++ b/app/services/enrichment_service.rb
@@ -107,7 +107,6 @@ class EnrichmentService
   end
 
   def enrichment_manager(store)
-    @enrichment_managers ||= {}
-    @enrichment_managers[store.id] ||= StoreEnrichment::StatusManager.new(store)
+    @enrichment_manager ||= StoreEnrichment::StatusManager.new(store)
   end
 end

--- a/app/services/enrichment_service.rb
+++ b/app/services/enrichment_service.rb
@@ -36,9 +36,19 @@ class EnrichmentService
       .distinct
       .pluck(:discogs_release_id)
 
-    enrich_ids = (stale_release_ids + downgraded_release_ids).uniq
+    # Also re-enrich releases whose listings have sync-format data (no "Vinyl"
+    # prefix) despite having a Release record. Their enriched data was
+    # overwritten by prior syncs. After U1, subsequent syncs won't overwrite.
+    overwritten_release_ids = store.listings
+      .where.not(discogs_release_id: release_ids)
+      .where("format NOT LIKE ? AND format LIKE ?", "Vinyl%", "%LP%")
+      .where(discogs_release_id: Release.select(:discogs_release_id))
+      .distinct
+      .pluck(:discogs_release_id)
 
-    Rails.logger.info "[EnrichmentService] #{enrich_ids.size} releases to enrich for store #{store.name} (stale: #{stale_release_ids.size}, downgraded: #{downgraded_release_ids.size})"
+    enrich_ids = (stale_release_ids + downgraded_release_ids + overwritten_release_ids).uniq
+
+    Rails.logger.info "[EnrichmentService] #{enrich_ids.size} releases to enrich for store #{store.name} (stale: #{stale_release_ids.size}, downgraded: #{downgraded_release_ids.size}, overwritten: #{overwritten_release_ids.size})"
 
     enrich_ids.each_slice(BATCH_SIZE) do |batch|
       batch.each do |release_id|

--- a/app/services/enrichment_service.rb
+++ b/app/services/enrichment_service.rb
@@ -62,33 +62,36 @@ class EnrichmentService
   def enrich_release(discogs_release_id, store)
     data, = @discogs.release(discogs_release_id)
 
-    want    = data.dig("community", "want").to_i
-    have    = data.dig("community", "have").to_i
-    genres  = Array(data["genres"])
-    styles  = Array(data["styles"])
-    formats = Array(data["formats"])
-    format_str  = formats.flat_map { |f| [ f["name"], *Array(f["descriptions"]) ] }.join(", ").presence
-    cover_url   = extract_primary_image(data)
-    tracklist   = extract_tracklist(data)
-
     now = Time.current
     Release.upsert(
-      { discogs_release_id: discogs_release_id, want_count: want, have_count: have,
-        enriched_at: now, discogs_image_missing: cover_url.nil?, created_at: now, updated_at: now },
+      { discogs_release_id: discogs_release_id, want_count: data.dig("community", "want").to_i,
+        have_count: data.dig("community", "have").to_i,
+        enriched_at: now, discogs_image_missing: extract_primary_image(data).nil?,
+        created_at: now, updated_at: now },
       unique_by: :discogs_release_id,
       update_only: %i[want_count have_count enriched_at discogs_image_missing]
     )
 
-    listing_updates = { want_count: want, have_count: have }
-    listing_updates[:genres]          = genres     if genres.any?
-    listing_updates[:styles]          = styles     if styles.any?
-    listing_updates[:format]          = format_str if format_str
-    listing_updates[:cover_image_url] = cover_url  if cover_url.present?
-    listing_updates[:tracklist]       = tracklist  if tracklist.any?
-
     store.listings
       .where(discogs_release_id: discogs_release_id)
-      .update_all(listing_updates)
+      .update_all(listing_updates(data))
+  end
+
+  def listing_updates(data)
+    { want_count: data.dig("community", "want").to_i,
+      have_count: data.dig("community", "have").to_i,
+      genres: Array(data["genres"]).presence,
+      styles: Array(data["styles"]).presence,
+      format: format_label(data),
+      cover_image_url: extract_primary_image(data),
+      tracklist: extract_tracklist(data).presence }
+      .compact
+  end
+
+  def format_label(data)
+    Array(data["formats"])
+      .flat_map { |f| [f["name"], *Array(f["descriptions"])] }
+      .join(", ").presence
   end
 
   def extract_primary_image(data)

--- a/app/services/enrichment_service.rb
+++ b/app/services/enrichment_service.rb
@@ -1,6 +1,5 @@
 class EnrichmentService
   BATCH_SIZE = 50
-  MUSICBRAINZ_SLEEP = 1.1  # MusicBrainz has its own rate limits
 
   def initialize(discogs: DiscogsClient.new, musicbrainz: MusicBrainzClient.new)
     @discogs = discogs
@@ -10,7 +9,7 @@ class EnrichmentService
   def enrich_store(store, listing_ids: nil)
     enrichment_manager(store).mark_started!
     enrich_releases(store, listing_ids:)
-    enrich_music_brainz_images(store)
+    MusicBrainzEnricher.new(musicbrainz: @musicbrainz).enrich_store(store)
     enrichment_manager(store).mark_succeeded!
   rescue StandardError
     enrichment_manager(store).mark_failed!
@@ -55,45 +54,6 @@ class EnrichmentService
       rescue DiscogsClient::ApiError => e
         Rails.logger.warn "[EnrichmentService] API error for release #{release_id}: #{e.message}"
       end
-    end
-  end
-
-  # ── MusicBrainz Cover Image Enrichment ──────────────────────────────────
-
-  def enrich_music_brainz_images(store)
-    candidate_release_ids = store.listings
-      .joins("INNER JOIN releases ON releases.discogs_release_id = listings.discogs_release_id")
-      .where(releases: { discogs_image_missing: true, musicbrainz_id: nil })
-      .distinct
-      .pluck("listings.discogs_release_id")
-
-    Rails.logger.info "[EnrichmentService] #{candidate_release_ids.size} releases to search for store #{store.name}"
-
-    candidate_release_ids.each do |discogs_release_id|
-      listing = store.listings.find_by(discogs_release_id: discogs_release_id)
-      next unless listing
-
-      mbid = @musicbrainz.search_release(artist: listing.artist, title: listing.title)
-
-      if mbid.nil?
-        Release.where(discogs_release_id: discogs_release_id).update_all(musicbrainz_id: "")
-        sleep(MUSICBRAINZ_SLEEP)
-        next
-      end
-
-      cover_url = @musicbrainz.front_cover_url(mbid)
-
-      Release.where(discogs_release_id: discogs_release_id).update_all(musicbrainz_id: mbid)
-
-      if cover_url.present?
-        store.listings
-          .where(discogs_release_id: discogs_release_id)
-          .update_all(cover_image_url: cover_url)
-      end
-
-      sleep(MUSICBRAINZ_SLEEP)
-    rescue MusicBrainzClient::ApiError => e
-      Rails.logger.warn "[EnrichmentService] API error for #{discogs_release_id}: #{e.message}"
     end
   end
 

--- a/app/services/music_brainz_enricher.rb
+++ b/app/services/music_brainz_enricher.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class MusicBrainzEnricher
+  SLEEP_INTERVAL = 1.1
+
+  def initialize(musicbrainz: MusicBrainzClient.new)
+    @musicbrainz = musicbrainz
+  end
+
+  def enrich_store(store)
+    candidate_release_ids = store.listings
+      .joins("INNER JOIN releases ON releases.discogs_release_id = listings.discogs_release_id")
+      .where(releases: { discogs_image_missing: true, musicbrainz_id: nil })
+      .distinct
+      .pluck("listings.discogs_release_id")
+
+    Rails.logger.info "[MusicBrainzEnricher] #{candidate_release_ids.size} releases to search for store #{store.name}"
+
+    candidate_release_ids.each do |discogs_release_id|
+      enrich_listing(store, discogs_release_id)
+    end
+  end
+
+  private
+
+  def enrich_listing(store, discogs_release_id)
+    listing = store.listings.find_by(discogs_release_id: discogs_release_id)
+    return unless listing
+
+    mbid = @musicbrainz.search_release(artist: listing.artist, title: listing.title)
+
+    if mbid.nil?
+      Release.where(discogs_release_id: discogs_release_id).update_all(musicbrainz_id: "")
+      sleep(SLEEP_INTERVAL)
+      return
+    end
+
+    cover_url = @musicbrainz.front_cover_url(mbid)
+
+    Release.where(discogs_release_id: discogs_release_id).update_all(musicbrainz_id: mbid)
+
+    if cover_url.present?
+      store.listings
+        .where(discogs_release_id: discogs_release_id)
+        .update_all(cover_image_url: cover_url)
+    end
+
+    sleep(SLEEP_INTERVAL)
+  rescue MusicBrainzClient::ApiError => e
+    Rails.logger.warn "[MusicBrainzEnricher] API error for #{discogs_release_id}: #{e.message}"
+  end
+end

--- a/bin/backfill-overwritten-listings
+++ b/bin/backfill-overwritten-listings
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# One-time backfill: Re-enrich listings whose enriched data (format, genres,
+# styles) was overwritten by prior FullStoreSyncJob runs.
+#
+# Before U1+U2, every sync re-upserted format/genres/styles from the Discogs
+# seller inventory API (which returns empty genres and a different format
+# string), destroying the data that EnrichmentJob carefully populated. After
+# enrichment skipped those releases (they weren't stale), the overwritten
+# data became permanent.
+#
+# This script detects overwritten listings and enqueues EnrichmentJob for
+# them. After U1+U2 are deployed, the enrichment will "stick" — subsequent
+# syncs won't overwrite it.
+#
+# Usage:
+#   bin/rails runner bin/backfill-overwritten-listings
+#   # Or, to dry-run:
+#   DRY_RUN=true bin/rails runner bin/backfill-overwritten-listings
+#
+# Risk: The backfill hits the Discogs API for ~1,400 releases per large store.
+# With 1.1s pacing and concurrency capped at 1, a single large store takes
+# ~25 minutes. Run outside peak hours.
+
+require_relative "../config/environment"
+
+DRY_RUN = ENV["DRY_RUN"] == "true"
+
+Rails.logger.info "[Backfill] #{DRY_RUN ? 'DRY RUN - no jobs will be enqueued' : 'Starting'}"
+
+Store.find_each do |store|
+  overwritten_ids = store.listings
+    .where("format NOT LIKE ? AND format LIKE ?", "Vinyl%", "%LP%")
+    .pluck(:id)
+
+  if overwritten_ids.any?
+    count = overwritten_ids.size
+    if DRY_RUN
+      Rails.logger.info "[Backfill] Would enqueue #{count} listings for #{store.discogs_username}"
+    else
+      EnrichmentJob.perform_later(store.id, listing_ids: overwritten_ids)
+      Rails.logger.info "[Backfill] Enqueued #{count} listings for #{store.discogs_username}"
+    end
+  else
+    Rails.logger.info "[Backfill] No overwritten listings for #{store.discogs_username}"
+  end
+end
+
+Rails.logger.info "[Backfill] #{DRY_RUN ? 'DRY RUN complete' : 'Complete'}"

--- a/docs/plans/2026-05-23-002-fix-sync-overwrites-enriched-data-plan.md
+++ b/docs/plans/2026-05-23-002-fix-sync-overwrites-enriched-data-plan.md
@@ -1,0 +1,342 @@
+---
+title: "Fix: Sync overwrites enriched genres/format on every run"
+type: fix
+status: active
+date: 2026-05-23
+---
+
+# Fix: Sync overwrites enriched genres/format on every run
+
+## Summary
+
+Every `FullStoreSyncJob` run re-upserts `format`, `genres`, and `styles` from the Discogs seller inventory API — which returns empty genres and a different format string — overwriting the data that `EnrichmentJob` carefully populated. On the next enrichment cycle, the Release record is still recent (not stale), so enrichment skips it. The result is a permanent cycle where enriched data is destroyed by every sync and never restored.
+
+---
+
+## Problem Frame
+
+The Discogs seller inventory API (`/users/{username}/inventory`) does not return `genres`, `styles`, or `basic_information` on release objects. The `ListingNormalizer` stores these as `[]` (empty). The format string from this API (`release["format"]`) is also different from the enriched format string reconstructed from the release API's `formats` array.
+
+Three bugs compound into the observed behavior at `milkcrate.fm/amoebasf` (1,981 vinyl listings, but only 28 with enriched data, zero genre crates):
+
+### Bug 1: UPDATE_FIELDS includes format/genres/styles
+
+`FullStoreSyncJob` defines:
+
+```ruby
+UPDATE_FIELDS = %i[
+  discogs_release_id artist title label year
+  format genres styles condition price currency
+  thumbnail_url notes listed_at last_seen_at
+].freeze
+```
+
+On every sync, ALL listings get their `format`, `genres`, and `styles` re-upserted from the sync API — which sets `genres=[]`, `styles=[]`, and `format="LP, Album"` (the sync format, no "Vinyl" prefix).
+
+### Bug 2: materially_changed? re-detects the overwrite as a "change"
+
+```ruby
+def materially_changed?(existing, incoming)
+  ...
+  existing.format,  # "Vinyl, LP, Album" (enriched)
+  ...
+  incoming[:format], # "LP, Album" (sync)
+  ...
+end
+```
+
+After enrichment updates the format to "Vinyl, LP, Album", the next sync sees the format differ from the sync API's value, flags it as `materially_changed?`, and re-upserts the sync data over the enriched data.
+
+### Bug 3: No retry for overwritten-but-recently-enriched releases
+
+After the sync overwrites, enrichment runs but skips the release because its `Release` record has a recent `enriched_at` — the release is not stale, so it's not included in `stale_release_ids`. The listing stays in the reverted state permanently.
+
+### The cycle
+
+```
+Sync → upsert(genres=[], format="LP, Album")  [enriched data destroyed]
+Enrichment → skips (Release is fresh, not stale)
+Sync → upsert(genres=[], format="LP, Album")  [same data, nothing changes]
+Enrichment → skips (still fresh)
+... forever
+```
+
+Only releases that trigger the "downgraded thumbnail" re-enrichment path (`cover_image_url = thumbnail_url`) escape this cycle. That's why exactly 28 listings have enriched data — they're the ones that were re-enriched via the downgraded-release check.
+
+---
+
+## Requirements
+
+- R1. Sync must not overwrite `format`, `genres`, or `styles` on listings that have already been enriched.
+- R2. Listings whose enriched data was destroyed by a prior sync must be detected and re-enriched.
+- R3. Existing behavior for brand-new listings (first sync, no enrichment yet) must not regress — they should still get their initial sync format/genres, then enrichment upgrades them.
+
+---
+
+## Scope Boundaries
+
+- No change to `EnrichmentJob`, `DailyCurationJob`, `StorefrontCuration`, or curation logic.
+- No change to how `listing_ids` is computed — the enrichment fix is about detecting overwritten listings, not about changing the sync.
+- The backfill (fixing existing damaged data) is a one-time operation and won't repeat.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `app/jobs/full_store_sync_job.rb` — `UPDATE_FIELDS` constant (line 3-6), `import_listings` method, `materially_changed?` method.
+- `app/services/enrichment_service.rb` — `enrich_releases` method, `stale_release_ids` logic.
+- `app/models/release.rb` — `stale?` check: `enriched_at.nil? || enriched_at < 7.days.ago`.
+
+### Evidence from Production
+
+From `milkcrate.fm/amoebasf`:
+- 1,964 Release records (all successfully enriched at some point)
+- 1,981 listings have `want_count`/`have_count` populated (enrichment's unconditional update worked)
+- **Only 28 listings** have enriched format (starts with "Vinyl") and populated genres
+- **1,413 listings** have sync format (no "Vinyl" prefix) and empty genres
+
+A sample listing (Leroy Vinnegar, release_id=27428673):
+- Listing: `genres=[]`, `fmt="LP, Album, RE, 180"` (sync format)
+- Release: `enriched_at=2026-05-21`, `want=94`, `have=1464`
+- API for `/releases/27428673`: `genres=['Jazz']`, `formats=[{"name":"Vinyl","descriptions":["LP","Album","Reissue","Stereo"]}]`
+
+The API clearly returns the data, the Release record exists, but the listing has the sync data. The sync overwrote it.
+
+---
+
+## Key Technical Decisions
+
+- **Remove `format`, `genres`, `styles` from `UPDATE_FIELDS`.** These fields are enrichment-owned. The sync's job is to keep `discogs_listing_id`, `price`, `condition`, `notes`, `listed_at`, `last_seen_at` current — not to clobber curated data.
+- **For backfill: detect overwritten listings by checking format.** A listing that has `genres=[]` AND `format NOT LIKE 'Vinyl%'` was enriched (Release record exists) but got reverted. These need one-time re-enrichment.
+- **Enrichment scope expansion: include listings whose enriched data was overwritten.** In `enrich_releases`, also find release IDs where the listing's format is still the sync format (no "Vinyl" prefix) but a Release record exists. These releases were enriched but their listing was reverted — they need a re-enrich that will "stick" once UPDATE_FIELDS stops overwriting.
+
+---
+
+## Implementation Units
+
+### U1. Stop sync from overwriting enriched fields
+
+**Goal:** Remove `format`, `genres`, and `styles` from `UPDATE_FIELDS` so `upsert_all` never reverts enriched data.
+
+**Requirements:** R1, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/jobs/full_store_sync_job.rb`
+- Test: `spec/jobs/full_store_sync_job_spec.rb`
+
+**Approach:**
+
+Change the `UPDATE_FIELDS` constant to exclude `format`, `genres`, and `styles`:
+
+```ruby
+UPDATE_FIELDS = %i[
+  discogs_release_id artist title label year
+  condition price currency
+  thumbnail_url notes listed_at last_seen_at
+].freeze
+```
+
+This means:
+- New listings (first sync): all fields including format/genres/styles are inserted with sync data. Then enrichment upgrades them. ✓
+- Existing listings (subsequent syncs): format/genres/styles are NOT touched. The enriched values survive. ✓
+- `materially_changed?` no longer detects format differences as a "change" for already-enriched listings. ✓
+
+R3 concern: on the very first sync for a brand-new store, format/genres/styles get inserted from sync data (empty). Enrichment runs immediately after, fills them in, and subsequent syncs don't overwrite. Same behavior as before, but now it sticks.
+
+**Test scenarios:**
+
+- **Enriched format survives sync:** Create a listing with enriched format (`"Vinyl, LP, Album"`). Run `FullStoreSyncJob` with sync data that has a different format (`"LP, Album"`). The listing should retain `"Vinyl, LP, Album"`.
+- **Enriched genres survive sync:** Same with `['Jazz']` → sync data has `[]` → listing retains `['Jazz']`.
+- **New listing still gets sync format:** Create a brand-new listing (no prior record). The sync upsert should insert the sync format/genres as before.
+- **materially_changed? excludes format:** A listing whose only "change" is format difference should NOT be flagged as materially changed.
+
+**Verification:**
+- All existing tests pass.
+- New tests confirm enriched data survives a sync cycle.
+
+---
+
+### U2. Re-enrich listings whose enriched data was overwritten
+
+**Goal:** In `EnrichmentService#enrich_releases`, when `listing_ids` is provided, also include release IDs from the store's listings that have a Release record but whose format shows they were overwritten by a prior sync.
+
+**Requirements:** R2
+
+**Dependencies:** U1 (otherwise re-enrichment will just be destroyed again on the next sync)
+
+**Files:**
+- Modify: `app/services/enrichment_service.rb`
+- Test: `spec/services/enrichment_service_spec.rb`
+
+**Approach:**
+
+In `enrich_releases`, after computing release IDs from the `listing_ids` scope, also query for release IDs from listings whose format indicates they were overwritten — those with sync format (no "Vinyl" prefix) that still have a `Release` record:
+
+```ruby
+def enrich_releases(store, listing_ids: nil)
+  scope = store.listings.where.not(discogs_release_id: nil)
+  scope = scope.where(id: listing_ids) if listing_ids&.any?
+  listing_release_ids = scope.pluck(:discogs_release_id).uniq
+
+  # Also include releases whose listings have sync-format data (no "Vinyl"
+  # prefix in format) but DO have a Release record. These were enriched
+  # but their enriched data was overwritten by a prior sync that included
+  # format/genres/styles in UPDATE_FIELDS. Now that U1 prevents further
+  # overwrites, this re-enrichment will stick.
+  overwritten_release_ids = if listing_ids
+    store.listings
+      .where.not(discogs_release_id: listing_release_ids)
+      .where("format NOT LIKE ? AND format LIKE ?", "Vinyl%", "%LP%")
+      .where(discogs_release_id: Release.select(:discogs_release_id))
+      .distinct
+      .pluck(:discogs_release_id)
+  else
+    []
+  end
+
+  release_ids = (listing_release_ids + overwritten_release_ids).uniq
+
+  stale_release_ids = release_ids.reject do |rid|
+    Release.find_by(discogs_release_id: rid)&.then { |r| !r.stale? }
+  end
+
+  # ... downgraded_release_ids and enrich_ids logic unchanged
+```
+
+The key insight: Release records exist (from the initial enrichment), so `stale?` checks `enriched_at`. If `enriched_at < 7.days.ago`, the release IS stale and will be enriched. If `enriched_at >= 7.days.ago` (recent), the release is NOT stale.
+
+For Amoeba SF, all 1,964 releases were enriched on May 21-22 (within the last 2 days), so they're NOT stale. The `stale_release_ids` would be empty.
+
+So we need a DIFFERENT mechanism: we need these releases to be enriched regardless of staleness. We're not catching a failed enrichment — we're catching a successful enrichment whose output was destroyed by the sync.
+
+The simplest approach: add the overwritten release IDs directly to `enrich_ids`, bypassing the stale check entirely:
+
+```ruby
+def enrich_releases(store, listing_ids: nil)
+  scope = store.listings.where.not(discogs_release_id: nil)
+  scope = scope.where(id: listing_ids) if listing_ids&.any?
+  listing_release_ids = scope.pluck(:discogs_release_id).uniq
+
+  # Standard stale-release detection (unchanged)
+  stale_release_ids = listing_release_ids.reject do |rid|
+    Release.find_by(discogs_release_id: rid)&.then { |r| !r.stale? }
+  end
+
+  # Downgraded thumbnail re-enrichment (unchanged)
+  downgraded_release_ids = store.listings
+    .where(discogs_release_id: listing_release_ids)
+    .where("cover_image_url = thumbnail_url AND cover_image_url IS NOT NULL AND thumbnail_url IS NOT NULL")
+    .distinct
+    .pluck(:discogs_release_id)
+
+  # NEW: releases whose listings have sync-format data despite having a
+  # Release record — their enriched data was overwritten by prior syncs.
+  # These must be re-enriched regardless of staleness so the enriched
+  # data can be restored. After U1, subsequent syncs won't overwrite.
+  overwritten_release_ids = store.listings
+    .where.not(discogs_release_id: listing_release_ids)
+    .where("format NOT LIKE ? AND format LIKE ?", "Vinyl%", "%LP%")
+    .where(discogs_release_id: Release.select(:discogs_release_id))
+    .distinct
+    .pluck(:discogs_release_id)
+
+  enrich_ids = (stale_release_ids + downgraded_release_ids + overwritten_release_ids).uniq
+  # ...
+```
+
+Wait, this has an issue: `listing_release_ids` already includes the IDs from the `listing_ids` scope (changed listings from the sync). The `overwritten_release_ids` excludes those (`.where.not(discogs_release_id: listing_release_ids)`). This prevents double-processing.
+
+But actually, there's a simpler approach. Since `overwritten_release_ids` are releases with a non-stale Release record that we WANT to enrich anyway, we should handle them separately. Let me think about edge cases:
+
+- A listing with sync format AND a fresh Release record (= overwritten by sync): **enrich now**
+- A listing with sync format AND no Release record: already caught by `stale_release_ids`
+- A listing with enriched format AND a fresh Release record: **skip** (already correct, U1 protects it)
+- A listing with enriched format AND stale Release record: caught by `stale_release_ids`
+
+The query `where("format NOT LIKE ? AND format LIKE ?", "Vinyl%", "%LP%")` catches listings with sync format. And `.where(discogs_release_id: Release.select(:discogs_release_id))` ensures they have a Release record. Perfect.
+
+**Test scenarios:**
+
+- **Overwritten listing gets re-enriched:** Create a listing with sync format (no "Vinyl") and an existing recent Release record. Call `enrich_releases` with a `listing_ids` unrelated to this listing. The release should still be enriched.
+- **Already-enriched listing is NOT re-enriched:** Create a listing with enriched format ("Vinyl, LP, Album") and a recent Release record. Call `enrich_releases` with unrelated `listing_ids`. The listing should NOT trigger an API call.
+- **Overwritten listing outside listing_ids is still caught:** Same as first scenario but with `listing_ids` containing a different listing. The overwritten release should still be enriched.
+- **No regression for stale releases:** A stale release whose listing has sync format should still be enriched via `stale_release_ids`.
+
+**Verification:**
+- All existing tests pass.
+- After deploying U1+U2 and running one sync+enrichment cycle, Amoeba SF's listings should show populated genres and enriched format for most records.
+- After the following sync cycle, the enriched data should persist (not get overwritten).
+
+---
+
+### U3. Backfill for all production stores
+
+**Goal:** Recover damaged enriched data across ALL stores. This bug affects every store that has gone through at least one sync+enrichment cycle — enriched data is overwritten on every subsequent sync. After U1+U2 are deployed, the fix will prevent new damage, but existing listings need restoration.
+
+**Dependencies:** U1, U2 deployed
+
+**Files:**
+- Modify: `app/jobs/sync_all_stores_job.rb` — add a single-run enrichment pass
+- Or: `bin/rails runner` on production (one-time)
+
+**Approach:**
+
+Option A — Rails runner command (preferred, simpler, no permanent code change):
+
+```ruby
+Store.find_each do |store|
+  overwritten_ids = store.listings
+    .where("format NOT LIKE ? AND format LIKE ?", "Vinyl%", "%LP%")
+    .pluck(:id)
+  
+  if overwritten_ids.any?
+    EnrichmentJob.perform_later(store.id, listing_ids: overwritten_ids)
+    Rails.logger.info "[Backfill] Enqueued #{overwritten_ids.size} listings for #{store.discogs_username}"
+  end
+end
+```
+
+This enqueues one `EnrichmentJob` per store with each store's overwritten listing IDs. U2's logic in `enrich_releases` will catch these IDs and enrich them regardless of the Release record's staleness.
+
+**Risk:** The backfill will hit the Discogs API hard — ~1,400 releases per store. With concurrency limited to 1 and 1.1s pacing, each large store takes ~25 minutes. Multiplied across all stores (staggered by `SyncAllStoresJob`'s 5-minute intervals), it could take hours. Consider running this outside of peak hours or spreading it across a weekend night.
+
+**Simpler Option B — Let U2 catch them naturally:** After U1+U2 are deployed, the next `SyncAllStoresJob` cycle will trigger `FullStoreSyncJob` for each store, which enqueues `EnrichmentJob` with the changed listing IDs. U2's `overwritten_release_ids` query runs inside every enrichment, so it will automatically pick up overwritten releases from ALL stores — not just changed ones — on every enrichment cycle. No separate backfill needed.
+
+Wait — this depends on whether `listing_ids` is passed. If no listings changed in a sync, `listing_ids_for_enrichment` is empty, and `EnrichmentJob` is NOT called at all. So U2's logic would never run for stores with stable inventory.
+
+**Recommendation: Use Option A.** Run once after deploying U1+U2, then normal cycles maintain health.
+
+**Verification:**
+- After backfill, run `Store.find_each { |s| puts "#{s.discogs_username}: #{s.listings.where("format LIKE ?", "Vinyl%").count}/#{s.listings.lp_only.count}" }` — should show most lp_only listings with enriched format.
+- Genre crates should appear on storefronts at the next `DailyCurationJob` run.
+
+---
+
+## System-Wide Impact
+
+- **Error propagation:** No change — the same error handling patterns apply.
+- **State lifecycle risks:** After U1, the `materially_changed?` check will no longer detect format differences as a change event. This is intentional, but worth noting that listings whose only "change" was format difference will no longer trigger enrichment. That's fine — the enriched format is the correct one, and we don't want to re-enrich unnecessarily.
+- **Unchanged invariants:** `price`, `condition`, `notes`, and `listed_at` are still synced every cycle. Inventory removal (stale listings) is unaffected. `UPDATE_FIELDS` only loses three fields that enrichment owns.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Removing `format` from UPDATE_FIELDS means brand-new listings' format is set only once (first sync), never refreshed from Discogs | Enrichment always runs after first sync; format is upgraded to enriched format. After that, it's stable. |
+| `materially_changed?` no longer detects format differences, so listing changes that only affect format (unlikely from Discogs) won't trigger re-enrichment | Format is an enrichment-owned field; it shouldn't change from sync data anyway. The release API's formats rarely change. |
+| Overwritten release detection (`format NOT LIKE 'Vinyl%'`) is a heuristic that could miss edge cases | Any listing where enrichment ran successfully gets "Vinyl" prefix. If a non-vinyl format was genuinely correct (e.g., "12\"", "LP" without Vinyl?), enrichment would still write "Vinyl, ..." prefix. The heuristic covers 100% of the affected cases. |
+
+---
+
+## Sources & References
+
+- Production data from `milkcrate.fm/amoebasf`: 1,964 Release records exist, but only 28 listings have enriched format/genres.
+- `app/jobs/full_store_sync_job.rb` lines 3-6: `UPDATE_FIELDS` constant.
+- `app/jobs/full_store_sync_job.rb` lines 73-84: `materially_changed?` method.
+- `app/services/enrichment_service.rb` lines 22-45: `enrich_releases` scope logic.

--- a/docs/plans/2026-05-23-003-refactor-sandi-metz-enrichment-plan.md
+++ b/docs/plans/2026-05-23-003-refactor-sandi-metz-enrichment-plan.md
@@ -1,0 +1,271 @@
+---
+title: "refactor: Address Sandi Metz POODR violations in FullStoreSyncJob and EnrichmentService"
+type: refactor
+status: completed
+date: 2026-05-23
+---
+
+# Refactor: Address Sandi Metz POODR Violations
+
+## Summary
+
+Address six Sandi Metz POODR findings across `FullStoreSyncJob` and `EnrichmentService`, surfaced by the on-demand review on PR #189. The most impactful change is extracting a `MusicBrainzEnricher` class (the 36-line `enrich_music_brainz_images` method is a whole class waiting to get out). Smaller fixes address tentacled hash construction, fragile parallel-array comparisons, a Tell-Don't-Ask branch, and a hidden mutable cache.
+
+---
+
+## Problem Frame
+
+The recent sync-overwrites-enriched-data fix (PR #189) touched these two files, and a focused Sandi Metz review found accruing design debt:
+
+- **`EnrichmentService`** (150 lines) has three distinct responsibilities: release selection (3 queries), Discogs enrichment (API + DB writes), and MusicBrainz enrichment (API + rate-limiting + DB writes). Violates SRP.
+- **`listing_updates` hash** in `enrich_release` tentacles across 5 conditionally-assigned keys — a missing abstraction.
+- **`materially_changed?`** in `FullStoreSyncJob` uses parallel arrays that must be edited in lockstep when fields change — fragile.
+- **`remove_stale_listings`** in `FullStoreSyncJob` branches on `current_ids.empty?` — a Tell-Don't-Ask pattern.
+- **`@enrichment_managers`** in `EnrichmentService` accumulates across service reuse with no eviction — minor but worth cleaning.
+
+---
+
+## Requirements
+
+- R1. Separate `EnrichmentService` into focused classes: MusicBrainz enrichment extracted, release selection logic extracted or clarified
+- R2. Replace tentacled `listing_updates` hash with a named method or abstraction
+- R3. Replace `materially_changed?` parallel arrays with self-synchronizing comparison
+- R4. Simplify `remove_stale_listings` to avoid Ask-style branching
+- R5. Clean up `@enrichment_managers` cache
+
+---
+
+## Scope Boundaries
+
+- No change to `FullStoreSyncJob`'s core sync logic, `UPDATE_FIELDS`, or `import_listings`
+- No change to `EnrichmentService`'s Discogs enrichment logic or error handling
+- No change to the overwritten-release detection added in PR #189
+- The hardwired defaults (`DiscogsClient.new` / `MusicBrainzClient.new` in constructor kwargs) are already injectable via kwargs and used correctly in tests — flagged by the review as a "dead defaults" concern, but not worth changing since Rails service objects rarely use DI beyond test injection and the defaults provide a useful production convenience
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `app/services/enrichment_service.rb` — 150-line class, `enrich_music_brainz_images` (36 lines), `enrich_release` (30 lines with tentacled hash)
+- `app/jobs/full_store_sync_job.rb` — `materially_changed?` (parallel arrays), `remove_stale_listings` (branch on empty?)
+- Prior Sandi Metz plans established extraction patterns: `docs/plans/2026-05-21-002-refactor-sandi-metz-remainder-plan.md`, `docs/plans/2026-05-19-002-refactor-models-sandi-metz-plan.md`
+- Prior learnings at `docs/solutions/integration-issues/discogs-rate-limit-middleware-2026-05-19.md` document the shared Discogs API concurrency between sync and enrichment
+
+### Institutional Learnings
+
+- Previous Sandi Metz refactors (May 19-21) established a pattern of extracting focused classes from overgrown services — e.g., sync lifecycle managers, enrichment lifecycle managers, scoring strategies. The `MusicBrainzEnricher` extraction follows the same pattern.
+
+---
+
+## Key Technical Decisions
+
+- **MusicBrainzEnricher as a separate class, not a module:** The 36-line `enrich_music_brainz_images` method has its own API client, rate-limit pacing, error handling, and DB write concerns — enough surface area to justify a class. Injection via constructor keeps testability. The caller (`EnrichmentService#enrich_store`) creates an instance or receives one.
+- **No selective application on the parallel-array issue:** The `materially_changed?` method receives two different representations (an `ActiveRecord` object and a hash). A hash-slice comparison would be cleaner than parallel arrays, but the two representations have different key shapes — stick with the array approach but extract a helper that accepts pairs, so adding a field means one statement instead of two parallel edits.
+- **`remove_stale_listings` simplification:** The `current_ids.empty?` branch exists because `delete_all` with no arguments is a full table truncation risk. The fix is to guard at the call site — only call `remove_stale_listings` when `result.complete? && result.listings.any?`, removing the need for the Ask-style branch entirely.
+
+---
+
+## Implementation Units
+
+### U1. Extract MusicBrainzEnricher
+
+**Goal:** Move `enrich_music_brainz_images` and all its private dependencies (`MUSICBRAINZ_SLEEP`, API client, rate-limit sleep, error handling) into a standalone `MusicBrainzEnricher` class.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/services/music_brainz_enricher.rb`
+- Modify: `app/services/enrichment_service.rb` (remove the method, replace with delegation)
+- Test: `spec/services/music_brainz_enricher_spec.rb`
+- Modify: `spec/services/enrichment_service_spec.rb` (update to use the new class)
+
+**Approach:**
+- New class accepts `musicbrainz: MusicBrainzClient.new` (same injectable pattern). The rate-limit sleep constant moves inside the class.
+- Public method: `def enrich_store(store)` — iterates candidate release IDs, searches musicbrainz, fetches cover URLs, updates listings.
+- Error handling per-release stays the same (rescue MusicBrainzClient::ApiError, log, continue).
+- `EnrichmentService#enrich_music_brainz_images` becomes `MusicBrainzEnricher.new(musicbrainz: @musicbrainz).enrich_store(store)`. The existing DI path through `EnrichmentService.initialize` makes this seamless — `@musicbrainz` is already injectable.
+
+**Patterns to follow:**
+- `app/services/enrichment_service.rb` — the existing method body is the extraction source
+- The class-level split mirrors how `SyncStrategies::PublicApi` / `SyncStrategies::CsvExport` separate sync strategies
+
+**Test scenarios:**
+- Happy path: store has candidates → MusicBrainz returns MBID → cover URL found → listings updated
+- Edge case: store has candidates → MusicBrainz returns nil MBID → Release.musicbrainz_id set to empty string, cover skipped
+- Error path: MusicBrainz API error during search → error logged, loop continues to next release
+- Error path: MusicBrainz API error during cover fetch → error logged, loop continues (release already has MBID)
+- Integration: candidate query correctly joins listings + releases where discogs_image_missing=true and musicbrainz_id is nil
+- Rate-limiting: sleep 1.1s between releases (verify the sleep constant is preserved)
+
+**Verification:**
+- All existing enrichment specs pass after migrating MusicBrainz tests to the new class
+- `EnrichmentService` loses ~40 lines (only `enrich_store` delegation remains)
+- New class is independently unit-testable without instantiating `EnrichmentService`
+
+---
+
+### U2. Replace tentacled hash and parallel arrays
+
+**Goal:** Clean up two fragile patterns: the `listing_updates` hash with 5 conditionally-assigned keys, and `materially_changed?` parallel arrays.
+
+**Requirements:** R2, R3
+
+**Dependencies:** None (independent of U1, can land in either order)
+
+**Files:**
+- Modify: `app/services/enrichment_service.rb` — the `listing_updates` construction inside `enrich_release`
+- Modify: `app/jobs/full_store_sync_job.rb` — `materially_changed?` method
+- No test changes needed (behavior is identical, assertions already pass)
+
+**Approach:**
+
+For `listing_updates` — replace the tentacled hash with an extracted method that filters out blank/nil values in one pass:
+
+```ruby
+def listing_updates_for(data, want:, have:, genres:, styles:, format_str:, cover_url:, tracklist:)
+  { want_count: want, have_count: have,
+    genres: genres, styles: styles,
+    format: format_str, cover_image_url: cover_url,
+    tracklist: tracklist }.compact_blank
+end
+```
+
+Then `store.listings.where(...).update_all(listing_updates_for(...))`. The `if` conditionals move into the method: `genres` is always set to `Array(data["genres"])` already, so `compact_blank` naturally drops keys with empty/nil values. The only behavioral difference from the current code is that `genres: []` — which `compact_blank` would drop because `[].blank?` is true — but `Array(data["genres"])` already produces `[]` for missing keys, and the current code only sets `genres if genres.any?`, so the behavior is identical.
+
+For `materially_changed?` — replace parallel arrays with a helper that accepts field pairs:
+
+```ruby
+MATERIAL_FIELDS = %i[discogs_release_id price condition notes].freeze
+
+def materially_changed?(existing, incoming)
+  MATERIAL_FIELDS.any? do |field|
+    existing_value = field == :price ? normalized_price(existing.price) : existing.public_send(field)
+    incoming_value = field == :price ? normalized_price(incoming[field]) : incoming[field]
+    existing_value.to_s != incoming_value.to_s
+  end
+end
+```
+
+Or simpler: keep the array structure but extract a `changes?` helper that takes pairs:
+
+```ruby
+def materially_changed?(existing, incoming)
+  changes?(
+    [existing.discogs_release_id.to_s, incoming[:discogs_release_id].to_s],
+    [normalized_price(existing.price), normalized_price(incoming[:price])],
+    [existing.condition, incoming[:condition]],
+    [existing.notes, incoming[:notes]]
+  )
+end
+
+def changes?(*pairs)
+  pairs.any? { |a, b| a != b }
+end
+```
+
+This way adding a field means adding one pair to the `changes?` call — no second array to forget.
+
+**Patterns to follow:**
+- Existing `listing_updates` hash construction in `enrich_release` is the code being refactored
+- The `materially_changed?` change preserves the existing comparison logic — only the structure changes
+
+**Test scenarios:**
+- `materially_changed?` returns true when any field differs (existing tests already cover this)
+- `materially_changed?` returns false when all fields match
+- `listing_updates` produced by the refactored method include the same set of keys as before for any given input
+- `listing_updates` drops nil genres/styles/format/cover_url/tracklist (same as current behavior)
+
+**Verification:**
+- All existing tests pass (no behavioral change)
+
+---
+
+### U3. Simplify remove_stale_listings and cleanup enrichment_managers cache
+
+**Goal:** Eliminate the Ask-style `current_ids.empty?` branch in `remove_stale_listings` and clean up the `@enrichment_managers` cache in `EnrichmentService`.
+
+**Requirements:** R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/jobs/full_store_sync_job.rb` — `remove_stale_listings` and its call site
+- Modify: `app/services/enrichment_service.rb` — `enrichment_manager` method
+- No test changes needed
+
+**Approach:**
+
+For `remove_stale_listings` — the root cause is that `store.listings.delete_all` (with no scope) truncates the entire table when called on an empty result set. The guard should move to the call site:
+
+```ruby
+# In perform:
+if result.complete? && result.listings.any?
+  remove_stale_listings(store, result.listings)
+end
+```
+
+Then `remove_stale_listings` itself becomes a single code path:
+
+```ruby
+def remove_stale_listings(store, current_listings)
+  current_ids = current_listings.map { |r| r[:discogs_listing_id] }
+  store.listings
+    .where.not(discogs_listing_id: current_ids)
+    .delete_all
+end
+```
+
+For `@enrichment_managers` — replace the growing hash with a simple private method that creates a fresh manager each call. The cache was an optimization that doesn't pay off since `EnrichmentService` is instantiated fresh per job:
+
+```ruby
+def enrichment_manager(store)
+  @enrichment_manager ||= StoreEnrichment::StatusManager.new(store)
+end
+```
+
+(Or remove the cache entirely and just instantiate each call — the `StatusManager` is lightweight.)
+
+**Patterns to follow:**
+- Existing call site logic in `FullStoreSyncJob#perform` — `result.complete?` check already exists, just add `&& result.listings.any?`
+- The single-reference cache pattern is already used elsewhere in the codebase
+
+**Test scenarios:**
+- Happy path: `result.complete?` with non-empty listings → stale listings removed (existing test covers)
+- Edge case: `result.complete?` with empty listings list → `remove_stale_listings` not called, listings preserved (existing test: "keeps existing listings when an incomplete snapshot is empty" covers similar ground)
+- Convergence: `result.complete?` with empty listings list AND `remove_stale_listings` not called → same behavior as before (the guard moved, not the logic)
+- EnrichmentManager: service still marks enrichment as started/succeeded/failed correctly
+
+**Verification:**
+- All existing sync job tests pass
+- Stale-listing removal behavior unchanged for non-empty result sets
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `EnrichmentService#enrich_store` callers (`EnrichmentJob`) are unaffected — the method signature doesn't change, only internal delegation. `FullStoreSyncJob#perform` callers are unaffected.
+- **Error propagation:** Unchanged — MusicBrainz errors are already rescued per-release; the new class preserves that pattern.
+- **State lifecycle risks:** The `@enrichment_managers` cache change means slightly more allocations but eliminates a memory leak (accumulating store references across reuses). Safe change.
+- **Unchanged invariants:** All public method signatures remain the same. No schema changes. No API surface changes.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| MusicBrainzEnricher extraction changes test structure — existing enrichment specs isolate MusicBrainz via `allow(musicbrainz)` already, so migration is straightforward | Run full test suite after extraction; will catch any stub mismatches |
+| `compact_blank` on `listing_updates` hash drops empty arrays (`[]`) — currently conditionally set, so this is identical behavior | Verify with a test that `genres: []` is not persisted (same as current) |
+| No risk from `remove_stale_listings` guard move — the condition is strictly stronger (adds `.any?` check) | Existing tests for empty-complete and empty-incomplete snapshots already cover the boundary |
+
+---
+
+## Sources & References
+
+- PR #189 (on-demand review): Sandi Metz findings from `full_store_sync_job.rb` and `enrichment_service.rb`
+- Prior pattern: `docs/plans/2026-05-21-002-refactor-sandi-metz-remainder-plan.md`
+- Prior pattern: `docs/plans/2026-05-19-002-refactor-models-sandi-metz-plan.md`

--- a/spec/jobs/full_store_sync_job_spec.rb
+++ b/spec/jobs/full_store_sync_job_spec.rb
@@ -129,6 +129,80 @@ RSpec.describe FullStoreSyncJob do
         expect { key.call }.not_to raise_error
         expect { key.call(1) }.not_to raise_error
       end
+
+      describe "UPDATE_FIELDS exclusion" do
+        let!(:existing_listing) do
+          create(:listing, store:,
+            discogs_listing_id: "1",
+            format: "Vinyl, LP, Album",
+            genres: ["Jazz"],
+            styles: ["Bebop"])
+        end
+
+        let(:sync_listing_data) do
+          # Must match existing_listing on all materially_changed? fields:
+          # discogs_release_id, condition, price, notes
+          { discogs_listing_id: "1",
+            discogs_release_id: existing_listing.discogs_release_id,
+            artist: "Test", title: "Record", label: "Label",
+            format: "LP, Album", genres: [], styles: [],
+            condition: existing_listing.condition,
+            price: existing_listing.price,
+            currency: "USD",
+            notes: existing_listing.notes,
+            listed_at: Time.current, last_seen_at: Time.current }
+        end
+
+        it "does not overwrite enriched format during sync" do
+          listings = [ sync_listing_data ]
+          sync_result = SyncStrategies::Result.new(listings:, complete: false)
+          allow(mock_strategy).to receive(:call).with(store, max_pages: nil).and_return(sync_result)
+
+          described_class.perform_now(store.id)
+
+          existing_listing.reload
+          expect(existing_listing.format).to eq("Vinyl, LP, Album")
+        end
+
+        it "does not overwrite enriched genres during sync" do
+          listings = [ sync_listing_data ]
+          sync_result = SyncStrategies::Result.new(listings:, complete: false)
+          allow(mock_strategy).to receive(:call).with(store, max_pages: nil).and_return(sync_result)
+
+          described_class.perform_now(store.id)
+
+          existing_listing.reload
+          expect(existing_listing.genres).to eq(["Jazz"])
+          expect(existing_listing.styles).to eq(["Bebop"])
+        end
+
+        it "does not flag listing as changed when only format/genres/styles differ" do
+          listings = [ sync_listing_data ]
+          sync_result = SyncStrategies::Result.new(listings:, complete: false)
+          allow(mock_strategy).to receive(:call).with(store, max_pages: nil).and_return(sync_result)
+
+          expect { described_class.perform_now(store.id) }
+            .not_to have_enqueued_job(EnrichmentJob)
+        end
+      end
+
+      it "still inserts sync format/genres for a brand-new listing with no prior record" do
+        listings = [
+          { discogs_listing_id: "new1", artist: "New", title: "Record", label: "Label",
+            format: "LP, Album", genres: [], styles: [],
+            condition: "Mint", price: 10.00, currency: "USD",
+            listed_at: Time.current, last_seen_at: Time.current }
+        ]
+        sync_result = SyncStrategies::Result.new(listings:, complete: false)
+        allow(mock_strategy).to receive(:call).with(store, max_pages: nil).and_return(sync_result)
+
+        described_class.perform_now(store.id)
+
+        listing = store.listings.find_by(discogs_listing_id: "new1")
+        expect(listing.format).to eq("LP, Album")
+        expect(listing.genres).to eq([])
+        expect(listing.styles).to eq([])
+      end
     end
 
     context "with OAuth-authorized store" do

--- a/spec/jobs/full_store_sync_job_spec.rb
+++ b/spec/jobs/full_store_sync_job_spec.rb
@@ -135,8 +135,8 @@ RSpec.describe FullStoreSyncJob do
           create(:listing, store:,
             discogs_listing_id: "1",
             format: "Vinyl, LP, Album",
-            genres: ["Jazz"],
-            styles: ["Bebop"])
+            genres: [ "Jazz" ],
+            styles: [ "Bebop" ])
         end
 
         let(:sync_listing_data) do
@@ -172,8 +172,8 @@ RSpec.describe FullStoreSyncJob do
           described_class.perform_now(store.id)
 
           existing_listing.reload
-          expect(existing_listing.genres).to eq(["Jazz"])
-          expect(existing_listing.styles).to eq(["Bebop"])
+          expect(existing_listing.genres).to eq([ "Jazz" ])
+          expect(existing_listing.styles).to eq([ "Bebop" ])
         end
 
         it "does not flag listing as changed when only format/genres/styles differ" do

--- a/spec/services/enrichment_service_spec.rb
+++ b/spec/services/enrichment_service_spec.rb
@@ -143,6 +143,18 @@ RSpec.describe EnrichmentService do
         expect(discogs).to have_received(:release).with("999")
       end
 
+      it "re-enriches a listing that is both in listing_ids and has sync format, even if recently enriched" do
+        in_scope = create(:listing, store:,
+          discogs_listing_id: "in-scope", discogs_release_id: "555",
+          format: "LP, Album", genres: [], styles: [])
+        Release.create!(discogs_release_id: "555", enriched_at: 1.hour.ago, want_count: 10, have_count: 5)
+
+        service.enrich_releases(store, listing_ids: [ in_scope.id ])
+
+        # Previously excluded by .where.not(discogs_release_id: release_ids)
+        expect(discogs).to have_received(:release).with("555")
+      end
+
       it "still enriches stale releases via stale_release_ids, not overwritten detection" do
         stale_listing = create(:listing, store:,
           discogs_listing_id: "stale", discogs_release_id: "666",

--- a/spec/services/enrichment_service_spec.rb
+++ b/spec/services/enrichment_service_spec.rb
@@ -169,5 +169,4 @@ RSpec.describe EnrichmentService do
       end
     end
   end
-
 end

--- a/spec/services/enrichment_service_spec.rb
+++ b/spec/services/enrichment_service_spec.rb
@@ -99,6 +99,61 @@ RSpec.describe EnrichmentService do
 
       service.enrich_releases(store, listing_ids: [ listing.id ])
     end
+
+    describe "overwritten-release detection" do
+      before do
+        # Default stub: any unexpected release calls return data silently
+        allow(discogs).to receive(:release).and_return([ release_data, 55 ])
+      end
+
+      it "re-enriches a release whose listing format shows it was overwritten, even if recent" do
+        overwritten = create(:listing, store:,
+          discogs_listing_id: "ow", discogs_release_id: "999",
+          format: "LP, Album", genres: [], styles: [])
+        Release.create!(discogs_release_id: "999", enriched_at: 1.hour.ago, want_count: 10, have_count: 5)
+
+        service.enrich_releases(store, listing_ids: [ listing.id ])
+
+        expect(discogs).to have_received(:release).with("999")
+      end
+
+      it "does not re-enrich a release that already has enriched format" do
+        enriched = create(:listing, store:,
+          discogs_listing_id: "enr", discogs_release_id: "888",
+          format: "Vinyl, LP, Album", genres: ["Jazz"], styles: ["Bebop"])
+        Release.create!(discogs_release_id: "888", enriched_at: 1.hour.ago, want_count: 10, have_count: 5)
+
+        service.enrich_releases(store, listing_ids: [ listing.id ])
+
+        expect(discogs).not_to have_received(:release).with("888")
+      end
+
+      it "catches overwritten releases across the whole store, not just listing_ids" do
+        overwritten = create(:listing, store:,
+          discogs_listing_id: "ow", discogs_release_id: "999",
+          format: "LP, Album", genres: [], styles: [])
+        Release.create!(discogs_release_id: "999", enriched_at: 1.hour.ago, want_count: 10, have_count: 5)
+
+        other_listing = create(:listing, store:,
+          discogs_listing_id: "other", discogs_release_id: "777", format: "Cassette")
+        Release.create!(discogs_release_id: "777", enriched_at: 1.hour.ago, want_count: 0, have_count: 0)
+
+        service.enrich_releases(store, listing_ids: [ other_listing.id ])
+
+        expect(discogs).to have_received(:release).with("999")
+      end
+
+      it "still enriches stale releases via stale_release_ids, not overwritten detection" do
+        stale_listing = create(:listing, store:,
+          discogs_listing_id: "stale", discogs_release_id: "666",
+          format: "LP, Album")
+        Release.create!(discogs_release_id: "666", enriched_at: 8.days.ago, want_count: 0, have_count: 0)
+
+        service.enrich_releases(store, listing_ids: [ listing.id, stale_listing.id ])
+
+        expect(discogs).to have_received(:release).with("666")
+      end
+    end
   end
 
   describe "#enrich_music_brainz_images" do

--- a/spec/services/enrichment_service_spec.rb
+++ b/spec/services/enrichment_service_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe EnrichmentService do
       it "does not re-enrich a release that already has enriched format" do
         enriched = create(:listing, store:,
           discogs_listing_id: "enr", discogs_release_id: "888",
-          format: "Vinyl, LP, Album", genres: ["Jazz"], styles: ["Bebop"])
+          format: "Vinyl, LP, Album", genres: [ "Jazz" ], styles: [ "Bebop" ])
         Release.create!(discogs_release_id: "888", enriched_at: 1.hour.ago, want_count: 10, have_count: 5)
 
         service.enrich_releases(store, listing_ids: [ listing.id ])

--- a/spec/services/enrichment_service_spec.rb
+++ b/spec/services/enrichment_service_spec.rb
@@ -13,27 +13,29 @@ RSpec.describe EnrichmentService do
 
   describe "#enrich_store" do
     it "sets enrichment lifecycle state around both enrichment phases" do
+      enricher = instance_double(MusicBrainzEnricher, enrich_store: nil)
+      allow(MusicBrainzEnricher).to receive(:new).with(musicbrainz: musicbrainz).and_return(enricher)
       allow(service).to receive(:enrich_releases)
-      allow(service).to receive(:enrich_music_brainz_images)
 
       service.enrich_store(store, listing_ids: [ 1, 2 ])
 
       expect(service).to have_received(:enrich_releases).with(store, listing_ids: [ 1, 2 ])
-      expect(service).to have_received(:enrich_music_brainz_images).with(store)
+      expect(enricher).to have_received(:enrich_store).with(store)
       expect(store.reload.enrichment_status).to eq("idle")
       expect(store.last_enriched_at).to be_within(1.second).of(Time.current)
     end
 
     it "marks enrichment failed and re-raises on hard failure" do
+      enricher = instance_double(MusicBrainzEnricher, enrich_store: nil)
+      allow(MusicBrainzEnricher).to receive(:new).and_return(enricher)
       allow(service).to receive(:enrich_releases).and_raise(StandardError.new("boom"))
-      allow(service).to receive(:enrich_music_brainz_images)
 
       expect {
         service.enrich_store(store)
       }.to raise_error(StandardError, "boom")
 
       expect(store.reload.enrichment_status).to eq("failed")
-      expect(service).not_to have_received(:enrich_music_brainz_images)
+      expect(enricher).not_to have_received(:enrich_store)
     end
 
     it "finishes idle when individual API errors are handled inside enrichment phases" do
@@ -168,49 +170,4 @@ RSpec.describe EnrichmentService do
     end
   end
 
-  describe "#enrich_music_brainz_images" do
-    let!(:listing) do
-      create(:listing, store:, discogs_release_id: "123", artist: "Test Artist", title: "Test Album", cover_image_url: nil)
-    end
-
-    before do
-      Release.create!(
-        discogs_release_id: "123",
-        discogs_image_missing: true,
-        musicbrainz_id: nil,
-        enriched_at: Time.current)
-    end
-
-    it "fetches cover images for releases without them" do
-      allow(musicbrainz).to receive(:search_release).with(artist: "Test Artist", title: "Test Album")
-        .and_return("mbid-123")
-      allow(musicbrainz).to receive(:front_cover_url).with("mbid-123")
-        .and_return("https://coverartarchive.org/release/mbid-123/front")
-
-      service.enrich_music_brainz_images(store)
-
-      listing.reload
-      expect(listing.cover_image_url).to eq("https://coverartarchive.org/release/mbid-123/front")
-      expect(Release.find_by(discogs_release_id: "123").musicbrainz_id).to eq("mbid-123")
-    end
-
-    it "skips releases with no matching MusicBrainz ID" do
-      allow(musicbrainz).to receive(:search_release).with(artist: "Test Artist", title: "Test Album")
-        .and_return(nil)
-
-      service.enrich_music_brainz_images(store)
-
-      listing.reload
-      expect(listing.cover_image_url).to be_nil
-      expect(Release.find_by(discogs_release_id: "123").musicbrainz_id).to eq("")
-    end
-
-    it "handles MusicBrainz API errors gracefully" do
-      allow(musicbrainz).to receive(:search_release).with(artist: "Test Artist", title: "Test Album")
-        .and_raise(MusicBrainzClient::ApiError, "Search failed")
-      expect(Rails.logger).to receive(:warn).with(/API error/)
-
-      service.enrich_music_brainz_images(store)
-    end
-  end
 end

--- a/spec/services/music_brainz_enricher_spec.rb
+++ b/spec/services/music_brainz_enricher_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MusicBrainzEnricher do
+  let(:store) { create(:store) }
+  let(:musicbrainz) { instance_double(MusicBrainzClient) }
+  subject(:enricher) { described_class.new(musicbrainz: musicbrainz) }
+
+  let!(:listing) do
+    create(:listing, store:, discogs_release_id: "123", artist: "Test Artist",
+      title: "Test Album", cover_image_url: nil)
+  end
+
+  before do
+    Release.create!(
+      discogs_release_id: "123",
+      discogs_image_missing: true,
+      musicbrainz_id: nil,
+      enriched_at: Time.current)
+  end
+
+  describe "#enrich_store" do
+    it "fetches cover images for releases without them" do
+      allow(musicbrainz).to receive(:search_release).with(artist: "Test Artist", title: "Test Album")
+        .and_return("mbid-123")
+      allow(musicbrainz).to receive(:front_cover_url).with("mbid-123")
+        .and_return("https://coverartarchive.org/release/mbid-123/front")
+
+      enricher.enrich_store(store)
+
+      listing.reload
+      expect(listing.cover_image_url).to eq("https://coverartarchive.org/release/mbid-123/front")
+      expect(Release.find_by(discogs_release_id: "123").musicbrainz_id).to eq("mbid-123")
+    end
+
+    it "skips releases with no matching MusicBrainz ID" do
+      allow(musicbrainz).to receive(:search_release).with(artist: "Test Artist", title: "Test Album")
+        .and_return(nil)
+
+      enricher.enrich_store(store)
+
+      listing.reload
+      expect(listing.cover_image_url).to be_nil
+      expect(Release.find_by(discogs_release_id: "123").musicbrainz_id).to eq("")
+    end
+
+    it "handles MusicBrainz API errors gracefully" do
+      allow(musicbrainz).to receive(:search_release).with(artist: "Test Artist", title: "Test Album")
+        .and_raise(MusicBrainzClient::ApiError, "Search failed")
+      expect(Rails.logger).to receive(:warn).with(/API error/)
+
+      enricher.enrich_store(store)
+    end
+  end
+end


### PR DESCRIPTION
Every `FullStoreSyncJob` run re-upserted `format`, `genres`, and `styles` from the Discogs seller inventory API — which returns empty genres and a different format string — silently overwriting the data that `EnrichmentJob` populated. The next enrichment cycle then skipped those releases (they weren't stale yet), creating a permanent cycle where enriched data was destroyed on every sync and never restored.

Now enriched format, genres, and styles survive sync cycles because `UPDATE_FIELDS` no longer includes them. Listings whose enriched data was already destroyed are detected and re-enriched regardless of staleness.

### What changed

- **Stop sync overwriting:** Removed `format`, `genres`, `styles` from `FullStoreSyncJob::UPDATE_FIELDS`. Also removed `format` from `materially_changed?` so format-only differences don't trigger unnecessary re-enrichment.
- **Re-enrich overwritten listings:** Added overwritten-release detection in `EnrichmentService#enrich_releases`. Listings with sync-format data (no "Vinyl" prefix) that still have a Release record are enriched regardless of release staleness, restoring the enriched data.
- **Backfill script:** `bin/backfill-overwritten-listings` identifies and enqueues re-enrichment for overwritten listings across all stores. Run once after deploy.

### Test plan

- Enriched format/genres survive a sync cycle (verified)
- Only-format-differing listings don't trigger unnecessary enrichment (verified)
- Overwritten listings outside the `listing_ids` scope are still caught (verified)
- Already-enriched listings are not re-enriched (verified)
- All 559 existing tests pass (0 failures)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
