### PR TITLE
feat(home): rebuild buyer-led storefront lobby

### DIFF
--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -14,7 +14,7 @@ import {
   type RiffleDirection,
 } from "../lib/riffle_navigation"
 import { useViewport } from "@/hooks/use_viewport"
-import { SCALE_PRESS, springPress, springTactile, transitionCrate, transitionCrateDesktop, reducedMotionTransition } from "@/lib/motion_tokens"
+import { SCALE_PRESS, springPress, transitionCrate, transitionCrateDesktop, reducedMotionTransition } from "@/lib/motion_tokens"
 import { useReducedMotionContext } from "./storefront_motion_config"
 import { isLessonEligible, markLessonLearned, isLessonLearned } from "../lib/first_swipe_lesson"
 import { usePreload } from "@/hooks/use_preload"
@@ -429,7 +429,7 @@ export default function CrateView({ crates, activeSlug, startIndex = 0, hideTabs
         {/* Desktop details panel */}
         {activeRecord && (
           <div className="hidden md:flex md:flex-col md:pt-7">
-            <RecordDetails listing={activeRecord} direction={direction.current} isCompact={isCompact} />
+            <RecordDetails listing={activeRecord} direction={direction.current} />
           <ScoreBreakdown listing={activeRecord} />
           </div>
         )}

--- a/app/frontend/components/home_storefront_lobby.test.tsx
+++ b/app/frontend/components/home_storefront_lobby.test.tsx
@@ -1,0 +1,112 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import StorefrontMotionConfig from "@/components/storefront_motion_config"
+import HomeStorefrontLobby from "./home_storefront_lobby"
+import type { HomepagePreview, Listing } from "@/types/inertia"
+
+vi.mock("@inertiajs/react", () => ({
+  Link: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}))
+
+const copy = {
+  headline: "Browse a Discogs seller like a record store.",
+  subhead:
+    "Milkcrate turns a seller's Discogs inventory into crates, picks, and bins made for digging.",
+  cta_demo: "Visit the demo store",
+  cta_apply: "Request a storefront",
+  footnote: "Discogs stays the source of inventory and checkout.",
+  preview_label: "Storefront lobby",
+  fallback_title: "Start with the demo store.",
+  fallback_body:
+    "Open Philadelphia Music to see crates, picks, bins, and the Discogs checkout path in context.",
+}
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+  return {
+    id: 1,
+    discogs_listing_id: "abc",
+    artist: "Artist",
+    title: "Record",
+    label: null,
+    year: null,
+    format: null,
+    genres: [],
+    styles: [],
+    condition: null,
+    price: "10.00",
+    currency: "USD",
+    cover_image_url: "/covers/record.jpg",
+    thumbnail_url: null,
+    notes: null,
+    discogs_url: "https://www.discogs.com/sell/item/1",
+    ...overrides,
+  }
+}
+
+function makePreview(overrides: Partial<HomepagePreview> = {}): HomepagePreview {
+  return {
+    store_name: "Philadelphia Music",
+    store_slug: "philadelphiamusic",
+    sections: [],
+    ...overrides,
+  }
+}
+
+function renderLobby(preview: HomepagePreview) {
+  return render(
+    <StorefrontMotionConfig>
+      <HomeStorefrontLobby copy={copy} preview={preview} />
+    </StorefrontMotionConfig>
+  )
+}
+
+describe("HomeStorefrontLobby", () => {
+  it("renders the buyer-led heading and both routes", () => {
+    renderLobby(makePreview())
+
+    expect(screen.getByRole("heading", { level: 1, name: copy.headline })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: copy.cta_demo })).toHaveAttribute("href", "/philadelphiamusic")
+    expect(screen.getByRole("link", { name: copy.cta_apply })).toHaveAttribute("href", "/apply")
+  })
+
+  it("uses the preview store slug for the demo CTA when present", () => {
+    renderLobby(makePreview({ store_slug: "demo-records" }))
+
+    expect(screen.getByRole("link", { name: copy.cta_demo })).toHaveAttribute("href", "/demo-records")
+    expect(screen.getByRole("link", { name: /Open the demo storefront/i })).toHaveAttribute("href", "/demo-records")
+  })
+
+  it("renders picks-wall crate proof when preview data is present", () => {
+    renderLobby(makePreview({
+      sections: [
+        {
+          key: "picks_wall",
+          crate: {
+            slug: "picks",
+            name: "Milkcrate Picks",
+            count: 2,
+            records: [
+              makeListing({ id: 1 }),
+              makeListing({ id: 2, discogs_listing_id: "def", title: "Second Record" }),
+            ],
+          },
+        },
+      ],
+    }))
+
+    expect(screen.getByText(copy.preview_label)).toBeInTheDocument()
+    expect(screen.getByText("Milkcrate Picks")).toBeInTheDocument()
+    expect(screen.getByText("2 records")).toBeInTheDocument()
+  })
+
+  it("renders an intentional fallback when preview data is empty", () => {
+    renderLobby(makePreview({ store_slug: null, sections: [] }))
+
+    expect(screen.getByText(copy.fallback_title)).toBeInTheDocument()
+    expect(screen.getByText(copy.fallback_body)).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /Open the demo storefront/i })).toHaveAttribute("href", "/philadelphiamusic")
+  })
+})

--- a/app/frontend/components/home_storefront_lobby.tsx
+++ b/app/frontend/components/home_storefront_lobby.tsx
@@ -1,0 +1,131 @@
+import { Link } from "@inertiajs/react"
+import CrateShelf from "@/components/crate_shelf"
+import type { Crate, HomepagePreview, StorefrontSection } from "@/types/inertia"
+
+export interface HomeHeroCopy {
+  headline: string
+  subhead: string
+  cta_demo: string
+  cta_apply: string
+  footnote: string
+  preview_label: string
+  fallback_title: string
+  fallback_body: string
+}
+
+interface Props {
+  copy: HomeHeroCopy
+  preview: HomepagePreview
+}
+
+function demoHref(preview: HomepagePreview) {
+  return preview.store_slug ? `/${preview.store_slug}` : "/philadelphiamusic"
+}
+
+function picksCrateFrom(sections: StorefrontSection[]): Crate | undefined {
+  const picksSection = sections.find((section) => section.key === "picks_wall")
+  return picksSection?.key === "picks_wall" ? picksSection.crate : undefined
+}
+
+function recordCountLabel(count: number) {
+  return count === 1 ? "1 record" : `${count} records`
+}
+
+export default function HomeStorefrontLobby({ copy, preview }: Props) {
+  const href = demoHref(preview)
+  const picksCrate = picksCrateFrom(preview.sections)
+  const hasPicks = Boolean(picksCrate && picksCrate.records.length > 0)
+
+  return (
+    <section
+      aria-labelledby="home-headline"
+      className="pb-10 pt-3 sm:pb-14 sm:pt-6"
+    >
+      <div className="grid items-center gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(320px,1.1fr)] lg:gap-12">
+        <div className="max-w-xl">
+          <p className="mc-section-name mb-3 text-sm">Milkcrate</p>
+          <h1
+            id="home-headline"
+            className="max-w-lg text-3xl font-bold leading-tight mc-text sm:text-4xl"
+          >
+            {copy.headline}
+          </h1>
+          <p className="mt-4 max-w-lg text-base leading-relaxed text-mc-text-dim">
+            {copy.subhead}
+          </p>
+
+          <div className="mt-6 flex w-full flex-col gap-3 sm:max-w-md sm:flex-row">
+            <Link
+              href={href}
+              className="inline-flex min-h-11 items-center justify-center rounded-lg bg-mc-accent px-6 py-3 text-center text-sm font-semibold tracking-wide text-mc-on-accent transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+            >
+              {copy.cta_demo}
+            </Link>
+            <Link
+              href="/apply"
+              className="inline-flex min-h-11 items-center justify-center rounded-lg border border-mc-border px-6 py-3 text-center text-sm font-semibold tracking-wide mc-text transition-colors hover:border-mc-accent hover:text-mc-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+            >
+              {copy.cta_apply}
+            </Link>
+          </div>
+
+          <p className="mt-4 max-w-md text-xs leading-relaxed text-mc-text-dim">
+            {copy.footnote}
+          </p>
+        </div>
+
+        <aside
+          aria-labelledby="home-lobby-preview-heading"
+          className="rounded-lg border border-mc-border bg-mc-bg-raised p-3 sm:p-4"
+        >
+          <div className="mb-3 flex items-center justify-between gap-4 border-b border-mc-border pb-2">
+            <div>
+              <p
+                id="home-lobby-preview-heading"
+                className="mc-section-name text-sm"
+              >
+                {copy.preview_label}
+              </p>
+              <p className="mt-1 text-xs text-mc-text-dim">
+                {preview.store_name}
+              </p>
+            </div>
+            <span className="text-xs uppercase tracking-widest text-mc-text-dim">
+              Discogs
+            </span>
+          </div>
+
+          {hasPicks && picksCrate ? (
+            <CrateShelf
+              crate={picksCrate}
+              headerSize="featured"
+              previewCount={4}
+              meta={recordCountLabel(picksCrate.records.length)}
+            />
+          ) : (
+            <div className="rounded-lg border border-mc-border bg-mc-bg-card p-4">
+              <p className="text-sm font-semibold mc-text">
+                {copy.fallback_title}
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-mc-text-dim">
+                {copy.fallback_body}
+              </p>
+              <div className="mt-4 grid grid-cols-3 gap-2" aria-hidden="true">
+                <span className="h-16 rounded-sm border border-mc-border/70 bg-mc-bg-raised" />
+                <span className="h-16 rounded-sm border border-mc-border/70 bg-mc-bg-raised" />
+                <span className="h-16 rounded-sm border border-mc-border/70 bg-mc-bg-raised" />
+              </div>
+            </div>
+          )}
+
+          <Link
+            href={href}
+            className="mt-4 inline-flex rounded text-xs font-semibold uppercase tracking-widest text-mc-accent transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+          >
+            Open the demo storefront
+          </Link>
+        </aside>
+      </div>
+    </section>
+  )
+}

--- a/app/frontend/components/record_tile.tsx
+++ b/app/frontend/components/record_tile.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useReducedMotionContext } from "@/components/storefront_motion_config"
 import type { Listing } from "../types/inertia"
 

--- a/app/frontend/layouts/marketing_layout.tsx
+++ b/app/frontend/layouts/marketing_layout.tsx
@@ -26,13 +26,13 @@ export default function MarketingLayout({ children }: { children: React.ReactNod
             href="/philadelphiamusic"
             className="text-xs text-mc-text-dim hover:text-mc-text transition-colors rounded px-2 py-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
           >
-            Demo
+            Browse demo
           </Link>
           <Link
             href="/apply"
             className="text-xs text-mc-text-dim hover:text-mc-text transition-colors rounded px-2 py-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
           >
-            Apply
+            For sellers
           </Link>
           <button
             type="button"

--- a/app/frontend/pages/home.tsx
+++ b/app/frontend/pages/home.tsx
@@ -1,30 +1,45 @@
 import { Link } from "@inertiajs/react"
 import { motion } from "framer-motion"
 import type { Variants } from "framer-motion"
+import HomeStorefrontLobby from "@/components/home_storefront_lobby"
 import MarketingLayout from "@/layouts/marketing_layout"
-import CrateView from "@/components/crate_view"
-import { PileProvider } from "@/contexts/pile_context"
+import type { HomeHeroCopy } from "@/components/home_storefront_lobby"
 import type { HomepagePreview } from "@/types/inertia"
+
+interface LoopItemCopy {
+  title: string
+  body: string
+}
+
+interface StoreMomentCopy {
+  title: string
+  body: string
+}
 
 interface Props {
   copy: {
-    headline: string
-    subhead: string
-    cta_demo: string
-    cta_apply: string
-    footnote: string
-    steps: {
-      step1_title: string
-      step1_body: string
-      step2_title: string
-      step2_body: string
-      step3_title: string
-      step3_body: string
+    hero: HomeHeroCopy
+    marketplace_loop: {
+      title: string
+      items: LoopItemCopy[]
     }
-    preview_label: string
-    record_fair_title: string
-    record_fair_body: string
-    store_character_title: string
+    seller_path: {
+      title: string
+      body: string
+      cta: string
+    }
+    store_character: {
+      title: string
+      moments: StoreMomentCopy[]
+    }
+    record_fair: {
+      title: string
+      body: string
+    }
+    final_cta: {
+      body: string
+      cta: string
+    }
   }
   preview: HomepagePreview
 }
@@ -40,261 +55,118 @@ const fadeUp: Variants = {
   },
 }
 
-const fadeIn: Variants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { duration: 0.4, ease: easeOut },
-  },
-}
-
-const ctaBase =
-  "w-full sm:flex-1 sm:min-w-0 min-h-11 px-6 sm:px-4 py-3 rounded-lg font-semibold text-sm sm:text-xs leading-5 tracking-wide text-center whitespace-nowrap inline-flex items-center justify-center transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
-
 export default function Home({ copy, preview }: Props) {
-  const hasPreview = preview.sections.length > 0
-  const picksSection = preview.sections.find((section) => section.key === "picks_wall")
-  const picksCrate = picksSection?.key === "picks_wall" ? picksSection.crate : undefined
-
   return (
     <MarketingLayout>
-      {/* ── Hero — vendor-first ────────────────────── */}
-      <motion.section
-        initial="hidden"
-        animate="visible"
-        aria-labelledby="home-headline"
-        className="flex flex-col items-center text-center pt-4 pb-10 sm:pb-16"
-      >
-        <motion.h1
-          variants={fadeUp}
-          id="home-headline"
-          className="text-2xl sm:text-3xl font-bold mc-text mb-3 leading-tight max-w-md"
-        >
-          {copy.headline}
-        </motion.h1>
+      <HomeStorefrontLobby copy={copy.hero} preview={preview} />
 
-        <motion.p
-          variants={fadeUp}
-          className="text-sm sm:text-base text-mc-text-dim mb-10 leading-relaxed max-w-md"
-        >
-          {copy.subhead}
-        </motion.p>
-
-        <motion.div
-          variants={fadeUp}
-          className="flex flex-col sm:flex-row items-center gap-3 w-full max-w-md"
-        >
-          {hasPreview && preview.store_slug ? (
-            <Link
-              href={`/${preview.store_slug}`}
-              className={`${ctaBase} bg-mc-accent text-mc-on-accent hover:opacity-90`}
-            >
-              {copy.cta_demo}
-            </Link>
-          ) : (
-            <Link
-              href="/philadelphiamusic"
-              className={`${ctaBase} bg-mc-accent text-mc-on-accent hover:opacity-90`}
-            >
-              {copy.cta_demo}
-            </Link>
-          )}
-          <Link
-            href="/apply"
-            className={`${ctaBase} border border-mc-border mc-text hover:border-mc-accent hover:text-mc-accent`}
-          >
-            {copy.cta_apply}
-          </Link>
-        </motion.div>
-
-        <motion.p
-          variants={fadeUp}
-          className="mt-5 text-xs text-mc-text-dim"
-        >
-          {copy.footnote}
-        </motion.p>
-      </motion.section>
-
-      {/* ── Storefront Preview — curation proof ─────── */}
       <motion.section
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, margin: "-80px" }}
-        aria-labelledby="home-preview-heading"
-        className="border-t border-mc-border py-10 sm:py-16"
+        aria-labelledby="home-loop-heading"
+        className="border-t border-mc-border py-10 sm:py-14"
       >
-        <div className="max-w-md mx-auto text-center mb-6 sm:mb-8">
-          <span className="mc-section-name text-sm" id="home-preview-heading">
-            {copy.preview_label}
-          </span>
+        <div className="max-w-3xl">
+          <p className="mc-section-name mb-3 text-sm">Marketplace loop</p>
+          <motion.h2
+            variants={fadeUp}
+            id="home-loop-heading"
+            className="text-xl font-semibold leading-tight mc-text sm:text-2xl"
+          >
+            {copy.marketplace_loop.title}
+          </motion.h2>
         </div>
 
-        {picksCrate && picksCrate.records.length > 0 ? (
-          <>
-            <div className="max-w-4xl mx-auto">
-              <PileProvider>
-                <CrateView
-                  crates={[picksCrate]}
-                  activeSlug={picksCrate.slug}
-                  hideTabs
-                  onSelectCrate={() => {}}
-                />
-              </PileProvider>
-            </div>
-            <div className="flex justify-center mt-6">
-              {preview.store_slug ? (
-                <Link
-                  href={`/${preview.store_slug}`}
-                  className="text-xs font-semibold uppercase tracking-widest text-mc-accent hover:opacity-80 transition-opacity"
-                >
-                  See the full store →
-                </Link>
-              ) : (
-                <Link
-                  href="/philadelphiamusic"
-                  className="text-xs font-semibold uppercase tracking-widest text-mc-accent hover:opacity-80 transition-opacity"
-                >
-                  See the full store →
-                </Link>
-              )}
-            </div>
-          </>
-        ) : (
-          <div className="text-center max-w-md mx-auto">
-            <p className="text-sm text-mc-text-dim mb-4">
-              We&apos;ll show the full Milkcrate experience in the demo store. Start with a
-              curated picks crate.
-            </p>
-            <Link
-              href="/philadelphiamusic"
-              className="text-sm font-semibold uppercase tracking-widest text-mc-accent hover:opacity-80 transition-opacity"
+        <div className="mt-8 grid gap-6 md:grid-cols-3">
+          {copy.marketplace_loop.items.map((item) => (
+            <motion.article
+              key={item.title}
+              variants={fadeUp}
+              className="border-t border-mc-border pt-4"
             >
-              Philadelphia Music →
-            </Link>
-          </div>
-        )}
+              <h3 className="text-sm font-semibold mc-text">
+                {item.title}
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-mc-text-dim">
+                {item.body}
+              </p>
+            </motion.article>
+          ))}
+        </div>
       </motion.section>
 
-      {/* ── Store Character — product-real concepts ── */}
+      <motion.section
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, margin: "-80px" }}
+        aria-labelledby="home-seller-heading"
+        className="border-t border-mc-border py-10 sm:py-14"
+      >
+        <div className="grid gap-6 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+          <div className="max-w-2xl">
+            <p className="mc-section-name mb-3 text-sm">For sellers</p>
+            <motion.h2
+              variants={fadeUp}
+              id="home-seller-heading"
+              className="text-xl font-semibold leading-tight mc-text sm:text-2xl"
+            >
+              {copy.seller_path.title}
+            </motion.h2>
+            <motion.p
+              variants={fadeUp}
+              className="mt-3 text-sm leading-relaxed text-mc-text-dim"
+            >
+              {copy.seller_path.body}
+            </motion.p>
+          </div>
+          <motion.div variants={fadeUp}>
+            <Link
+              href="/apply"
+              className="inline-flex min-h-11 items-center justify-center rounded-lg bg-mc-accent px-6 py-3 text-sm font-semibold tracking-wide text-mc-on-accent transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+            >
+              {copy.seller_path.cta}
+            </Link>
+          </motion.div>
+        </div>
+      </motion.section>
+
       <motion.section
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, margin: "-80px" }}
         aria-labelledby="home-character-heading"
-        className="border-t border-mc-border py-10 sm:py-16"
+        className="border-t border-mc-border py-10 sm:py-14"
       >
-        <motion.h2
-          variants={fadeUp}
-          id="home-character-heading"
-          className="text-lg sm:text-xl font-semibold mc-text text-center mb-10"
-        >
-          {copy.store_character_title}
-        </motion.h2>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-4xl mx-auto">
-          <motion.div
-            variants={fadeIn}
-            className="flex flex-col items-center text-center gap-3 p-4 rounded-xl bg-mc-bg-raised border border-mc-border"
+        <div className="max-w-3xl">
+          <p className="mc-section-name mb-3 text-sm">Store character</p>
+          <motion.h2
+            variants={fadeUp}
+            id="home-character-heading"
+            className="text-xl font-semibold leading-tight mc-text sm:text-2xl"
           >
-            <h3 className="text-sm font-semibold mc-text">Milkcrate Picks</h3>
-            <p className="text-xs text-mc-text-dim leading-relaxed">
-              Our digger algorithm surfaces the most interesting records in your inventory —
-              refreshed daily.
-            </p>
-          </motion.div>
+            {copy.store_character.title}
+          </motion.h2>
+        </div>
 
-          <motion.div
-            variants={fadeIn}
-            className="flex flex-col items-center text-center gap-3 p-4 rounded-xl bg-mc-bg-raised border border-mc-border"
-          >
-            <h3 className="text-sm font-semibold mc-text">Featured Crates</h3>
-            <p className="text-xs text-mc-text-dim leading-relaxed">
-              We shape a front-of-store view that highlights strong entry points for browsing.
-            </p>
-          </motion.div>
-
-          <motion.div
-            variants={fadeIn}
-            className="flex flex-col items-center text-center gap-3 p-4 rounded-xl bg-mc-bg-raised border border-mc-border"
-          >
-            <h3 className="text-sm font-semibold mc-text">Genre Bins</h3>
-            <p className="text-xs text-mc-text-dim leading-relaxed">
-              Records organized by genre, just like a real shop — jazz, soul, electronic,
-              hip-hop, and more.
-            </p>
-          </motion.div>
-
-          <motion.div
-            variants={fadeIn}
-            className="flex flex-col items-center text-center gap-3 p-4 rounded-xl bg-mc-bg-raised border border-mc-border"
-          >
-            <h3 className="text-sm font-semibold mc-text">Build Your Pile</h3>
-            <p className="text-xs text-mc-text-dim leading-relaxed">
-              Customers can collect records in a pile while they browse and compare finds.
-            </p>
-          </motion.div>
+        <div className="mt-8 grid gap-x-6 gap-y-7 sm:grid-cols-2 lg:grid-cols-5">
+          {copy.store_character.moments.map((moment) => (
+            <motion.article
+              key={moment.title}
+              variants={fadeUp}
+              className="border-t border-mc-border pt-4"
+            >
+              <h3 className="text-sm font-semibold mc-text">
+                {moment.title}
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-mc-text-dim">
+                {moment.body}
+              </p>
+            </motion.article>
+          ))}
         </div>
       </motion.section>
 
-      {/* ── Onboarding Steps — how it works ────────── */}
-      <motion.section
-        initial="hidden"
-        whileInView="visible"
-        viewport={{ once: true, margin: "-80px" }}
-        aria-labelledby="home-steps-heading"
-        className="border-t border-mc-border py-10 sm:py-16"
-      >
-        <div className="max-w-4xl mx-auto">
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 sm:gap-10">
-            <motion.div
-              variants={fadeUp}
-              className="flex flex-col items-center text-center gap-3"
-            >
-              <div className="w-10 h-10 rounded-full bg-mc-accent text-mc-on-accent flex items-center justify-center font-bold text-sm">
-                1
-              </div>
-              <h3 className="text-sm font-semibold mc-text">
-                {copy.steps.step1_title}
-              </h3>
-              <p className="text-xs text-mc-text-dim leading-relaxed max-w-[220px]">
-                {copy.steps.step1_body}
-              </p>
-            </motion.div>
-
-            <motion.div
-              variants={fadeUp}
-              className="flex flex-col items-center text-center gap-3"
-            >
-              <div className="w-10 h-10 rounded-full bg-mc-accent text-mc-on-accent flex items-center justify-center font-bold text-sm">
-                2
-              </div>
-              <h3 className="text-sm font-semibold mc-text">
-                {copy.steps.step2_title}
-              </h3>
-              <p className="text-xs text-mc-text-dim leading-relaxed max-w-[220px]">
-                {copy.steps.step2_body}
-              </p>
-            </motion.div>
-
-            <motion.div
-              variants={fadeUp}
-              className="flex flex-col items-center text-center gap-3"
-            >
-              <div className="w-10 h-10 rounded-full bg-mc-accent text-mc-on-accent flex items-center justify-center font-bold text-sm">
-                3
-              </div>
-              <h3 className="text-sm font-semibold mc-text">
-                {copy.steps.step3_title}
-              </h3>
-              <p className="text-xs text-mc-text-dim leading-relaxed max-w-[220px]">
-                {copy.steps.step3_body}
-              </p>
-            </motion.div>
-          </div>
-        </div>
-      </motion.section>
-
-      {/* ── Record-Fair Callout ────────────────────── */}
       <motion.section
         initial="hidden"
         whileInView="visible"
@@ -302,44 +174,43 @@ export default function Home({ copy, preview }: Props) {
         aria-labelledby="home-fair-heading"
         className="border-t border-mc-border py-10 sm:py-14"
       >
-        <div className="max-w-lg mx-auto text-center">
+        <div className="max-w-2xl">
+          <p className="mc-section-name mb-3 text-sm">Record fairs</p>
           <motion.h2
             variants={fadeUp}
             id="home-fair-heading"
-            className="text-base sm:text-lg font-semibold mc-text mb-3"
+            className="text-xl font-semibold leading-tight mc-text sm:text-2xl"
           >
-            {copy.record_fair_title}
+            {copy.record_fair.title}
           </motion.h2>
           <motion.p
             variants={fadeUp}
-            className="text-sm text-mc-text-dim leading-relaxed mb-4"
+            className="mt-3 text-sm leading-relaxed text-mc-text-dim"
           >
-            {copy.record_fair_body}
+            {copy.record_fair.body}
           </motion.p>
         </div>
       </motion.section>
 
-      {/* ── Final CTA ──────────────────────────────── */}
       <motion.section
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, margin: "-80px" }}
         className="border-t border-mc-border py-10 sm:py-16"
       >
-        <div className="max-w-md mx-auto text-center">
+        <div className="max-w-2xl">
           <motion.p
             variants={fadeUp}
-            className="text-sm text-mc-text-dim mb-6 leading-relaxed"
+            className="text-sm leading-relaxed text-mc-text-dim"
           >
-            We&rsquo;re onboarding stores one at a time. Tell us about yours and we&rsquo;ll be in
-            touch.
+            {copy.final_cta.body}
           </motion.p>
-          <motion.div variants={fadeUp}>
+          <motion.div variants={fadeUp} className="mt-6">
             <Link
               href="/apply"
-              className="inline-block px-8 py-3 rounded-lg bg-mc-accent text-mc-on-accent font-semibold text-sm tracking-wide hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+              className="inline-flex min-h-11 items-center justify-center rounded-lg bg-mc-accent px-6 py-3 text-sm font-semibold tracking-wide text-mc-on-accent transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
             >
-              {copy.cta_apply}
+              {copy.final_cta.cta}
             </Link>
           </motion.div>
         </div>

--- a/app/frontend/test/pages/home.test.tsx
+++ b/app/frontend/test/pages/home.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import Home from "../../pages/home"
 import { renderWithTier } from "../viewport-test-utils"
-import type { HomepagePreview } from "../../types/inertia"
+import type { HomepagePreview, Listing } from "../../types/inertia"
 
 vi.mock("@inertiajs/react", () => ({
   Link: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
@@ -28,25 +28,95 @@ vi.mock("@inertiajs/react", () => ({
 }))
 
 const copy = {
-  headline: "Your Discogs inventory, now a storefront.",
-  subhead:
-    "Milkcrate turns your existing Discogs listings into a warm, browsable record shop that you can share in seconds.",
-  cta_demo: "See the demo \u2192",
-  cta_apply: "Get your store on Milkcrate",
-  footnote: "Early access. We handle the setup.",
-  steps: {
-    step1_title: "Share your Discogs",
-    step1_body: "Tell us your Discogs username. That\u2019s it.",
-    step2_title: "We sync & curate",
-    step2_body: "Your inventory becomes curated crates \u2014 picks, featured, genre bins.",
-    step3_title: "Share your store",
-    step3_body: "One link. Your customers browse like they\u2019re in the shop.",
+  hero: {
+    headline: "Browse a Discogs seller like a record store.",
+    subhead:
+      "Milkcrate turns a seller's Discogs inventory into crates, picks, and bins made for digging.",
+    cta_demo: "Visit the demo store",
+    cta_apply: "Request a storefront",
+    footnote: "Discogs stays the source of inventory and checkout.",
+    preview_label: "Storefront lobby",
+    fallback_title: "Start with the demo store.",
+    fallback_body:
+      "Open Philadelphia Music to see crates, picks, bins, and the Discogs checkout path in context.",
   },
-  preview_label: "Flip Through Milkcrate Picks",
-  record_fair_title: "Bring your store to the next record fair",
-  record_fair_body:
-    "QR codes on cards, bags, and signage turn foot traffic into return visitors \u2014 long after the fair ends.",
-  store_character_title: "Your inventory, curated like a real shop",
+  marketplace_loop: {
+    title: "The loop works because buyers get the better room.",
+    items: [
+      {
+        title: "Buyers dig through crates",
+        body: "Start with picks, then move through bins that feel closer to a shop than a spreadsheet.",
+      },
+      {
+        title: "Stores share one front door",
+        body: "A Milkcrate link gives regulars and fair visitors a warmer way into existing Discogs stock.",
+      },
+      {
+        title: "Discogs still handles checkout",
+        body: "Listings, availability, and purchases stay grounded in the seller's Discogs workflow.",
+      },
+    ],
+  },
+  seller_path: {
+    title: "Have a Discogs shop worth browsing?",
+    body: "Tell us your username. We are onboarding storefronts carefully while the beta stays hands-on.",
+    cta: "Request a storefront",
+  },
+  store_character: {
+    title: "A storefront with record-store shape.",
+    moments: [
+      {
+        title: "Milkcrate Picks",
+        body: "A front wall of records gives buyers a place to start.",
+      },
+      {
+        title: "Featured Crates",
+        body: "Focused sections make a large inventory easier to enter.",
+      },
+      {
+        title: "Genre Bins",
+        body: "Familiar bins keep the browse moving without burying the records.",
+      },
+      {
+        title: "Build a Pile",
+        body: "Buyers can compare finds before heading back to Discogs.",
+      },
+      {
+        title: "Store Character",
+        body: "Future premium surfaces can make storefronts feel more like the seller behind them.",
+      },
+    ],
+  },
+  record_fair: {
+    title: "Bring the store back from the record fair.",
+    body: "A Milkcrate link gives table traffic a way to keep browsing after the room closes.",
+  },
+  final_cta: {
+    body: "We are onboarding stores one at a time. Send your Discogs username and we will review it for beta access.",
+    cta: "Request a storefront",
+  },
+}
+
+function makeListing(overrides: Partial<Listing> = {}): Listing {
+  return {
+    id: 1,
+    discogs_listing_id: "abc",
+    artist: "Artist",
+    title: "Record",
+    label: null,
+    year: null,
+    format: null,
+    genres: [],
+    styles: [],
+    condition: null,
+    price: "10.00",
+    currency: "USD",
+    cover_image_url: "/covers/record.jpg",
+    thumbnail_url: null,
+    notes: null,
+    discogs_url: "https://www.discogs.com/sell/item/1",
+    ...overrides,
+  }
 }
 
 function makePreview(overrides: Partial<HomepagePreview> = {}): HomepagePreview {
@@ -58,258 +128,179 @@ function makePreview(overrides: Partial<HomepagePreview> = {}): HomepagePreview 
   }
 }
 
-// ── Emoji regression characters ──────────────────────────────
-const emojiChars = ["🥛", "📀", "👀", "📦"]
+function makePreviewWithPicks(records: Listing[] = [makeListing()]): HomepagePreview {
+  return makePreview({
+    sections: [
+      {
+        key: "picks_wall",
+        crate: {
+          slug: "picks",
+          name: "Milkcrate Picks",
+          count: records.length,
+          records,
+        },
+      },
+    ],
+  })
+}
 
-describe("Home page — vendor-facing rebuild", () => {
+const decorativeGlyphs = ["🥛", "📀", "👀", "📦"]
+
+describe("Home page - buyer-led storefront lobby", () => {
   describe("hero section", () => {
-    it("renders a vendor-first H1 heading", () => {
+    it("renders a buyer-led H1 heading", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
       expect(
-        screen.getByRole("heading", { name: copy.headline })
+        screen.getByRole("heading", { name: copy.hero.headline })
       ).toBeInTheDocument()
     })
 
-    it("does not render the milk emoji in the hero", () => {
+    it("does not render the old seller-first headline or em dash copy", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      // The hero area must not include any emoji glyphs
-      const hero = document.querySelector("[aria-labelledby]")
-      const textContent = hero?.textContent ?? ""
-      for (const emoji of emojiChars) {
-        expect(textContent).not.toContain(emoji)
-      }
+      const pageText = document.body.textContent ?? ""
+      expect(pageText).not.toContain("Your Discogs inventory, now a storefront")
+      expect(pageText).not.toContain("—")
     })
 
-    it("renders the primary CTA linking to /apply", () => {
+    it("keeps the demo and seller CTAs routed", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      // There are multiple CTAs with the same text (hero + final section).
-      const ctas = screen.getAllByRole("link", { name: copy.cta_apply })
-      expect(ctas.length).toBeGreaterThanOrEqual(1)
-      expect(ctas[0]).toHaveAttribute("href", "/apply")
+      expect(screen.getByRole("link", { name: copy.hero.cta_demo })).toHaveAttribute("href", "/philadelphiamusic")
+      expect(screen.getAllByRole("link", { name: copy.hero.cta_apply })[0]).toHaveAttribute("href", "/apply")
     })
 
-    it("renders the demo CTA linking to the demo store", () => {
-      render(<Home copy={copy} preview={makePreview()} />)
+    it("falls back to the demo route when no preview slug is present", () => {
+      render(<Home copy={copy} preview={makePreview({ store_slug: null })} />)
 
-      // With a real store slug, the demo CTA should link to that store
-      const demoLink = screen.getByRole("link", { name: copy.cta_demo })
-      expect(demoLink).toHaveAttribute("href", "/philadelphiamusic")
+      expect(screen.getByRole("link", { name: copy.hero.cta_demo })).toHaveAttribute("href", "/philadelphiamusic")
     })
 
-    it("renders the footnote", () => {
+    it("renders the Discogs checkout footnote", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      expect(screen.getByText(copy.footnote)).toBeInTheDocument()
+      expect(screen.getByText(copy.hero.footnote)).toBeInTheDocument()
     })
   })
 
-  describe("storefront preview section", () => {
-    it("renders the preview section label", () => {
-      render(<Home copy={copy} preview={makePreview()} />)
+  describe("storefront lobby proof", () => {
+    it("renders product-native crate proof when picks data is present", () => {
+      renderWithTier("wide", <Home copy={copy} preview={makePreviewWithPicks()} />)
 
-      expect(screen.getByText(copy.preview_label)).toBeInTheDocument()
-    })
-
-    it("renders preview crates when sections are present", () => {
-      const preview = makePreview({
-        sections: [
-          {
-            key: "picks_wall",
-            crate: {
-              slug: "picks",
-              name: "Milkcrate Picks",
-              count: 4,
-              records: [
-                {
-                  id: 1,
-                  discogs_listing_id: "abc",
-                  artist: "Artist",
-                  title: "Record",
-                  label: null,
-                  year: null,
-                  format: null,
-                  genres: [],
-                  styles: [],
-                  condition: null,
-                  price: "10.00",
-                  currency: "USD",
-                  cover_image_url: null,
-                  thumbnail_url: null,
-                  notes: null,
-                  discogs_url: "https://www.discogs.com/sell/item/1",
-                },
-              ],
-            },
-          },
-        ],
-      })
-
-      renderWithTier(
-        "wide",
-        <Home copy={copy} preview={preview} />
-      )
-
-      // The picks crate name should appear in the preview section.
-      // (It also appears in the store character section; getAllByText avoids ambiguity.)
+      expect(screen.getByText(copy.hero.preview_label)).toBeInTheDocument()
       expect(screen.getAllByText("Milkcrate Picks").length).toBeGreaterThanOrEqual(1)
     })
 
-    it("renders a CTA when no preview sections exist", () => {
-      const preview = makePreview({ sections: [] })
+    it("renders an intentional fallback lobby when preview sections are empty", () => {
+      render(<Home copy={copy} preview={makePreview({ sections: [] })} />)
 
-      render(<Home copy={copy} preview={preview} />)
+      expect(screen.getByText(copy.hero.preview_label)).toBeInTheDocument()
+      expect(screen.getByText(copy.hero.fallback_title)).toBeInTheDocument()
+      expect(screen.getByRole("link", { name: /Open the demo storefront/i })).toHaveAttribute("href", "/philadelphiamusic")
+    })
 
-      // When there's no preview data, the section should still render
-      // with a CTA instead of crate shelves
-      expect(screen.getByText(copy.preview_label)).toBeInTheDocument()
+    it("renders a one-record preview without crashing", () => {
+      const preview = makePreviewWithPicks([makeListing({ id: 7, title: "Single Pick" })])
+
+      renderWithTier("compact", <Home copy={copy} preview={preview} />)
+
+      expect(screen.getAllByText("Milkcrate Picks").length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText("1 record")).toBeInTheDocument()
     })
   })
 
-  describe("onboarding steps", () => {
-    it("renders all three onboarding step titles", () => {
+  describe("marketplace loop and seller path", () => {
+    it("renders buyers, stores, and Discogs in one loop", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      expect(screen.getByText(copy.steps.step1_title)).toBeInTheDocument()
-      expect(screen.getByText(copy.steps.step2_title)).toBeInTheDocument()
-      expect(screen.getByText(copy.steps.step3_title)).toBeInTheDocument()
+      expect(screen.getByRole("heading", { name: copy.marketplace_loop.title })).toBeInTheDocument()
+      for (const item of copy.marketplace_loop.items) {
+        expect(screen.getByText(item.title)).toBeInTheDocument()
+        expect(screen.getByText(item.body)).toBeInTheDocument()
+      }
     })
 
-    it("renders onboarding step body text", () => {
+    it("includes a beta-safe seller route to /apply", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      expect(screen.getByText(copy.steps.step1_body)).toBeInTheDocument()
-      expect(screen.getByText(copy.steps.step2_body)).toBeInTheDocument()
-      expect(screen.getByText(copy.steps.step3_body)).toBeInTheDocument()
+      expect(screen.getByText(copy.seller_path.body)).toBeInTheDocument()
+      expect(screen.getAllByRole("link", { name: copy.seller_path.cta })[0]).toHaveAttribute("href", "/apply")
+      expect(document.body.textContent).not.toMatch(/instant|self-serve setup/i)
+    })
+
+    it("removes the old onboarding mechanics", () => {
+      render(<Home copy={copy} preview={makePreview()} />)
+
+      expect(screen.queryByText("Share your Discogs")).not.toBeInTheDocument()
+      expect(screen.queryByText("We sync & curate")).not.toBeInTheDocument()
+      expect(screen.queryByText("Share your store")).not.toBeInTheDocument()
     })
   })
 
   describe("store character section", () => {
-    it("renders the store character section title", () => {
+    it("renders product-native store moments", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      expect(
-        screen.getByText(copy.store_character_title)
-      ).toBeInTheDocument()
-    })
-
-    it("does not use emoji as decorative icons in the store character section", () => {
-      render(<Home copy={copy} preview={makePreview()} />)
-
-      const body = document.body.textContent ?? ""
-      for (const emoji of emojiChars) {
-        expect(body).not.toContain(emoji)
+      expect(screen.getByRole("heading", { name: copy.store_character.title })).toBeInTheDocument()
+      for (const moment of copy.store_character.moments) {
+        expect(screen.getByText(moment.title)).toBeInTheDocument()
+        expect(screen.getByText(moment.body)).toBeInTheDocument()
       }
     })
 
-    it("does not advertise one-click Discogs cart transfer", () => {
+    it("does not render unsupported feature-card claims", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      expect(screen.queryByText(/One click sends everything to their Discogs cart/i)).not.toBeInTheDocument()
-    })
-
-    it("does not claim stores manually spotlight featured crates", () => {
-      render(<Home copy={copy} preview={makePreview()} />)
-
-      expect(screen.queryByText(/Spotlight the crates you want customers to see first/i)).not.toBeInTheDocument()
+      const text = document.body.textContent ?? ""
+      expect(text).not.toMatch(/One click sends everything to their Discogs cart/i)
+      expect(text).not.toMatch(/Spotlight the crates you want customers to see first/i)
+      expect(text).not.toMatch(/manual crate spotlighting/i)
+      expect(text).not.toMatch(/shipped customization controls/i)
     })
   })
 
-  describe("record-fair callout", () => {
-    it("renders the record-fair title near the final CTA", () => {
+  describe("record-fair and final CTA", () => {
+    it("keeps record-fair copy as a supporting callout", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      expect(screen.getByText(copy.record_fair_title)).toBeInTheDocument()
+      expect(screen.getByText(copy.record_fair.title)).toBeInTheDocument()
+      expect(screen.getByText(copy.record_fair.body)).toBeInTheDocument()
     })
 
-    it("renders the record-fair body text", () => {
+    it("renders the final seller CTA", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      expect(screen.getByText(copy.record_fair_body)).toBeInTheDocument()
+      expect(screen.getByText(copy.final_cta.body)).toBeInTheDocument()
+      expect(screen.getAllByRole("link", { name: copy.final_cta.cta }).length).toBeGreaterThanOrEqual(1)
     })
   })
 
-  describe("emoji regression", () => {
-    it("does not render any emoji in the entire page", () => {
+  describe("responsive rendering and accessibility", () => {
+    it.each(["compact", "comfy", "wide"] as const)("renders at %s tier", (tier) => {
+      const { container } = renderWithTier(
+        tier,
+        <Home copy={copy} preview={makePreviewWithPicks()} />
+      )
+
+      expect(container).toBeInTheDocument()
+      expect(screen.getByRole("heading", { level: 1, name: copy.hero.headline })).toBeInTheDocument()
+      expect(screen.getAllByRole("link", { name: copy.hero.cta_apply }).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it("keeps the H1 as the first page heading", () => {
       render(<Home copy={copy} preview={makePreview()} />)
 
-      const textContent = document.body.textContent ?? ""
+      expect(screen.getAllByRole("heading")[0]).toHaveTextContent(copy.hero.headline)
+    })
 
-      for (const emoji of emojiChars) {
-        expect(textContent).not.toContain(emoji)
+    it("does not render decorative emoji glyphs", () => {
+      render(<Home copy={copy} preview={makePreview()} />)
+
+      const text = document.body.textContent ?? ""
+      for (const glyph of decorativeGlyphs) {
+        expect(text).not.toContain(glyph)
       }
-    })
-
-    it("does not use the milk emoji as a hero icon", () => {
-      render(<Home copy={copy} preview={makePreview()} />)
-
-      // The milk emoji glyph (🥛) must not appear anywhere in the DOM
-      expect(document.body.innerHTML).not.toContain("🥛")
-    })
-  })
-
-  describe("responsive rendering", () => {
-    it("renders at compact tier without horizontal overflow or errors", () => {
-      const { container } = renderWithTier(
-        "compact",
-        <Home copy={copy} preview={makePreview()} />
-      )
-
-      // The page should render without crashing at compact
-      expect(container).toBeInTheDocument()
-      expect(screen.getByRole("heading", { name: copy.headline })).toBeInTheDocument()
-    })
-
-    it("renders at comfy tier without errors", () => {
-      const { container } = renderWithTier(
-        "comfy",
-        <Home copy={copy} preview={makePreview()} />
-      )
-
-      expect(container).toBeInTheDocument()
-      expect(screen.getByRole("heading", { name: copy.headline })).toBeInTheDocument()
-    })
-
-    it("renders at wide tier without errors", () => {
-      const { container } = renderWithTier(
-        "wide",
-        <Home copy={copy} preview={makePreview()} />
-      )
-
-      expect(container).toBeInTheDocument()
-      expect(screen.getByRole("heading", { name: copy.headline })).toBeInTheDocument()
-    })
-  })
-
-  describe("accessibility", () => {
-    it("CTA links have discernible text", () => {
-      render(<Home copy={copy} preview={makePreview()} />)
-
-      const demoLinks = screen.getAllByRole("link", { name: copy.cta_demo })
-      expect(demoLinks.length).toBeGreaterThanOrEqual(1)
-
-      const applyLinks = screen.getAllByRole("link", { name: copy.cta_apply })
-      expect(applyLinks.length).toBeGreaterThanOrEqual(1)
-    })
-
-    it("sections have meaningful headings", () => {
-      render(<Home copy={copy} preview={makePreview()} />)
-
-      const headings = screen.getAllByRole("heading")
-      expect(headings.length).toBeGreaterThan(1)
-
-      // The H1 (hero) should be the first heading
-      expect(headings[0]).toHaveTextContent(copy.headline)
-    })
-
-    it("focus order follows visual order (CTA links are keyboard reachable)", () => {
-      render(<Home copy={copy} preview={makePreview()} />)
-
-      // All CTA links must be in the document and reachable
-      const ctaLinks = screen.getAllByRole("link")
-      expect(ctaLinks.length).toBeGreaterThanOrEqual(2)
     })
   })
 })

--- a/app/frontend/test/pages/page_smoke.test.tsx
+++ b/app/frontend/test/pages/page_smoke.test.tsx
@@ -38,24 +38,58 @@ vi.mock("@inertiajs/react", () => ({
 }))
 
 const homeCopy = {
-  headline: "Your Discogs inventory, now a storefront.",
-  subhead: "Milkcrate turns your existing Discogs listings into a warm, browsable record shop that you can share in seconds.",
-  cta_demo: "See the demo \u2192",
-  cta_apply: "Get your store on Milkcrate",
-  footnote: "Early access. We handle the setup.",
-  steps: {
-    step1_title: "Share your Discogs",
-    step1_body: "Tell us your Discogs username. That's it.",
-    step2_title: "We sync & curate",
-    step2_body: "Your inventory becomes curated crates — picks, featured, genre bins.",
-    step3_title: "Share your store",
-    step3_body: "One link. Your customers browse like they're in the shop.",
+  hero: {
+    headline: "Browse a Discogs seller like a record store.",
+    subhead:
+      "Milkcrate turns a seller's Discogs inventory into crates, picks, and bins made for digging.",
+    cta_demo: "Visit the demo store",
+    cta_apply: "Request a storefront",
+    footnote: "Discogs stays the source of inventory and checkout.",
+    preview_label: "Storefront lobby",
+    fallback_title: "Start with the demo store.",
+    fallback_body:
+      "Open Philadelphia Music to see crates, picks, bins, and the Discogs checkout path in context.",
   },
-  preview_label: "Flip Through Milkcrate Picks",
-  record_fair_title: "Bring your store to the next record fair",
-  record_fair_body:
-    "QR codes on cards, bags, and signage turn foot traffic into return visitors — long after the fair ends.",
-  store_character_title: "Your shop. Crated for browsing.",
+  marketplace_loop: {
+    title: "The loop works because buyers get the better room.",
+    items: [
+      {
+        title: "Buyers dig through crates",
+        body: "Start with picks, then move through bins that feel closer to a shop than a spreadsheet.",
+      },
+      {
+        title: "Stores share one front door",
+        body: "A Milkcrate link gives regulars and fair visitors a warmer way into existing Discogs stock.",
+      },
+      {
+        title: "Discogs still handles checkout",
+        body: "Listings, availability, and purchases stay grounded in the seller's Discogs workflow.",
+      },
+    ],
+  },
+  seller_path: {
+    title: "Have a Discogs shop worth browsing?",
+    body: "Tell us your username. We are onboarding storefronts carefully while the beta stays hands-on.",
+    cta: "Request a storefront",
+  },
+  store_character: {
+    title: "A storefront with record-store shape.",
+    moments: [
+      { title: "Milkcrate Picks", body: "A front wall of records gives buyers a place to start." },
+      { title: "Featured Crates", body: "Focused sections make a large inventory easier to enter." },
+      { title: "Genre Bins", body: "Familiar bins keep the browse moving without burying the records." },
+      { title: "Build a Pile", body: "Buyers can compare finds before heading back to Discogs." },
+      { title: "Store Character", body: "Future premium surfaces can make storefronts feel more like the seller behind them." },
+    ],
+  },
+  record_fair: {
+    title: "Bring the store back from the record fair.",
+    body: "A Milkcrate link gives table traffic a way to keep browsing after the room closes.",
+  },
+  final_cta: {
+    body: "We are onboarding stores one at a time. Send your Discogs username and we will review it for beta access.",
+    cta: "Request a storefront",
+  },
 }
 
 const previewFallback = {
@@ -147,7 +181,7 @@ describe("page smoke tests", () => {
   it("renders the home page", () => {
     render(<Home copy={homeCopy} preview={previewFallback} />)
 
-    expect(screen.getByRole("heading", { name: homeCopy.headline })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: homeCopy.hero.headline })).toBeInTheDocument()
   })
 
   it("home page header does not render emoji wordmark", () => {

--- a/app/frontend/test/pages/responsive_surface_matrix.test.tsx
+++ b/app/frontend/test/pages/responsive_surface_matrix.test.tsx
@@ -63,27 +63,58 @@ import type { AdminDashboardProps, StoreShowProps, HomepagePreview } from "../..
 // ── Shared test data ────────────────────────────────────────────
 
 const homeCopy = {
-  headline: "Your Discogs inventory, now a storefront.",
-  subhead:
-    "Milkcrate turns your existing Discogs listings into a warm, browsable record shop that you can share in seconds.",
-  cta_demo: "See the demo →",
-  cta_apply: "Get your store on Milkcrate",
-  footnote: "Early access. We handle the setup.",
-  steps: {
-    step1_title: "Share your Discogs",
-    step1_body: "Tell us your Discogs username. That\u2019s it.",
-    step2_title: "We sync & curate",
-    step2_body:
-      "Your inventory becomes curated crates — picks, featured, genre bins.",
-    step3_title: "Share your store",
-    step3_body:
-      "One link. Your customers browse like they\u2019re in the shop.",
+  hero: {
+    headline: "Browse a Discogs seller like a record store.",
+    subhead:
+      "Milkcrate turns a seller's Discogs inventory into crates, picks, and bins made for digging.",
+    cta_demo: "Visit the demo store",
+    cta_apply: "Request a storefront",
+    footnote: "Discogs stays the source of inventory and checkout.",
+    preview_label: "Storefront lobby",
+    fallback_title: "Start with the demo store.",
+    fallback_body:
+      "Open Philadelphia Music to see crates, picks, bins, and the Discogs checkout path in context.",
   },
-  preview_label: "Flip Through Milkcrate Picks",
-  record_fair_title: "Bring your store to the next record fair",
-  record_fair_body:
-    "QR codes on cards, bags, and signage turn foot traffic into return visitors — long after the fair ends.",
-  store_character_title: "Your shop. Crated for browsing.",
+  marketplace_loop: {
+    title: "The loop works because buyers get the better room.",
+    items: [
+      {
+        title: "Buyers dig through crates",
+        body: "Start with picks, then move through bins that feel closer to a shop than a spreadsheet.",
+      },
+      {
+        title: "Stores share one front door",
+        body: "A Milkcrate link gives regulars and fair visitors a warmer way into existing Discogs stock.",
+      },
+      {
+        title: "Discogs still handles checkout",
+        body: "Listings, availability, and purchases stay grounded in the seller's Discogs workflow.",
+      },
+    ],
+  },
+  seller_path: {
+    title: "Have a Discogs shop worth browsing?",
+    body: "Tell us your username. We are onboarding storefronts carefully while the beta stays hands-on.",
+    cta: "Request a storefront",
+  },
+  store_character: {
+    title: "A storefront with record-store shape.",
+    moments: [
+      { title: "Milkcrate Picks", body: "A front wall of records gives buyers a place to start." },
+      { title: "Featured Crates", body: "Focused sections make a large inventory easier to enter." },
+      { title: "Genre Bins", body: "Familiar bins keep the browse moving without burying the records." },
+      { title: "Build a Pile", body: "Buyers can compare finds before heading back to Discogs." },
+      { title: "Store Character", body: "Future premium surfaces can make storefronts feel more like the seller behind them." },
+    ],
+  },
+  record_fair: {
+    title: "Bring the store back from the record fair.",
+    body: "A Milkcrate link gives table traffic a way to keep browsing after the room closes.",
+  },
+  final_cta: {
+    body: "We are onboarding stores one at a time. Send your Discogs username and we will review it for beta access.",
+    cta: "Request a storefront",
+  },
 }
 
 const previewFallback: HomepagePreview = {
@@ -188,7 +219,7 @@ describe("responsive surface matrix", () => {
       expect(container).toBeTruthy()
       // Quick structural smoke: heading should be present
       expect(
-        screen.getByRole("heading", { name: homeCopy.headline })
+        screen.getByRole("heading", { name: homeCopy.hero.headline })
       ).toBeInTheDocument()
     })
 
@@ -285,7 +316,7 @@ describe("responsive surface matrix", () => {
     ))
     expect(container).toBeTruthy()
     expect(
-      screen.getByRole("heading", { name: homeCopy.headline })
+      screen.getByRole("heading", { name: homeCopy.hero.headline })
     ).toBeInTheDocument()
   })
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,22 +30,47 @@
 en:
   pages:
     home:
-      headline: "Your Discogs inventory, now a storefront."
-      subhead: "Milkcrate turns your existing Discogs listings into a warm, browsable record shop that you can share in seconds."
-      cta_demo: "See the demo →"
-      cta_apply: "Get your store on Milkcrate"
-      footnote: "Early access. We handle the setup."
-      steps:
-        step1_title: "Share your Discogs"
-        step1_body: "Tell us your Discogs username. That's it."
-        step2_title: "We sync & curate"
-        step2_body: "Your inventory becomes curated crates — picks, featured, genre bins."
-        step3_title: "Share your store"
-        step3_body: "One link. Your customers browse like they're in the shop."
-      preview_label: "Flip Through Milkcrate Picks"
-      record_fair_title: "Bring your store to the next record fair"
-      record_fair_body: "QR codes on cards, bags, and signage turn foot traffic into return visitors — long after the fair ends."
-      store_character_title: "Your shop. Crated for browsing."
+      hero:
+        headline: "Browse a Discogs seller like a record store."
+        subhead: "Milkcrate turns a seller's Discogs inventory into crates, picks, and bins made for digging."
+        cta_demo: "Visit the demo store"
+        cta_apply: "Request a storefront"
+        footnote: "Discogs stays the source of inventory and checkout."
+        preview_label: "Storefront lobby"
+        fallback_title: "Start with the demo store."
+        fallback_body: "Open Philadelphia Music to see crates, picks, bins, and the Discogs checkout path in context."
+      marketplace_loop:
+        title: "The loop works because buyers get the better room."
+        items:
+          - title: "Buyers dig through crates"
+            body: "Start with picks, then move through bins that feel closer to a shop than a spreadsheet."
+          - title: "Stores share one front door"
+            body: "A Milkcrate link gives regulars and fair visitors a warmer way into existing Discogs stock."
+          - title: "Discogs still handles checkout"
+            body: "Listings, availability, and purchases stay grounded in the seller's Discogs workflow."
+      seller_path:
+        title: "Have a Discogs shop worth browsing?"
+        body: "Tell us your username. We are onboarding storefronts carefully while the beta stays hands-on."
+        cta: "Request a storefront"
+      store_character:
+        title: "A storefront with record-store shape."
+        moments:
+          - title: "Milkcrate Picks"
+            body: "A front wall of records gives buyers a place to start."
+          - title: "Featured Crates"
+            body: "Focused sections make a large inventory easier to enter."
+          - title: "Genre Bins"
+            body: "Familiar bins keep the browse moving without burying the records."
+          - title: "Build a Pile"
+            body: "Buyers can compare finds before heading back to Discogs."
+          - title: "Store Character"
+            body: "Future premium surfaces can make storefronts feel more like the seller behind them."
+      record_fair:
+        title: "Bring the store back from the record fair."
+        body: "A Milkcrate link gives table traffic a way to keep browsing after the room closes."
+      final_cta:
+        body: "We are onboarding stores one at a time. Send your Discogs username and we will review it for beta access."
+        cta: "Request a storefront"
     apply:
       headline: "Get your store on Milkcrate"
       subhead: "We're onboarding stores one at a time. Fill this out and we'll be in touch."

--- a/docs/ideation/2026-05-23-home-page-redesign-ideation.md
+++ b/docs/ideation/2026-05-23-home-page-redesign-ideation.md
@@ -1,0 +1,186 @@
+---
+date: 2026-05-23
+topic: home-page-redesign
+focus: Buyer-led homepage with seller storefront path for Discogs buyers and sellers
+mode: repo-grounded
+---
+
+# Ideation: Home Page Redesign
+
+## Grounding Context
+
+Milkcrate is a Rails/Inertia app for browsing a Discogs seller's vinyl inventory as curated crates. The product strategy names record buyers as the primary audience: Milkcrate helps online record browsing feel like walking into a record store, using spatial bins, walls, genre sections, and algorithmic curation. Sellers matter because they get a browsable storefront from the inventory they already maintain on Discogs.
+
+The current homepage is structurally seller-first. `config/locales/en.yml` leads with "Your Discogs inventory, now a storefront," and `app/frontend/pages/home.tsx` explains seller setup steps before the broader marketplace loop is clear. That creates the ambiguity the redesign needs to solve: buyers should immediately understand why browsing a Milkcrate store is different from searching Discogs, while sellers should immediately see that buyer experience as the reason to claim a storefront.
+
+The product already contains the strongest marketing asset: real store browsing UI. `app/frontend/pages/stores/show.tsx`, `app/frontend/components/store_floor.tsx`, `app/frontend/components/crate_view.tsx`, and `app/frontend/components/crate_shelf.tsx` already express the record-store metaphor through cover walls, crates, genre bins, tactile navigation, and a local pile. Existing design guidance in `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md` says marketing and product surfaces should share `BrandMark`, `MilkcrateShell`, preview primitives, viewport tiers, motion tokens, and the record/crate visual vocabulary.
+
+External research supports a buyer-led page with a seller path instead of an equal split. Discogs buyer docs emphasize search, filters, wantlists, seller lookup, and transaction safety. Discogs seller docs emphasize listing, inventory management, bulk edits, filtering, pricing, and order progression. CrateScout validates the Discogs-inventory-to-discovery seller pitch, but leans on generic AI/customer-matching language. Two-sided marketplace examples generally avoid forcing both audiences into one generic hero: Airbnb and Etsy have dedicated host/seller pages, OpenTable and Tock separate diner discovery from restaurant-operator outcomes, Bandcamp explicitly links fan discovery to artist storefront value, and Reverb makes shops buyer-followable through saved shops and saved searches.
+
+Sources:
+
+- Discogs buyer flow: https://support.discogs.com/hc/en-us/articles/360001573434-How-To-Buy-Music-On-Discogs
+- Discogs seller docs: https://support.discogs.com/hc/en-us/articles/360001562473-How-To-Sell-Music-On-Discogs
+- Discogs inventory docs: https://support.discogs.com/hc/en-us/articles/360007714754-How-Can-I-Manage-My-Inventory
+- CrateScout: https://www.cratescout.com/
+- Airbnb host page: https://www.airbnb.com/host/homes
+- Etsy seller page: https://www.etsy.com/sell
+- Bandcamp fans/artists pages: https://bandcamp.com/fans and https://bandcamp.com/artists
+- Reverb shops/favorites docs: https://help.reverb.com/hc/en-us/articles/41988459644699-How-do-I-search-for-a-specific-shop and https://help.reverb.com/hc/en-us/articles/41988383227163-How-to-use-Favorites
+- OpenTable restaurant solutions: https://www.opentable.com/restaurant-solutions/
+- Tock/Squarespace restaurant page: https://www.squarespace.com/tock
+
+## Topic Axes
+
+- Audience hierarchy and page architecture
+- Buyer discovery proof
+- Seller storefront value
+- Mobile-first conversion path
+- Shared product/marketing design language
+
+## Ranked Ideas
+
+### 1. One-Page Storefront Lobby, Not Equal Split Messaging
+
+**Description:** Use one primary homepage now, but stop trying to make one hero speak equally to buyers and sellers. Lead with the buyer experience because that is the product proof: buyers browse Discogs sellers like they are in a record store. Then give sellers a strong, obvious path inside the same page: claim/request a storefront, understand the zero-effort setup, and see the future customization promise.
+
+**Axis:** Audience hierarchy and page architecture
+
+**Basis:** `direct:` `STRATEGY.md` names buyers as primary, while `config/locales/en.yml` currently leads with seller copy. `external:` Airbnb, Etsy, OpenTable, and Tock all separate or strongly route supply-side business pitches rather than forcing both audiences into one generic headline.
+
+**Rationale:** The homepage should make the marketplace loop legible: buyers browse stores; sellers claim the storefront buyers want to browse. Equal hero messaging would blur the product again.
+
+**Downsides:** Sellers may need one extra scroll or tap to reach their pitch. Mitigate with a header link, hero secondary CTA, and seller anchor.
+
+**Confidence:** 92%
+
+**Complexity:** Low-Medium
+
+**Status:** Explored
+
+### 2. Hero As A Working Mini-Store
+
+**Description:** Replace the static marketing-first hero with a mobile-first working preview of the Milkcrate experience: cover art, crate label, pile affordance, and a direct path into the demo store. The hero should feel like the first few feet inside a store, not a SaaS brochure.
+
+**Axis:** Buyer discovery proof
+
+**Basis:** `direct:` `app/frontend/pages/home.tsx` already renders `CrateView` preview data, and `README.md` documents live store routes like `/philadelphiamusic`; strategy says the browse should feel like walking into a record shop.
+
+**Rationale:** A playable preview answers "who is this for?" faster than copy. Buyers see the benefit immediately; sellers see what their Discogs inventory can become.
+
+**Downsides:** Needs careful payload/performance handling and a non-empty demo fallback.
+
+**Confidence:** 90%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 3. Seller Claim Band: "Already Selling On Discogs? Give Buyers A Storefront."
+
+**Description:** Add a seller-specific band or section that makes the supply-side value concrete: keep Discogs for inventory and checkout; Milkcrate becomes the browsable front room. During beta, the CTA should avoid overpromising full self-serve claiming.
+
+**Axis:** Seller storefront value
+
+**Basis:** `direct:` the app has `/apply`, OAuth claim routes, and the strategy's free demo to paid OAuth path. `external:` CrateScout validates "turn Discogs inventory into customer magnet" as a seller hook, but uses generic AI/customer-matching language Milkcrate can avoid.
+
+**Rationale:** The seller pitch should be concrete and operational. This avoids making sellers think they need to migrate ecommerce systems.
+
+**Downsides:** "Claim" can overpromise until onboarding is fully self-serve; copy may need "early storefront" or "request setup" during beta.
+
+**Confidence:** 88%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+### 4. The Marketplace Loop Section
+
+**Description:** Add a compact section that connects both audiences without splitting the page: buyers dig through crates; stores get a shareable storefront; Discogs still handles the sale. Keep it qualitative until first-party metrics exist.
+
+**Axis:** Audience hierarchy and seller storefront value
+
+**Basis:** `reasoned:` sellers do not buy "a prettier page" in isolation; they buy the belief that buyers will browse longer, build piles, and click through to Discogs. `direct:` strategy's metrics are outbound clicks, pile adds, and crates browsed.
+
+**Rationale:** This can become the conceptual bridge of the page and explain why the same product matters to both audiences.
+
+**Downsides:** Without live metrics, it must not become fake SaaS analytics.
+
+**Confidence:** 84%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+### 5. Shared Product/Marketing Design Language
+
+**Description:** Make marketing feel like the product. Use the same warm tokens, crate shelves, record tiles, tactile motion, compact typography, and "pile/dig/crate" language instead of generic SaaS cards.
+
+**Axis:** Shared product/marketing design language
+
+**Basis:** `direct:` `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md` says marketing, store, and apply surfaces should share `BrandMark`, `MilkcrateShell`, preview primitives, responsive tiers, and record/crate visual vocabulary.
+
+**Rationale:** The product is the pitch. If the page feels unlike the product, the store metaphor weakens before anyone opens a demo.
+
+**Downsides:** Reusing full interactive product components in marketing can bring context/provider complexity; prefer bounded preview primitives where possible.
+
+**Confidence:** 91%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 6. Mobile QR Path For Record Fairs
+
+**Description:** Assume many first visits happen from a phone after a card, bag, table sign, or social link. The first interaction should be browseable within seconds, with compact CTAs for browsing the demo and requesting a seller storefront.
+
+**Axis:** Mobile-first conversion path
+
+**Basis:** `direct:` `STRATEGY.md` names the June 6, 2026 record fair as an acquisition milestone. `external:` Tock/OpenTable frame operator value around reach and conversion channels, not just software features.
+
+**Rationale:** The record-fair path gives the page a concrete acquisition context without making the whole product event-only.
+
+**Downsides:** Too much record-fair framing can make the product feel narrow; keep it as one section or callout.
+
+**Confidence:** 82%
+
+**Complexity:** Low-Medium
+
+**Status:** Unexplored
+
+### 7. Premium Tease As Store Character, Not Theme Settings
+
+**Description:** Tease premium customization as "make it feel like your shop" with examples of different storefront moods or section names, not as a color picker. The free generated store should still feel complete.
+
+**Axis:** Seller storefront value and shared design language
+
+**Basis:** `direct:` strategy names custom pages, identity controls, and theming as paid partnership value; `StorefrontTheme` exists in the model layer.
+
+**Rationale:** This supports seller aspiration without making current free/demo storefronts feel broken or under-featured.
+
+**Downsides:** Must avoid implying customization is already available if it is not.
+
+**Confidence:** 78%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Full separate buyer and seller homepages now | Premature. One well-structured page can answer the current ambiguity; separate pages become useful when pricing/onboarding depth grows. |
+| 2 | Equal buyer/seller split hero | Recreates the clarity problem by refusing to choose a primary first-screen job. |
+| 3 | Lead with seller-only positioning | Conflicts with strategy, which names record buyers as primary, and weakens the seller proof. |
+| 4 | Lead with AI matching | External competitors already use generic AI language; Milkcrate's stronger differentiation is record-store browsing. |
+| 5 | Fake dashboard or metric cards | No grounded metrics yet; would look like unsupported SaaS proof. |
+| 6 | Attack Discogs directly | Milkcrate depends on Discogs for inventory and checkout; complementary framing is more credible. |
+| 7 | Long editorial brand story | On-brand but too slow for mobile QR traffic and does not resolve audience routing. |
+| 8 | Immediate pricing section | Premium direction matters, but pricing is not ready enough to carry homepage clarity. |
+| 9 | Pure aesthetic redesign | The actual issue is product-positioning architecture, not just visual polish. |
+| 10 | Desktop-first split media hero | Violates the mobile-first constraint and would make the product demo feel secondary on phones. |
+
+## Recommended Next Step
+
+Run `compound-engineering:ce-brainstorm` on idea 1, with ideas 2, 3, 4, 5, and 6 treated as supporting scope. The brainstorm should produce a concrete mobile-first page structure and copy brief before implementation planning.

--- a/docs/plans/2026-05-23-005-feat-buyer-led-home-lobby-plan.md
+++ b/docs/plans/2026-05-23-005-feat-buyer-led-home-lobby-plan.md
@@ -1,0 +1,363 @@
+---
+title: "feat: Rebuild homepage as buyer-led storefront lobby"
+type: feat
+status: completed
+date: 2026-05-23
+origin_docs:
+  - docs/ideation/2026-05-23-home-page-redesign-ideation.md
+---
+
+# feat: Rebuild homepage as buyer-led storefront lobby
+
+## Summary
+
+Rebuild the public homepage around one clear lobby experience: buyers should immediately understand that Milkcrate lets them browse a Discogs seller like they are in a record store, while sellers see that same buyer experience as the reason to request a storefront. The work stays on one mobile-first page, uses existing record/crate primitives, and keeps seller promises beta-safe until self-serve claiming and premium customization are truly ready.
+
+---
+
+## Problem Frame
+
+The current homepage still reads seller-first: the headline is "Your Discogs inventory, now a storefront," the first CTA choice appears before product proof, and later sections use a generic feature-card rhythm. That blurs Milkcrate's strategic center: record buyers are the primary audience, and seller value comes from giving those buyers a warm storefront that Discogs inventory alone does not provide.
+
+---
+
+## Requirements
+
+- R1. Lead with the buyer browsing promise, not an equal buyer/seller split and not a seller-only inventory headline.
+- R2. Make product proof visible in the first viewport on mobile, using the visual language of records, crates, and a storefront lobby.
+- R3. Keep sellers clearly routed from the homepage with beta-safe language around requesting or claiming a storefront.
+- R4. Explain the marketplace loop: buyers browse crates, sellers get a shareable storefront, and Discogs remains the inventory and checkout system.
+- R5. Replace generic SaaS-like cards and onboarding mechanics with product-native store moments.
+- R6. Keep the page mobile-first and let larger layouts expand from the compact information hierarchy.
+- R7. Preserve the current public routes: `/`, `/philadelphiamusic`, `/apply`, and store routes.
+- R8. Preserve bounded homepage preview payload behavior and avoid shipping full store data to the marketing page.
+- R9. Keep copy truthful: no instant self-serve setup, no shipped premium customization claims, no fake conversion metrics.
+- R10. Keep the shared Milkcrate brand, shell, viewport, and motion systems intact.
+- R11. Maintain rendering and accessibility coverage across compact, comfy, and wide viewport tiers.
+
+---
+
+## Scope Boundaries
+
+- No separate seller page in this pass.
+- No pricing table, plan comparison, payments, or entitlement logic.
+- No self-serve Discogs OAuth claim flow or route changes.
+- No new curation algorithm, store sync behavior, or Discogs API integration changes.
+- No analytics dashboard, testimonials, or ungrounded conversion claims.
+- No premium theme editor or customization UI.
+- No broad redesign of store browsing pages, `CrateView`, `StoreFloor`, `/apply`, or admin.
+
+### Deferred to Follow-Up Work
+
+- Dedicated seller page: add when pricing, self-serve claim, paid acquisition, or seller education requires more depth than the homepage can carry.
+- Premium customization marketing: add after the shipped customization surface and entitlement boundary are defined.
+- QR or record-fair asset generation: plan separately if the Philamoca fair follow-up needs printable assets or vendor-specific codes.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `app/frontend/pages/home.tsx` currently owns the homepage section structure, CTA routing, preview rendering, onboarding steps, store-character cards, record-fair callout, and final seller CTA.
+- `config/locales/en.yml` is the source for homepage and apply copy. Current homepage strings include seller-first positioning and em dashes that conflict with design guidance.
+- `app/controllers/pages_controller.rb` keeps the home action thin and passes `copy` plus `preview` props to Inertia.
+- `app/presenters/marketing_preview_presenter.rb` bounds the preview payload with `MAX_PREVIEW_RECORDS`, `MAX_FEATURED_CRATES`, and `MAX_GENRE_CRATES`, then falls back to typed empty preview data when no demo store exists.
+- `app/frontend/types/inertia.ts` defines `HomepagePreview`, `StorefrontSection`, `Crate`, and `Listing`, which should remain the shared contract unless implementation proves a small additive field is necessary.
+- `app/frontend/components/crate_shelf.tsx` and `app/frontend/components/record_tile.tsx` are the current reusable crate/record display primitives. `StorefrontPreview` was removed from production code, so this plan should not depend on restoring that stale abstraction.
+- `app/frontend/components/crate_view.tsx` is the full interactive record browser. The homepage can link into the demo store, but should not embed the full `CrateView` interaction model in the hero.
+- Existing tests to update include `app/frontend/test/pages/home.test.tsx`, `app/frontend/test/pages/page_smoke.test.tsx`, `app/frontend/test/pages/responsive_surface_matrix.test.tsx`, and `spec/requests/pages_spec.rb`.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md` establishes `MarketingLayout`, `MilkcrateShell`, `BrandMark`, bounded preview data, `RecordTile`, and `CrateShelf` as the public-surface vocabulary.
+- `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md` establishes compact, comfy, and wide viewport tiers plus `renderWithTier` test coverage.
+- `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md` requires motion to use shared token/provider patterns and reduced-motion support rather than one-off animation values.
+- `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md` warns that responsive refactors can silently drop branch guards. Homepage changes should test populated and fallback preview states across tiers.
+- `docs/DESIGN.md` rejects SaaS-generic hero patterns, identical card grids, excessive decorative accents, wrapped cards, and em dashes in UI copy.
+- `docs/PRODUCT.md` and `STRATEGY.md` name record buyers as primary and store owners as secondary, with "record store browsing" as the product purpose.
+
+### External References
+
+External marketplace and competitor research is summarized in `docs/ideation/2026-05-23-home-page-redesign-ideation.md`. No additional external developer research is needed for this plan because the implementation should follow established local Rails, Inertia, React, viewport, and motion patterns.
+
+---
+
+## Key Technical Decisions
+
+- Keep one homepage now: the clarity problem is audience hierarchy, not lack of routing. A seller page should wait until seller-specific funnel depth exists.
+- Use buyer proof as seller proof: the strongest seller pitch is seeing what a buyer experiences, so the hero should show the storefront lobby before seller mechanics.
+- Build the hero proof from existing preview primitives: `CrateShelf` and `RecordTile` are the maintained shared components; reviving `StorefrontPreview` would add abstraction churn for one page.
+- Avoid embedding full `CrateView` in the hero: `CrateView` owns focused browsing, pile context, and rich interaction. The homepage should preview the doorway, then send users to the demo store for the full interaction.
+- Keep Rails layering simple: `PagesController` stays thin, `MarketingPreviewPresenter` stays presentation-oriented, and curation logic remains in existing services.
+- Treat fallback preview as a designed state: if local demo data is absent, the first viewport still needs a credible lobby shape and clear demo link, not a blank proof section.
+- Let compact layout define the hierarchy: desktop can add density and side-by-side composition only after the mobile order works.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- One page or multiple pages: keep one primary homepage in this pass, with a dedicated seller page deferred.
+- Should the hero split buyer and seller equally: no. It should lead with buyer browsing and give sellers a clear secondary route.
+- Should the page look like the product: yes. Use record/crate primitives, the shared shell, existing tokens, and product vocabulary instead of generic marketing cards.
+
+### Deferred to Implementation
+
+- Exact copy wording: implementation should tune the final lines in context, while preserving buyer-first hierarchy, beta-safe seller promises, and the no-em-dash rule.
+- Exact hero composition across breakpoints: implementation should tune spacing and density after seeing the live layout, while preserving the compact-first order.
+- Whether a small helper component is needed for the hero preview: decide while implementing. If `home.tsx` becomes dense or repeated, extract a focused component rather than a broad preview framework.
+
+---
+
+## High-Level Technical Design
+
+> This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+| Page moment | Primary job | Audience served | Notes |
+| --- | --- | --- | --- |
+| First viewport lobby | Prove "browse a Discogs seller like a record store" | Buyers first, sellers second | Buyer headline, demo CTA, seller secondary CTA or anchor, product-native mini-store proof |
+| Marketplace loop | Explain why both sides care | Buyers and sellers | Buyers dig, stores get a shareable front room, Discogs handles transaction |
+| Seller claim band | Convert interested sellers without overpromising | Sellers | Request/setup language, Discogs username path, early-access framing |
+| Store character | Show what Milkcrate makes from inventory | Both | Crates, sections, pile, store mood, and premium tease as character rather than settings |
+| Record-fair/final CTA | Ground a real acquisition context | Sellers | Keep as one callout, not the page's whole identity |
+
+---
+
+## Implementation Units
+
+### U1. Reframe Homepage Copy Contract Around Buyer-Led Lobby
+
+**Goal:** Replace seller-first homepage copy with a buyer-led content model that still gives sellers a clear path.
+
+**Requirements:** R1, R3, R4, R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `config/locales/en.yml`
+- Modify: `app/frontend/pages/home.tsx`
+- Modify: `app/frontend/layouts/marketing_layout.tsx`
+- Test: `app/frontend/test/pages/home.test.tsx`
+- Test: `app/frontend/test/pages/page_smoke.test.tsx`
+- Test: `app/frontend/test/pages/responsive_surface_matrix.test.tsx`
+- Test: `spec/requests/pages_spec.rb`
+
+**Approach:**
+- Replace the current seller-first headline and subhead with buyer browsing language.
+- Preserve locale-driven copy rather than hard-coding new marketing text in React.
+- Rename or reshape homepage copy groups as needed so the page model reflects lobby, marketplace loop, seller path, store character, and fair/final CTA sections.
+- Re-label shared marketing header actions if current labels are too generic for the buyer/seller routing job, while preserving the existing routes.
+- Keep `/apply` copy mostly outside this pass unless a shared CTA label requires a small consistency update.
+- Remove em dashes from user-facing homepage strings.
+
+**Execution note:** Start with failing copy/contract tests so the old seller-first headline cannot survive by accident.
+
+**Patterns to follow:**
+- Locale-driven `copy` prop from `app/controllers/pages_controller.rb`.
+- Existing page smoke tests that assert homepage copy and route props.
+
+**Test scenarios:**
+- Happy path: GET `/` returns a buyer-led headline in `copy.headline`.
+- Regression: homepage copy no longer includes "Your Discogs inventory, now a storefront."
+- Regression: homepage copy values do not contain em dashes.
+- Happy path: primary demo CTA and seller CTA both remain present with discernible labels.
+- Integration: frontend tests render the updated copy object without TypeScript shape drift.
+
+**Verification:**
+- The first text a mobile visitor reads is about browsing records, not operating seller inventory.
+
+### U2. Build The First-Viewport Storefront Lobby
+
+**Goal:** Move product proof into the first viewport with a mobile-first mini-store composition that feels like Milkcrate, not a SaaS hero.
+
+**Requirements:** R1, R2, R6, R8, R10, R11
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/frontend/pages/home.tsx`
+- Create: `app/frontend/components/home_storefront_lobby.tsx`
+- Test: `app/frontend/components/home_storefront_lobby.test.tsx`
+- Test: `app/frontend/test/pages/home.test.tsx`
+- Test: `app/frontend/test/pages/responsive_surface_matrix.test.tsx`
+
+**Approach:**
+- Compose the hero as a lobby: compact copy, immediate demo CTA, secondary seller route, and a bounded crate/record preview in the same first-screen story.
+- Extract a focused homepage-only lobby component so the page file owns section order while the new component owns preview-state rendering.
+- Prefer `CrateShelf` and `RecordTile` for preview visuals. Use `CrateView` only as the linked full demo destination, not as an embedded hero control.
+- Keep the mini-store proof non-interactive or lightly linked to the demo store; do not introduce pile behavior, record flipping, or crate navigation into the homepage hero.
+- Ensure compact view renders in a single deliberate order before adding wider side-by-side composition.
+- Use existing motion tokens and `MarketingLayout` providers if animation is needed; avoid inline spring values.
+
+**Patterns to follow:**
+- Non-interactive `CrateShelf` behavior in `app/frontend/components/crate_shelf.tsx`.
+- `RecordTile` lightweight cover rendering.
+- `MarketingLayout` wrapping `StorefrontMotionConfig` and `ViewportProvider`.
+
+**Test scenarios:**
+- Happy path: when preview data includes a `picks_wall` crate with records, the first viewport renders a product-native crate/record proof.
+- Happy path: demo CTA links to the preview store slug when present and `/philadelphiamusic` otherwise.
+- Regression: homepage no longer imports or renders full `CrateView` for the marketing preview.
+- Edge case: one-record preview data renders without layout crash or empty proof copy.
+- Responsive: compact, comfy, and wide tiers render the hero without duplicate CTAs, missing heading, or preview crash.
+- Accessibility: hero links have discernible names and the H1 remains the first page heading.
+
+**Verification:**
+- A mobile visitor can understand the buyer experience before scrolling past the hero.
+
+### U3. Replace Onboarding Mechanics With Marketplace Loop And Seller Claim Path
+
+**Goal:** Rework the middle of the page so buyer and seller value reinforce each other instead of competing.
+
+**Requirements:** R3, R4, R6, R7, R9, R11
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `app/frontend/pages/home.tsx`
+- Modify: `config/locales/en.yml`
+- Test: `app/frontend/test/pages/home.test.tsx`
+- Test: `app/frontend/test/pages/responsive_surface_matrix.test.tsx`
+
+**Approach:**
+- Replace the current numbered "Share your Discogs / We sync / Share your store" section with a marketplace-loop section that explains buyers, sellers, and Discogs in one flow.
+- Add a seller claim/request band with beta-safe wording and a direct `/apply` route.
+- Keep the record-fair callout, but make it a supporting acquisition moment rather than the page's main argument.
+- Use full-width bands or unframed section layouts rather than nested card stacks.
+
+**Patterns to follow:**
+- Existing `Link` CTA patterns in `home.tsx`.
+- Design guidance in `docs/DESIGN.md` for concise sections, flat surfaces, and no wrapped cards.
+
+**Test scenarios:**
+- Happy path: marketplace loop copy renders and references buyers, stores, and Discogs without false claims.
+- Happy path: seller section includes a route to `/apply`.
+- Regression: old onboarding step labels no longer appear.
+- Regression: seller copy does not imply instant self-serve setup.
+- Responsive: seller path appears after the buyer proof in compact tier and remains reachable without relying on desktop-only layout.
+
+**Verification:**
+- The page explains the two-sided value proposition without putting two unrelated pitches in the hero.
+
+### U4. Rebuild Store Character As Product-Native Moments
+
+**Goal:** Replace the current generic feature-card grid with moments that look and read like the Milkcrate product.
+
+**Requirements:** R2, R5, R6, R9, R10, R11
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `app/frontend/pages/home.tsx`
+- Modify: `config/locales/en.yml`
+- Test: `app/frontend/test/pages/home.test.tsx`
+
+**Approach:**
+- Keep the ideas that matter: Milkcrate Picks, featured crates, genre bins, pile building, and future store character.
+- Present them as product-native crate/store moments instead of identical feature cards.
+- Tease premium customization as store character only if the copy makes clear it is future-facing or premium-directional.
+- Use accent color for actions and section headers, not decorative fill.
+- Avoid fake metrics, dashboards, AI generic positioning, and unsupported controls.
+
+**Patterns to follow:**
+- `CrateShelf` and `RecordTile` for record/crate visual vocabulary where visuals help.
+- `docs/DESIGN.md` rules for the one accent, flat-by-default surfaces, and anti-SaaS layout.
+
+**Test scenarios:**
+- Happy path: store-character section renders product-native labels or moments for picks, crates, bins, and pile.
+- Regression: old generic feature-card copy does not appear.
+- Regression: no copy claims manual crate spotlighting, one-click Discogs cart transfer, or shipped customization controls.
+- Regression: decorative emoji are not rendered on the page.
+- Accessibility: section has a meaningful heading and does not rely on decorative-only glyphs to communicate meaning.
+
+**Verification:**
+- The section feels like a preview of Milkcrate storefront behavior, not a generic software feature list.
+
+### U5. Harden Preview Fallbacks And Regression Coverage
+
+**Goal:** Ensure the redesigned lobby remains stable when demo data is present, sparse, or absent.
+
+**Requirements:** R2, R8, R10, R11
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+- Modify: `app/frontend/pages/home.tsx`
+- Modify: `app/frontend/components/home_storefront_lobby.tsx`
+- Test: `app/frontend/components/home_storefront_lobby.test.tsx`
+- Test: `app/frontend/test/pages/home.test.tsx`
+- Test: `app/frontend/test/pages/page_smoke.test.tsx`
+- Test: `app/frontend/test/pages/responsive_surface_matrix.test.tsx`
+- Test: `spec/presenters/marketing_preview_presenter_spec.rb`
+- Test: `spec/requests/pages_spec.rb`
+
+**Approach:**
+- Preserve the existing bounded preview caps and avoid adding full-store payloads to the homepage.
+- If no live preview records exist, render an intentional fallback lobby state with a strong demo link instead of a blank or misleading fake store.
+- Keep fallback records out of the backend unless they are clearly non-sale placeholders and tests prove they cannot be mistaken for real Discogs listings.
+- Leave `HomepagePreview` and `MarketingPreviewPresenter` shape unchanged unless implementation discovers the existing typed empty fallback cannot support the designed frontend state.
+- Keep tests characterization-focused around current preview capping before changing presenter behavior.
+
+**Patterns to follow:**
+- `MarketingPreviewPresenter#fallback_preview` typed shape.
+- Presenter specs that already cover empty demo store and no-demo-store cases.
+- Responsive matrix tests that render home at all viewport tiers.
+
+**Test scenarios:**
+- Happy path: live preview data remains capped by records and crate counts.
+- Edge case: empty demo store returns a stable preview shape and the homepage renders an intentional fallback state.
+- Error path: presenter rescue still returns a safe fallback shape when demo store lookup or curation fails.
+- Regression: homepage preview never requires full store sections to render the first viewport.
+- Integration: request spec still proves `/` returns the `home` component with `copy` and `preview` props.
+
+**Verification:**
+- The redesigned homepage is credible with demo data and still usable in development or test environments without a synced demo store.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** GET `/` flows through `PagesController#home`, `MarketingPreviewPresenter`, Inertia `Home`, `MarketingLayout`, and the shared viewport/motion providers. Demo and seller CTAs continue routing to store slug or `/apply`.
+- **Error propagation:** Preview failures remain non-fatal and should fall back to a safe homepage state. Seller application behavior is unchanged.
+- **State lifecycle risks:** Avoid adding pile state, crate selection state, or full `CrateView` state to the marketing page. The lobby should not persist browsing state or mutate local pile storage.
+- **API surface parity:** `HomepagePreview` should stay backward-compatible unless implementation needs an additive field. Any contract change requires request, presenter, and frontend test updates.
+- **Integration coverage:** Unit tests should cover copy, fallback states, and component rendering; request specs should cover Inertia props; responsive matrix should cover all viewport tiers.
+- **Unchanged invariants:** Store routes, Discogs outbound links, curation scoring, inventory sync, OAuth onboarding, waitlist submission, and admin behavior remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Hero preview becomes a second product surface with duplicated browsing behavior | Use `CrateShelf` and `RecordTile`; link to the demo store for full browsing. |
+| Seller value gets buried by buyer-first hierarchy | Keep seller CTA in the hero and add a dedicated seller claim/request band below the marketplace loop. |
+| Fallback state weakens product proof in environments without demo data | Design an intentional fallback lobby with a clear demo link and test it explicitly. |
+| Copy overpromises self-serve claiming or premium customization | Keep beta-safe wording and add regression assertions against instant setup and shipped customization claims. |
+| Responsive redesign introduces compact-only or wide-only regressions | Update `home.test.tsx` and `responsive_surface_matrix.test.tsx` for compact, comfy, and wide states. |
+| Stale docs reference `StorefrontPreview` as if it still exists | Follow current production code and note that `StorefrontPreview` should not be restored unless a future broader preview abstraction is planned. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/DESIGN.md` only if the implementation establishes a reusable homepage/lobby pattern that should become design-system guidance. Do not update it just to describe this one page.
+- The project instruction says the developer runs `bin/dev`; do not start or stop app servers during implementation. Use existing running server checks or ask the developer before browser verification.
+- Visual verification should cover mobile first, then expanded desktop. In-app or browser testing should verify no overlapping text, no blank preview, and no hero copy/preview crowding.
+
+---
+
+## Sources & References
+
+- Origin ideation: `docs/ideation/2026-05-23-home-page-redesign-ideation.md`
+- Product strategy: `STRATEGY.md`
+- Product context: `docs/PRODUCT.md`
+- Design system: `docs/DESIGN.md`
+- Prior marketing plan: `docs/plans/2026-05-14-002-refactor-marketing-truth-alignment-plan.md`
+- Shared surface learning: `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md`
+- Viewport learning: `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`
+- Motion learning: `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`
+- Homepage implementation: `app/frontend/pages/home.tsx`
+- Marketing preview presenter: `app/presenters/marketing_preview_presenter.rb`

--- a/spec/presenters/marketing_preview_presenter_spec.rb
+++ b/spec/presenters/marketing_preview_presenter_spec.rb
@@ -113,6 +113,25 @@ RSpec.describe MarketingPreviewPresenter do
       end
     end
 
+    context "when curation raises" do
+      let!(:store) do
+        create(:store,
+          discogs_username: discogs_username,
+          name: "Philadelphia Music"
+        )
+      end
+
+      it "returns safe fallback preview data" do
+        allow(StorefrontCuration).to receive(:cached_curation).and_raise(StandardError, "curation failed")
+
+        result = described_class.new.preview_data
+
+        expect(result.keys).to match_array(%i[store_name store_slug sections])
+        expect(result[:store_slug]).to be_nil
+        expect(result[:sections]).to eq([])
+      end
+    end
+
     context "preview data shape matches expected frontend contract" do
       let!(:store) do
         create(:store,

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -12,19 +12,25 @@ RSpec.describe "Pages", type: :request do
       expect(inertia).to render_component("home")
     end
 
-    it "renders the vendor-facing headline" do
+    it "renders a buyer-led headline" do
       get "/"
-      expect(inertia.props["copy"]["headline"]).to include("now a storefront")
+      expect(inertia.props.dig("copy", "hero", "headline")).to include("Browse a Discogs seller like a record store")
+    end
+
+    it "does not include seller-first or em dash homepage copy" do
+      get "/"
+
+      copy_json = inertia.props["copy"].to_json
+      expect(copy_json).not_to include("Your Discogs inventory, now a storefront")
+      expect(copy_json).not_to include("—")
     end
 
     it "does not include retired dig-session content in copy values" do
       get "/"
 
-      inertia.props["copy"].each_value do |v|
-        next unless v.is_a?(String)
-        expect(v).not_to include("Sessions")
-        expect(v).not_to include("session-bar")
-      end
+      copy_json = inertia.props["copy"].to_json
+      expect(copy_json).not_to include("Sessions")
+      expect(copy_json).not_to include("session-bar")
     end
 
     it "includes a preview prop with store_name and sections" do


### PR DESCRIPTION
## Summary
Milkcrate's homepage now opens with the buyer experience: visitors see a compact storefront lobby that points into the demo store, while sellers still get a direct beta-safe path to request a storefront. The page no longer leads with seller inventory setup or generic onboarding mechanics; it explains the marketplace loop through buyers, stores, and Discogs, then uses product-native store moments to show what the storefront creates.

## Key Decisions
- Kept the homepage as one route and changed the audience hierarchy instead of adding a seller page before the seller funnel is ready.
- Extracted a focused `HomeStorefrontLobby` component that uses the existing bounded `HomepagePreview` contract and `CrateShelf` preview primitive instead of embedding full `CrateView` behavior in the hero.
- Preserved `/`, `/philadelphiamusic`, `/apply`, and store routes while relabeling public navigation and CTAs around browsing and seller requests.
- Kept fallback preview states intentional and buyer-facing without adding fake records or expanding the backend payload.

## Testing
- `npm run test:components` - 25 files, 364 tests passing
- `npm run test:frontend` - 57 tests passing
- `npm run typecheck` - passing
- `bundle exec rspec` - 589 examples passing
- `bundle exec rubocop` - no offenses

## Review Notes
- Code review found and fixed one product-copy issue: the empty-preview fallback no longer exposes implementation-facing “preview data” language.
- Visual browser verification was not captured because no local Rails/Vite server was running and repo instructions prohibit this agent from starting `bin/dev` or equivalent server processes.

## Post-Deploy Monitoring & Validation
- Log searches: `GET /`, `home`, `MarketingPreviewPresenter`, `ActionView::Template::Error`, `Inertia`, and JavaScript asset load errors for the deployed window.
- Metrics to watch: homepage 5xx rate, homepage p95 latency, `/philadelphiamusic` request volume from homepage traffic, `/apply` request volume from homepage traffic, and client-side error reporting if available.
- Healthy signals: `GET /` returns 200, homepage latency stays near pre-deploy baseline, demo and seller routes receive traffic, and `MarketingPreviewPresenter` warnings do not spike.
- Failure signals: elevated 5xxs on `/`, Inertia hydration/runtime errors, missing homepage `copy.hero` props, broken demo/apply links, or repeated preview fallback warnings.
- Rollback trigger: revert this PR if homepage 5xxs or client runtime errors persist after cache/assets refresh, or if buyer/seller CTAs route incorrectly in production.
- Validation window and owner: first 24 hours after deploy, owned by the deployer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
