### PR TITLE
refactor(frontend): decompose components, extract hooks, reduce prop coupling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,11 +57,11 @@ unstructured and must be synthesized into the final report (same treatment as
 
 | Agent | Select when diff touches... |
 |-------|---------------------------|
-| `ce-sandi-metz-js-reviewer` | JavaScript/TypeScript files (`*.js`, `*.jsx`, `*.ts`, `*.tsx`) with React components, hooks, or module-level abstractions. Pass `task: "Review this diff through a Sandi Metz lens adapted for React/JS. Check: component size (>100 lines), JSX return length (>10-15 lines), prop count (>4), hook complexity (>20 lines), components mixing fetch+render, prop drilling through 3+ levels, missing abstractions in repeated patterns. Report findings with file:line references."` |
+| `sandi-metz-js-reviewer` | JavaScript/TypeScript files (`*.js`, `*.jsx`, `*.ts`, `*.tsx`) with React components, hooks, or module-level abstractions. Pass `task: "Review this diff through a Sandi Metz lens adapted for React/JS. Check: component size (>100 lines), JSX return length (>10-15 lines), prop count (>4), hook complexity (>20 lines), components mixing fetch+render, prop drilling through 3+ levels, missing abstractions in repeated patterns. Report findings with file:line references."` |
 | `ce-dhh-rails-reviewer` | Rails architecture, service objects, session/auth choices, Hotwire-vs-SPA boundaries, abstractions that fight Rails conventions |
 | `ce-kieran-rails-reviewer` | Rails controllers, models, views, jobs, components, routes, or other application-layer Ruby code where clarity and conventions matter |
 
-For on-demand Sandi Metz review (outside the code review pipeline), use the `/ce-sandi-metz-review` skill for Ruby/Rails code, or `/ce-sandi-metz-js-review` for JavaScript/React/TypeScript code — each dispatches its respective reviewer to analyze a specific file, directory, or the current diff.
+For on-demand Sandi Metz review (outside the code review pipeline), use the `/ce-sandi-metz-review` skill for Ruby/Rails code, or `/sandi-metz-js-review` for JavaScript/React/TypeScript code — each dispatches its respective reviewer to analyze a specific file, directory, or the current diff.
 
 These Rails reviewers complement the standard persona catalog. They are opinionated lenses
 on Rails-specific patterns — dispatch them in addition to (not instead of) the standard

--- a/app/frontend/components/back_button.test.tsx
+++ b/app/frontend/components/back_button.test.tsx
@@ -1,33 +1,50 @@
-import React from "react"
-import { describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import BackButton from "./back_button"
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IconBackButton, TextBackButton } from "./back_button";
 
-describe("BackButton", () => {
-  it("renders icon variant with aria-label", () => {
-    const onClick = vi.fn()
-    render(<BackButton variant="icon" onClick={onClick} />)
+describe("IconBackButton", () => {
+  it("renders with default aria-label", () => {
+    const onClick = vi.fn();
+    render(<IconBackButton onClick={onClick} />);
 
-    const btn = screen.getByRole("button", { name: "Back" })
-    expect(btn).toBeDefined()
-    expect(btn.querySelector("[aria-hidden]")?.textContent).toContain("←")
-  })
+    const btn = screen.getByRole("button", { name: "Back" });
+    expect(btn).toBeDefined();
+    expect(btn.querySelector("[aria-hidden]")?.textContent).toContain("←");
+  });
 
-  it("renders text variant with label", () => {
-    const onClick = vi.fn()
-    render(<BackButton variant="text" label="Store" onClick={onClick} />)
+  it("renders with labelled aria-label", () => {
+    const onClick = vi.fn();
+    render(<IconBackButton onClick={onClick} label="Store" />);
 
-    const btn = screen.getByRole("button", { name: "Back to Store" })
-    expect(btn.textContent).toContain("Store")
-  })
+    const btn = screen.getByRole("button", { name: "Back to Store" });
+    expect(btn).toBeDefined();
+  });
 
   it("fires onClick when clicked", async () => {
-    const user = userEvent.setup()
-    const onClick = vi.fn()
-    render(<BackButton variant="icon" onClick={onClick} />)
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<IconBackButton onClick={onClick} />);
 
-    await user.click(screen.getByRole("button"))
-    expect(onClick).toHaveBeenCalledTimes(1)
-  })
-})
+    await user.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("TextBackButton", () => {
+  it("renders with label", () => {
+    const onClick = vi.fn();
+    render(<TextBackButton onClick={onClick} label="Store" />);
+
+    const btn = screen.getByRole("button", { name: "Back to Store" });
+    expect(btn.textContent).toContain("Store");
+  });
+
+  it("falls back to 'Back' without label", () => {
+    const onClick = vi.fn();
+    render(<TextBackButton onClick={onClick} />);
+
+    const btn = screen.getByRole("button", { name: "Back" });
+    expect(btn.textContent).toContain("Back");
+  });
+});

--- a/app/frontend/components/back_button.test.tsx
+++ b/app/frontend/components/back_button.test.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import BackButton from "./back_button"
+
+describe("BackButton", () => {
+  it("renders icon variant with aria-label", () => {
+    const onClick = vi.fn()
+    render(<BackButton variant="icon" onClick={onClick} />)
+
+    const btn = screen.getByRole("button", { name: "Back" })
+    expect(btn).toBeDefined()
+    expect(btn.querySelector("[aria-hidden]")?.textContent).toContain("←")
+  })
+
+  it("renders text variant with label", () => {
+    const onClick = vi.fn()
+    render(<BackButton variant="text" label="Store" onClick={onClick} />)
+
+    const btn = screen.getByRole("button", { name: "Back to Store" })
+    expect(btn.textContent).toContain("Store")
+  })
+
+  it("fires onClick when clicked", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<BackButton variant="icon" onClick={onClick} />)
+
+    await user.click(screen.getByRole("button"))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/frontend/components/back_button.tsx
+++ b/app/frontend/components/back_button.tsx
@@ -1,42 +1,55 @@
-interface BackButtonProps {
-  /** Icon: circular ← button. Text: "← Label" pill button. */
-  variant: "icon" | "text";
-  /** Label for the text variant (e.g., "Store"). */
-  label?: string;
+/**
+ * Shared focus-visible ring and aria-label pattern for back buttons.
+ * Used by both IconBackButton and TextBackButton internally.
+ */
+const sharedRingClasses =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg";
+
+interface BaseBackButtonProps {
   onClick: () => void;
   className?: string;
+  label?: string;
 }
 
 /**
- * Shared back-navigation button used in crate headers and app layout.
- * Two variants: a compact circular icon button and a desktop pill button.
+ * Compact circular ← button. Used in mobile headers and tight spaces.
  */
-export default function BackButton({ variant, label, onClick, className = "" }: BackButtonProps) {
-  if (variant === "icon") {
-    return (
-      <button
-        type="button"
-        onClick={onClick}
-        className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-mc-border bg-mc-bg-raised text-lg leading-none text-mc-text-dim transition-[color,border-color,transform] hover:border-mc-accent hover:text-mc-accent active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${className}`}
-        aria-label={label ? `Back to ${label}` : "Back"}
-      >
-        <span aria-hidden="true" className="-translate-y-px">
-          ←
-        </span>
-      </button>
-    );
-  }
+export function IconBackButton({ onClick, label, className = "" }: BaseBackButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-mc-border bg-mc-bg-raised text-lg leading-none text-mc-text-dim transition-[color,border-color,transform] hover:border-mc-accent hover:text-mc-accent active:scale-[0.97] ${sharedRingClasses} ${className}`}
+      aria-label={label ? `Back to ${label}` : "Back"}
+    >
+      <span aria-hidden="true" className="-translate-y-px">
+        ←
+      </span>
+    </button>
+  );
+}
 
+interface TextBackButtonProps extends BaseBackButtonProps {
+  /** Label for the text variant (e.g., "Store"). Required — renders "Back" as fallback. */
+  label?: string;
+}
+
+/**
+ * Desktop pill button with "← Label" text. Used in wide-layout headers.
+ */
+export function TextBackButton({ onClick, label, className = "" }: TextBackButtonProps) {
   const visibleLabel = label ? label.charAt(0).toUpperCase() + label.slice(1) : "Back";
 
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`flex items-center gap-1.5 text-xs font-medium text-mc-text-dim bg-mc-bg-raised border border-mc-border rounded-lg hover:border-mc-accent hover:text-mc-accent transition-colors whitespace-nowrap py-1.5 px-3 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${className}`}
+      className={`flex items-center gap-1.5 text-xs font-medium text-mc-text-dim bg-mc-bg-raised border border-mc-border rounded-lg hover:border-mc-accent hover:text-mc-accent transition-colors whitespace-nowrap py-1.5 px-3 cursor-pointer ${sharedRingClasses} ${className}`}
       aria-label={label ? `Back to ${label}` : "Back"}
     >
       ← {visibleLabel}
     </button>
   );
 }
+
+export default IconBackButton;

--- a/app/frontend/components/back_button.tsx
+++ b/app/frontend/components/back_button.tsx
@@ -1,12 +1,10 @@
-import React from "react"
-
 interface BackButtonProps {
   /** Icon: circular ← button. Text: "← Label" pill button. */
-  variant: "icon" | "text"
+  variant: "icon" | "text";
   /** Label for the text variant (e.g., "Store"). */
-  label?: string
-  onClick: () => void
-  className?: string
+  label?: string;
+  onClick: () => void;
+  className?: string;
 }
 
 /**
@@ -22,9 +20,11 @@ export default function BackButton({ variant, label, onClick, className = "" }: 
         className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-mc-border bg-mc-bg-raised text-lg leading-none text-mc-text-dim transition-[color,border-color,transform] hover:border-mc-accent hover:text-mc-accent active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${className}`}
         aria-label={label ? `Back to ${label}` : "Back"}
       >
-        <span aria-hidden="true" className="-translate-y-px">←</span>
+        <span aria-hidden="true" className="-translate-y-px">
+          ←
+        </span>
       </button>
-    )
+    );
   }
 
   return (
@@ -36,5 +36,5 @@ export default function BackButton({ variant, label, onClick, className = "" }: 
     >
       ← {label ?? "Back"}
     </button>
-  )
+  );
 }

--- a/app/frontend/components/back_button.tsx
+++ b/app/frontend/components/back_button.tsx
@@ -27,6 +27,8 @@ export default function BackButton({ variant, label, onClick, className = "" }: 
     );
   }
 
+  const visibleLabel = label ? label.charAt(0).toUpperCase() + label.slice(1) : "Back";
+
   return (
     <button
       type="button"
@@ -34,7 +36,7 @@ export default function BackButton({ variant, label, onClick, className = "" }: 
       className={`flex items-center gap-1.5 text-xs font-medium text-mc-text-dim bg-mc-bg-raised border border-mc-border rounded-lg hover:border-mc-accent hover:text-mc-accent transition-colors whitespace-nowrap py-1.5 px-3 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${className}`}
       aria-label={label ? `Back to ${label}` : "Back"}
     >
-      ← {label ?? "Back"}
+      ← {visibleLabel}
     </button>
   );
 }

--- a/app/frontend/components/back_button.tsx
+++ b/app/frontend/components/back_button.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+
+interface BackButtonProps {
+  /** Icon: circular ← button. Text: "← Label" pill button. */
+  variant: "icon" | "text"
+  /** Label for the text variant (e.g., "Store"). */
+  label?: string
+  onClick: () => void
+  className?: string
+}
+
+/**
+ * Shared back-navigation button used in crate headers and app layout.
+ * Two variants: a compact circular icon button and a desktop pill button.
+ */
+export default function BackButton({ variant, label, onClick, className = "" }: BackButtonProps) {
+  if (variant === "icon") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-mc-border bg-mc-bg-raised text-lg leading-none text-mc-text-dim transition-[color,border-color,transform] hover:border-mc-accent hover:text-mc-accent active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${className}`}
+        aria-label={label ? `Back to ${label}` : "Back"}
+      >
+        <span aria-hidden="true" className="-translate-y-px">←</span>
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1.5 text-xs font-medium text-mc-text-dim bg-mc-bg-raised border border-mc-border rounded-lg hover:border-mc-accent hover:text-mc-accent transition-colors whitespace-nowrap py-1.5 px-3 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${className}`}
+      aria-label={label ? `Back to ${label}` : "Back"}
+    >
+      ← {label ?? "Back"}
+    </button>
+  )
+}

--- a/app/frontend/components/crate_card.tsx
+++ b/app/frontend/components/crate_card.tsx
@@ -37,6 +37,8 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
         previewCount={4}
         openLabel="DIG →"
         headerSize={variant}
+        className="border-0 rounded-none"
+        isHovered={isHovered}
       />
     </motion.div>
   );

--- a/app/frontend/components/crate_card.tsx
+++ b/app/frontend/components/crate_card.tsx
@@ -37,8 +37,6 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
         previewCount={4}
         openLabel="DIG →"
         headerSize={variant}
-        className="border-0 rounded-none"
-        isHovered={isHovered}
       />
     </motion.div>
   );

--- a/app/frontend/components/crate_card.tsx
+++ b/app/frontend/components/crate_card.tsx
@@ -1,24 +1,22 @@
-import { motion } from "framer-motion"
-import { useTactileHover } from "@/hooks/use_tactile_hover"
-import { springTactile, springPress, SCALE_HOVER, SCALE_PRESS } from "@/lib/motion_tokens"
-import CrateShelf from "./crate_shelf"
-import type { Crate } from "../types/inertia"
+import { motion } from "framer-motion";
+import { useTactileHover } from "@/hooks/use_tactile_hover";
+import { springTactile, springPress, SCALE_HOVER, SCALE_PRESS } from "@/lib/motion_tokens";
+import CrateShelf from "./crate_shelf";
+import type { Crate } from "../types/inertia";
 
 interface Props {
-  crate: Crate
-  variant: "featured" | "genre"
-  onSelectCrate: (slug: string, startIndex?: number) => void
+  crate: Crate;
+  variant: "featured" | "genre";
+  onSelectCrate: (slug: string, startIndex?: number) => void;
 }
 
 /**
  * A tactile crate card — wraps CrateShelf in a Framer Motion container
  * that applies cursor-proximity hover animations (scale, lift, tilt,
- * border glow). The outer motion.div owns the border (so borderColor
- * animation is visible) and passes hover state into CrateShelf for
- * inner animations (open label, thumbnail scale).
+ * border glow). The outer motion.div owns the border animation.
  */
 export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
-  const { isHovered, isPressed, handlers } = useTactileHover()
+  const { isHovered, isPressed, handlers } = useTactileHover();
 
   return (
     <motion.div
@@ -39,9 +37,7 @@ export default function CrateCard({ crate, variant, onSelectCrate }: Props) {
         previewCount={4}
         openLabel="DIG →"
         headerSize={variant}
-        isHovered={isHovered}
-        className="border-0 rounded-none"
       />
     </motion.div>
-  )
+  );
 }

--- a/app/frontend/components/crate_section_grid.tsx
+++ b/app/frontend/components/crate_section_grid.tsx
@@ -1,0 +1,57 @@
+import CrateCard from "./crate_card";
+import { useViewport } from "@/hooks/use_viewport";
+import type { Crate } from "../types/inertia";
+
+interface CrateSectionGridProps {
+  /** Section heading text (e.g. "Featured"). */
+  title: string;
+  /** Number of crates in this section. */
+  count: number;
+  /** Crates to display. */
+  crates: Crate[];
+  /** Card visual variant to use. */
+  variant: "featured" | "genre";
+  /** Column count strategy: receives viewport flags, returns number of columns. */
+  columnCount: (isCompact: boolean, isComfy: boolean) => number;
+  /** Callback when a crate is selected. */
+  onSelectCrate: (slug: string, startIndex?: number) => void;
+  /** Optional gap size between grid items (Tailwind classes). Default: "gap-4". */
+  gap?: string;
+}
+
+/**
+ * A reusable section grid: heading with count + responsive grid of CrateCards.
+ * Extracted from FeaturedCratesRow and GenreGrid which were near-identical.
+ */
+export default function CrateSectionGrid({
+  title,
+  count,
+  crates,
+  variant,
+  columnCount,
+  onSelectCrate,
+  gap = "gap-4",
+}: CrateSectionGridProps) {
+  const { isCompact, isComfy } = useViewport();
+
+  if (crates.length === 0) return null;
+
+  const cols = columnCount(isCompact, isComfy);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-2 mb-4">
+        <span className="mc-section-name text-base font-semibold">{title}</span>
+        <span className="mc-section-count">{count}</span>
+      </div>
+      <div
+        className={`grid ${gap}`}
+        style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
+      >
+        {crates.map((crate) => (
+          <CrateCard key={crate.slug} crate={crate} variant={variant} onSelectCrate={onSelectCrate} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/components/crate_shelf.test.tsx
+++ b/app/frontend/components/crate_shelf.test.tsx
@@ -316,6 +316,24 @@ describe("CrateShelf", () => {
       expect(screen.getByText("Jazz")).toBeInTheDocument();
     });
 
+    it("applies className prop in static mode", () => {
+      const crate = makeCrate();
+
+      const { container } = renderShelf(<CrateShelf crate={crate} className="test-shelf" />);
+
+      expect(container.querySelector(".test-shelf")).toBeInTheDocument();
+    });
+
+    it("applies className prop in interactive mode", () => {
+      const crate = makeCrate();
+
+      const { container } = renderShelf(
+        <CrateShelf crate={crate} interactive className="test-shelf" onSelectCrate={vi.fn()} />,
+      );
+
+      expect(container.querySelector(".test-shelf")).toBeInTheDocument();
+    });
+
     it("renders interactive variant with correct role", () => {
       const crate = makeCrate();
 

--- a/app/frontend/components/crate_shelf.test.tsx
+++ b/app/frontend/components/crate_shelf.test.tsx
@@ -1,10 +1,10 @@
-import React from "react"
-import { describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import CrateShelf from "./crate_shelf"
-import StorefrontMotionConfig from "./storefront_motion_config"
-import type { Crate, Listing } from "../types/inertia"
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CrateShelf from "./crate_shelf";
+import StorefrontMotionConfig from "./storefront_motion_config";
+import type { Crate, Listing } from "../types/inertia";
 
 const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
   id: 1,
@@ -24,7 +24,7 @@ const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
   notes: null,
   discogs_url: "https://www.discogs.com/sell/item/1",
   ...overrides,
-})
+});
 
 const makeCrate = (overrides: Partial<Crate> = {}): Crate => ({
   slug: "jazz-crate",
@@ -37,224 +37,213 @@ const makeCrate = (overrides: Partial<Crate> = {}): Crate => ({
     makeListing({ id: 4, title: "Record 4" }),
   ],
   ...overrides,
-})
+});
 
 const renderShelf = (ui: React.ReactElement) =>
-  render(<StorefrontMotionConfig>{ui}</StorefrontMotionConfig>)
+  render(<StorefrontMotionConfig>{ui}</StorefrontMotionConfig>);
 
 describe("CrateShelf", () => {
   describe("non-interactive mode (default)", () => {
     it("renders crate name", () => {
-      const crate = makeCrate()
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} />)
+      renderShelf(<CrateShelf crate={crate} />);
 
-      expect(screen.getByText("Jazz")).toBeInTheDocument()
-    })
+      expect(screen.getByText("Jazz")).toBeInTheDocument();
+    });
 
     it("renders record count", () => {
-      const crate = makeCrate({ count: 4 })
+      const crate = makeCrate({ count: 4 });
 
-      renderShelf(<CrateShelf crate={crate} />)
+      renderShelf(<CrateShelf crate={crate} />);
 
-      expect(screen.getByText("4")).toBeInTheDocument()
-    })
+      expect(screen.getByText("4")).toBeInTheDocument();
+    });
 
     it("renders RecordTile components for records", () => {
-      const crate = makeCrate()
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} />)
+      renderShelf(<CrateShelf crate={crate} />);
 
       // Record titles from RecordTile fallback — ♪ symbols for no-image tiles
-      expect(document.querySelectorAll(".bg-mc-bg-raised").length).toBeGreaterThanOrEqual(1)
-    })
+      expect(document.querySelectorAll(".bg-mc-bg-raised").length).toBeGreaterThanOrEqual(1);
+    });
 
     it("renders at most 4 record tiles by default", () => {
       const crate = makeCrate({
         count: 8,
         records: Array.from({ length: 8 }, (_, i) =>
-          makeListing({ id: i + 1, title: `Record ${i + 1}` })
+          makeListing({ id: i + 1, title: `Record ${i + 1}` }),
         ),
-      })
+      });
 
-      renderShelf(<CrateShelf crate={crate} />)
+      renderShelf(<CrateShelf crate={crate} />);
 
       // Should only render 4 tiles max (default previewCount)
-      const notes = screen.getAllByText("♪")
-      expect(notes.length).toBeLessThanOrEqual(4)
-    })
+      const notes = screen.getAllByText("♪");
+      expect(notes.length).toBeLessThanOrEqual(4);
+    });
 
     it("header is not a button in non-interactive mode", () => {
-      const crate = makeCrate()
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} />)
+      renderShelf(<CrateShelf crate={crate} />);
 
-      expect(screen.getByText("Jazz")).toBeInTheDocument()
-      expect(screen.queryByRole("button")).not.toBeInTheDocument()
-    })
+      expect(screen.getByText("Jazz")).toBeInTheDocument();
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
 
     it("does not fire onSelectCrate when header is clicked", async () => {
-      const user = userEvent.setup()
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
+      const user = userEvent.setup();
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} onSelectCrate={onSelectCrate} />)
+      renderShelf(<CrateShelf crate={crate} onSelectCrate={onSelectCrate} />);
 
-      await user.click(screen.getByText("Jazz"))
+      await user.click(screen.getByText("Jazz"));
 
-      expect(onSelectCrate).not.toHaveBeenCalled()
-    })
-  })
+      expect(onSelectCrate).not.toHaveBeenCalled();
+    });
+  });
 
   describe("interactive mode", () => {
     it("renders header as a clickable element", () => {
-      const crate = makeCrate()
-      const onSelectCrate = vi.fn()
+      const crate = makeCrate();
+      const onSelectCrate = vi.fn();
 
-      renderShelf(
-        <CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />
-      )
+      renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />);
 
-      const button = screen.getByRole("button", { name: "Open Jazz" })
-      expect(button).toBeInTheDocument()
-    })
+      const button = screen.getByRole("button", { name: "Open Jazz" });
+      expect(button).toBeInTheDocument();
+    });
 
     it("calls onSelectCrate with slug when header is clicked", async () => {
-      const user = userEvent.setup()
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
+      const user = userEvent.setup();
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
 
-      renderShelf(
-        <CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />
-      )
+      renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />);
 
-      const button = screen.getByRole("button", { name: "Open Jazz" })
-      await user.click(button)
+      const button = screen.getByRole("button", { name: "Open Jazz" });
+      await user.click(button);
 
-      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate")
-      expect(onSelectCrate).toHaveBeenCalledTimes(1)
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate");
+      expect(onSelectCrate).toHaveBeenCalledTimes(1);
+    });
 
     it("calls onSelectCrate with slug and index when a record thumbnail is clicked", async () => {
-      const user = userEvent.setup()
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
+      const user = userEvent.setup();
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
 
-      renderShelf(
-        <CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />
-      )
+      renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />);
 
-      const recordBtn = screen.getByRole("button", { name: "Open Jazz at Record 1" })
-      await user.click(recordBtn)
+      const recordBtn = screen.getByRole("button", { name: "Open Jazz at Record 1" });
+      await user.click(recordBtn);
 
-      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate", 0)
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate", 0);
+    });
 
     it("calls onSelectCrate with correct index for 2nd record", async () => {
-      const user = userEvent.setup()
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
+      const user = userEvent.setup();
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
 
-      renderShelf(
-        <CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />
-      )
+      renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />);
 
-      const recordBtn = screen.getByRole("button", { name: "Open Jazz at Record 2" })
-      await user.click(recordBtn)
+      const recordBtn = screen.getByRole("button", { name: "Open Jazz at Record 2" });
+      await user.click(recordBtn);
 
-      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate", 1)
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate", 1);
+    });
 
     it("responds to Enter key on header", async () => {
-      const user = userEvent.setup()
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
+      const user = userEvent.setup();
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
 
-      renderShelf(
-        <CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />
-      )
+      renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />);
 
-      const button = screen.getByRole("button", { name: "Open Jazz" })
-      button.focus()
-      await user.keyboard("{Enter}")
+      const button = screen.getByRole("button", { name: "Open Jazz" });
+      button.focus();
+      await user.keyboard("{Enter}");
 
-      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate")
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate");
+    });
 
     it("responds to Space key on header", async () => {
-      const user = userEvent.setup()
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
+      const user = userEvent.setup();
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
 
-      renderShelf(
-        <CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />
-      )
+      renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />);
 
-      const button = screen.getByRole("button", { name: "Open Jazz" })
-      button.focus()
-      await user.keyboard(" ")
+      const button = screen.getByRole("button", { name: "Open Jazz" });
+      button.focus();
+      await user.keyboard(" ");
 
-      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate")
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate");
+    });
 
     it("does not fire onSelectCrate when header is clicked if no handler", async () => {
-      const user = userEvent.setup()
-      const crate = makeCrate()
+      const user = userEvent.setup();
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} interactive />)
+      renderShelf(<CrateShelf crate={crate} interactive />);
 
-      const button = screen.getByRole("button", { name: "Open Jazz" })
-      await user.click(button)
-      // No assertion needed — test passes if no error thrown
-    })
-  })
+      const button = screen.getByRole("button", { name: "Open Jazz" });
+      await user.click(button);
+      // Graceful: clicking without handler does not throw
+      expect(button).toBeInTheDocument();
+    });
+  });
 
   describe("product-browsing variant", () => {
     it("shows more than 4 records when previewCount is increased", () => {
       const crate = makeCrate({
         count: 8,
         records: Array.from({ length: 8 }, (_, i) =>
-          makeListing({ id: i + 1, title: `Rec ${i + 1}` })
+          makeListing({ id: i + 1, title: `Rec ${i + 1}` }),
         ),
-      })
+      });
 
       renderShelf(
-        <CrateShelf crate={crate} interactive previewCount={6} onSelectCrate={vi.fn()} />
-      )
+        <CrateShelf crate={crate} interactive previewCount={6} onSelectCrate={vi.fn()} />,
+      );
 
       // 6 record buttons + 1 header button = 7 total
-      expect(screen.getAllByRole("button").length).toBe(7)
-    })
+      expect(screen.getAllByRole("button").length).toBe(7);
+    });
 
     it("renders 3-column grid when previewCount is 6", () => {
       const crate = makeCrate({
         count: 8,
         records: Array.from({ length: 8 }, (_, i) =>
-          makeListing({ id: i + 1, title: `Record ${i + 1}` })
+          makeListing({ id: i + 1, title: `Record ${i + 1}` }),
         ),
-      })
+      });
 
       const { container } = renderShelf(
-        <CrateShelf crate={crate} interactive previewCount={6} onSelectCrate={vi.fn()} />
-      )
+        <CrateShelf crate={crate} interactive previewCount={6} onSelectCrate={vi.fn()} />,
+      );
 
-      const grid = container.querySelector("[style*='grid-template-columns']")
-      expect(grid).toBeInTheDocument()
+      const grid = container.querySelector("[style*='grid-template-columns']");
+      expect(grid).toBeInTheDocument();
       // 3 columns for 6-item preview
-      expect(grid?.getAttribute("style")).toContain("repeat(3, 1fr)")
-    })
+      expect(grid?.getAttribute("style")).toContain("repeat(3, 1fr)");
+    });
 
     it("renders 2-column grid by default (4-item preview)", () => {
-      const crate = makeCrate()
+      const crate = makeCrate();
 
       const { container } = renderShelf(
-        <CrateShelf crate={crate} interactive onSelectCrate={vi.fn()} />
-      )
+        <CrateShelf crate={crate} interactive onSelectCrate={vi.fn()} />,
+      );
 
-      const grid = container.querySelector("[style*='grid-template-columns']")
-      expect(grid).toBeInTheDocument()
-      expect(grid?.getAttribute("style")).toContain("repeat(2, 1fr)")
-    })
+      const grid = container.querySelector("[style*='grid-template-columns']");
+      expect(grid).toBeInTheDocument();
+      expect(grid?.getAttribute("style")).toContain("repeat(2, 1fr)");
+    });
 
     it("shows fewer records than previewCount when crate has fewer records", () => {
       const crate = makeCrate({
@@ -263,127 +252,118 @@ describe("CrateShelf", () => {
           makeListing({ id: 1, title: "Only Record" }),
           makeListing({ id: 2, title: "Another" }),
         ],
-      })
+      });
 
       renderShelf(
-        <CrateShelf crate={crate} interactive previewCount={6} onSelectCrate={vi.fn()} />
-      )
+        <CrateShelf crate={crate} interactive previewCount={6} onSelectCrate={vi.fn()} />,
+      );
 
       // Should only render available records, not empty tiles
       // 2 record buttons + 1 header button = 3 total
-      expect(screen.getAllByRole("button").length).toBe(3)
-    })
+      expect(screen.getAllByRole("button").length).toBe(3);
+    });
 
     it("shows meta text instead of count when meta is provided", () => {
-      const crate = makeCrate()
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} meta="May 14" />)
+      renderShelf(<CrateShelf crate={crate} meta="May 14" />);
 
-      expect(screen.getByText("May 14")).toBeInTheDocument()
+      expect(screen.getByText("May 14")).toBeInTheDocument();
       // Count "4" should NOT be shown — meta replaces it
-      expect(screen.queryByText("4")).not.toBeInTheDocument()
-    })
+      expect(screen.queryByText("4")).not.toBeInTheDocument();
+    });
 
     it("shows open label that is visible on hover in interactive mode", () => {
-      const crate = makeCrate()
-      const onSelectCrate = vi.fn()
+      const crate = makeCrate();
+      const onSelectCrate = vi.fn();
 
       renderShelf(
-        <CrateShelf crate={crate} interactive openLabel="DIG →" onSelectCrate={onSelectCrate} />
-      )
+        <CrateShelf crate={crate} interactive openLabel="DIG →" onSelectCrate={onSelectCrate} />,
+      );
 
       // The open label should be present (even if visually hidden via opacity)
-      expect(screen.getByText("DIG →")).toBeInTheDocument()
-    })
+      expect(screen.getByText("DIG →")).toBeInTheDocument();
+    });
 
     it("does not show open label in non-interactive mode", () => {
-      const crate = makeCrate()
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} openLabel="DIG →" />)
+      renderShelf(<CrateShelf crate={crate} openLabel="DIG →" />);
 
       // Open label is only for interactive mode — should not appear
-      expect(screen.queryByText("DIG →")).not.toBeInTheDocument()
-    })
-  })
+      expect(screen.queryByText("DIG →")).not.toBeInTheDocument();
+    });
+  });
 
   describe("edge cases", () => {
     it("handles crate with 0 records", () => {
-      const crate = makeCrate({ count: 0, records: [] })
+      const crate = makeCrate({ count: 0, records: [] });
 
-      renderShelf(<CrateShelf crate={crate} />)
+      renderShelf(<CrateShelf crate={crate} />);
 
-      expect(screen.getByText("Jazz")).toBeInTheDocument()
-      expect(screen.queryAllByText("♪").length).toBe(0)
-    })
+      expect(screen.getByText("Jazz")).toBeInTheDocument();
+      expect(screen.queryAllByText("♪").length).toBe(0);
+    });
 
     it("handles crate with 1 record", () => {
       const crate = makeCrate({
         count: 1,
         records: [makeListing({ id: 1, title: "Solo" })],
-      })
+      });
 
-      renderShelf(<CrateShelf crate={crate} />)
+      renderShelf(<CrateShelf crate={crate} />);
 
-      expect(screen.getByText("Jazz")).toBeInTheDocument()
-    })
+      expect(screen.getByText("Jazz")).toBeInTheDocument();
+    });
 
-    it("applies className prop", () => {
-      const crate = makeCrate()
+    it("renders interactive variant with correct role", () => {
+      const crate = makeCrate();
 
-      const { container } = renderShelf(<CrateShelf crate={crate} className="test-shelf" />)
+      renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={vi.fn()} />);
 
-      const shelf = container.querySelector(".test-shelf")
-      expect(shelf).toBeInTheDocument()
-    })
+      expect(screen.getByRole("button", { name: "Open Jazz" })).toBeInTheDocument();
+    });
 
     it("handles missing onSelectCrate gracefully in interactive mode", () => {
-      const crate = makeCrate()
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} interactive />)
+      renderShelf(<CrateShelf crate={crate} interactive />);
 
-      const button = screen.getByRole("button", { name: "Open Jazz" })
-      expect(button).toBeInTheDocument()
-    })
-  })
+      const button = screen.getByRole("button", { name: "Open Jazz" });
+      expect(button).toBeInTheDocument();
+    });
+  });
 
   describe("accessibility", () => {
     it("interactive header has tabIndex 0", () => {
-      const crate = makeCrate()
-      const onSelectCrate = vi.fn()
+      const crate = makeCrate();
+      const onSelectCrate = vi.fn();
 
-      renderShelf(
-        <CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />
-      )
+      renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />);
 
-      const button = screen.getByRole("button", { name: "Open Jazz" })
-      expect(button).toHaveAttribute("tabindex", "0")
-    })
+      const button = screen.getByRole("button", { name: "Open Jazz" });
+      expect(button).toHaveAttribute("tabindex", "0");
+    });
 
     it("non-interactive mode has no interactive elements", () => {
-      const crate = makeCrate()
+      const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} />)
+      renderShelf(<CrateShelf crate={crate} />);
 
-      expect(screen.queryByRole("button")).not.toBeInTheDocument()
-    })
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
 
     it("interactive mode does not nest button elements inside button elements", () => {
-      const crate = makeCrate()
-      renderShelf(
-        <CrateShelf
-          crate={crate}
-          interactive={true}
-          onSelectCrate={vi.fn()}
-        />
-      )
+      const crate = makeCrate();
+      renderShelf(<CrateShelf crate={crate} interactive={true} onSelectCrate={vi.fn()} />);
 
       // The header is a div with role="button"; thumbnails are <button>s.
       // No <button> should contain another <button>.
-      const buttons = document.querySelectorAll("button")
+      const buttons = document.querySelectorAll("button");
       buttons.forEach((btn) => {
-        const nestedButtons = btn.querySelectorAll("button")
-        expect(nestedButtons.length).toBe(0)
-      })
-    })
-  })
-})
+        const nestedButtons = btn.querySelectorAll("button");
+        expect(nestedButtons.length).toBe(0);
+      });
+    });
+  });
+});

--- a/app/frontend/components/crate_shelf.test.tsx
+++ b/app/frontend/components/crate_shelf.test.tsx
@@ -185,17 +185,6 @@ describe("CrateShelf", () => {
       expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate");
     });
 
-    it("does not fire onSelectCrate when header is clicked if no handler", async () => {
-      const user = userEvent.setup();
-      const crate = makeCrate();
-
-      renderShelf(<CrateShelf crate={crate} interactive />);
-
-      const button = screen.getByRole("button", { name: "Open Jazz" });
-      await user.click(button);
-      // Graceful: clicking without handler does not throw
-      expect(button).toBeInTheDocument();
-    });
   });
 
   describe("product-browsing variant", () => {
@@ -342,13 +331,19 @@ describe("CrateShelf", () => {
       expect(screen.getByRole("button", { name: "Open Jazz" })).toBeInTheDocument();
     });
 
-    it("handles missing onSelectCrate gracefully in interactive mode", () => {
+  });
+
+  describe("type contract", () => {
+    it("keeps static and interactive shelf props mutually exclusive", () => {
       const crate = makeCrate();
 
-      renderShelf(<CrateShelf crate={crate} interactive />);
+      // @ts-expect-error interactive shelves require onSelectCrate
+      const missingHandler = <CrateShelf crate={crate} interactive />;
+      // @ts-expect-error static shelves do not accept onSelectCrate
+      const staticWithHandler = <CrateShelf crate={crate} onSelectCrate={vi.fn()} />;
 
-      const button = screen.getByRole("button", { name: "Open Jazz" });
-      expect(button).toBeInTheDocument();
+      expect(missingHandler.props.interactive).toBe(true);
+      expect(staticWithHandler.props.onSelectCrate).toBeDefined();
     });
   });
 

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -1,71 +1,61 @@
-import React from "react"
-import { motion } from "framer-motion"
-import RecordTile from "./record_tile"
-import { useTactileHover } from "@/hooks/use_tactile_hover"
-import { springTactile, springPress, SCALE_HOVER } from "@/lib/motion_tokens"
-import type { Crate } from "../types/inertia"
+import React from "react";
+import { motion } from "framer-motion";
+import RecordTile from "./record_tile";
+import { useTactileHover } from "@/hooks/use_tactile_hover";
+import { springTactile, springPress, SCALE_HOVER } from "@/lib/motion_tokens";
+import type { Crate } from "../types/inertia";
 
 export interface CrateShelfProps {
-  crate: Crate
+  crate: Crate;
   /** When true, header and thumbnails become clickable for crate navigation. */
-  interactive?: boolean
+  interactive?: boolean;
   /** Callback for crate selection. Receives slug and optional record index. */
-  onSelectCrate?: (slug: string, startIndex?: number) => void
+  onSelectCrate?: (slug: string, startIndex?: number) => void;
   /** Maximum number of record thumbnails to show. Defaults to 4. */
-  previewCount?: number
+  previewCount?: number;
   /** Optional meta text shown beside the crate name (e.g. today's date). */
-  meta?: string
+  meta?: string;
   /** Optional explicit open-action label for touch-friendly affordance. */
-  openLabel?: string
+  openLabel?: string;
   /** Header text size: "featured" (text-base) or "genre" (text-sm, default). */
-  headerSize?: "featured" | "genre"
-  /** Override internal hover state (for CrateCard wrapping CrateShelf). */
-  isHovered?: boolean
+  headerSize?: "featured" | "genre";
   /** When true, enables thumbnail hover scale on non-compact viewports. */
-  tactileThumbnails?: boolean
-  /** Additional CSS class names. */
-  className?: string
+  tactileThumbnails?: boolean;
 }
 
-/**
- * A visual crate/shelf layout — name header + grid of RecordTile
- * thumbnails. Two modes:
- *
- * - Non-interactive (default): static label header, decorative thumbnails.
- *   For marketing preview surfaces.
- * - Interactive: clickable header + thumbnails that call onSelectCrate.
- *   For store browsing surfaces.
- *
- * When `interactive` is true and `openLabel` is provided, the header shows
- * a "DIG →" style affordance that slides in on hover and is always visible
- * on touch, following CrateCard's tactile patterns.
- *
- * Follows CrateCard's interactive pattern: role="button", tabIndex, and
- * keyboard handling with closest-check for nested interactive elements.
- */
-export default function CrateShelf({
+// ── Shared layout skeleton ─────────────────────────────────────
+
+function CrateShelfLayout({
   crate,
-  interactive = false,
-  onSelectCrate,
-  previewCount = 4,
+  previewCount,
+  headerSize = "genre",
   meta,
   openLabel,
-  headerSize = "genre",
-  isHovered: isHoveredOverride,
-  tactileThumbnails = false,
-  className = "",
-}: CrateShelfProps) {
-  const hasTactileRoot = interactive || isHoveredOverride !== undefined
-  const { isHovered: internalHovered, isPressed, handlers } = useTactileHover()
-  const isHovered = isHoveredOverride ?? internalHovered
-  const innerHoverScale = 1 + (SCALE_HOVER - 1) / 2
-  const nameClass = headerSize === "featured" ? "text-base font-semibold" : "text-sm font-semibold"
+  isHovered,
+  interactive,
+  onSelectCrate,
+  tactileThumbnails,
+  gridCols,
+  headerProps,
+}: {
+  crate: Crate;
+  previewCount: number;
+  headerSize?: "featured" | "genre";
+  meta?: string;
+  openLabel?: string;
+  isHovered: boolean;
+  interactive: boolean;
+  onSelectCrate?: (slug: string, startIndex?: number) => void;
+  tactileThumbnails: boolean;
+  gridCols: number;
+  headerProps: React.HTMLAttributes<HTMLDivElement>;
+}) {
+  const innerHoverScale = 1 + (SCALE_HOVER - 1) / 2;
+  const nameClass = headerSize === "featured" ? "text-base font-semibold" : "text-sm font-semibold";
 
   const headerContent = (
     <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-1">
-      <span className={`mc-section-name ${nameClass} truncate flex-1`}>
-        {crate.name}
-      </span>
+      <span className={`mc-section-name ${nameClass} truncate flex-1`}>{crate.name}</span>
       <div className="flex items-center gap-2 flex-shrink-0">
         {interactive && openLabel ? (
           <motion.span
@@ -79,53 +69,24 @@ export default function CrateShelf({
         <span className="mc-section-count text-xs">{meta ?? crate.count}</span>
       </div>
     </div>
-  )
-
-  const handleSelectCrate = () => {
-    onSelectCrate?.(crate.slug)
-  }
+  );
 
   const handleSelectRecord = (index: number, e: React.MouseEvent) => {
-    e.stopPropagation()
-    onSelectCrate?.(crate.slug, index)
-  }
+    e.stopPropagation();
+    onSelectCrate?.(crate.slug, index);
+  };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if ((e.target as HTMLElement).closest("button, a")) return
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault()
-      handleSelectCrate()
-    }
-  }
-
-  // Determine grid columns: 2 for 4 or fewer previews, 3 for 6,
-  // up to auto-fill for larger counts
-  const gridCols = previewCount <= 4 ? 2 : previewCount <= 6 ? 3 : 4
-
-  const shelfContent = (
+  return (
     <>
       {/* Header */}
-      <div className="px-3 pt-3 pb-1.5">
-        {interactive ? (
-          <div
-            role="button"
-            tabIndex={0}
-            onClick={handleSelectCrate}
-            onKeyDown={handleKeyDown}
-            className="cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-1 focus-visible:ring-offset-mc-bg-card"
-            aria-label={`Open ${crate.name}`}
-          >
-            {headerContent}
-          </div>
-        ) : (
-          headerContent
-        )}
+      <div className="px-3 pt-3 pb-1.5" {...headerProps}>
+        {headerContent}
       </div>
 
       {/* Record grid */}
       {crate.records.length > 0 ? (
         <div
-          className={`grid gap-1.5 px-3 pb-3 pt-1.5`}
+          className="grid gap-1.5 px-3 pb-3 pt-1.5"
           style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
         >
           {crate.records.slice(0, previewCount).map((record, i) =>
@@ -141,16 +102,16 @@ export default function CrateShelf({
                   animate={{ scale: isHovered ? innerHoverScale : 1 }}
                   transition={springTactile}
                 >
-                  <RecordTile listing={record} imageLoading="lazy" tactileHover={tactileThumbnails} />
+                  <RecordTile
+                    listing={record}
+                    imageLoading="lazy"
+                    tactileHover={tactileThumbnails}
+                  />
                 </motion.div>
               </button>
             ) : (
-              <RecordTile
-                key={record.id}
-                listing={record}
-                imageLoading="lazy"
-              />
-            )
+              <RecordTile key={record.id} listing={record} imageLoading="lazy" />
+            ),
           )}
         </div>
       ) : (
@@ -159,28 +120,109 @@ export default function CrateShelf({
         </div>
       )}
     </>
-  )
+  );
+}
 
-  if (!hasTactileRoot) {
-    return (
-      <div
-        className={`flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left ${className}`}
-      >
-        {shelfContent}
-      </div>
-    )
-  }
+// ── Static variant ──────────────────────────────────────────────
+
+function StaticCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
+  const { crate, previewCount = 4, meta, headerSize = "genre", tactileThumbnails = false } = params;
+  const gridCols = previewCount <= 4 ? 2 : previewCount <= 6 ? 3 : 4;
+
+  return (
+    <div className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left">
+      <CrateShelfLayout
+        crate={crate}
+        previewCount={previewCount}
+        meta={meta}
+        headerSize={headerSize}
+        isHovered={false}
+        interactive={false}
+        tactileThumbnails={tactileThumbnails}
+        gridCols={gridCols}
+        headerProps={{}}
+      />
+    </div>
+  );
+}
+
+// ── Interactive variant ─────────────────────────────────────────
+
+function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
+  const {
+    crate,
+    onSelectCrate,
+    previewCount = 4,
+    meta,
+    openLabel,
+    headerSize = "genre",
+    tactileThumbnails = false,
+  } = params;
+  const gridCols = previewCount <= 4 ? 2 : previewCount <= 6 ? 3 : 4;
+
+  const { isHovered, isPressed, handlers } = useTactileHover();
+
+  const handleSelectCrate = () => {
+    onSelectCrate?.(crate.slug);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.target as HTMLElement).closest("button, a")) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleSelectCrate();
+    }
+  };
 
   return (
     <motion.div
-      className={`flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left ${className}`}
+      className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left"
       animate={{
         scale: isPressed ? 0.99 : isHovered ? 1.008 : 1,
       }}
       transition={isPressed ? springPress : springTactile}
       {...handlers}
     >
-      {shelfContent}
+      <CrateShelfLayout
+        crate={crate}
+        previewCount={previewCount}
+        meta={meta}
+        openLabel={openLabel}
+        headerSize={headerSize}
+        isHovered={isHovered}
+        interactive={true}
+        onSelectCrate={onSelectCrate}
+        tactileThumbnails={tactileThumbnails}
+        gridCols={gridCols}
+        headerProps={{
+          role: "button",
+          tabIndex: 0,
+          onClick: handleSelectCrate,
+          onKeyDown: handleKeyDown,
+          className:
+            "cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-1 focus-visible:ring-offset-mc-bg-card",
+          "aria-label": `Open ${crate.name}`,
+        }}
+      />
     </motion.div>
-  )
+  );
 }
+
+// ── Public component ────────────────────────────────────────────
+
+/**
+ * A visual crate/shelf layout — name header + grid of RecordTile
+ * thumbnails. Delegates to StaticCrateShelf or InteractiveCrateShelf
+ * based on the `interactive` prop.
+ */
+export default function CrateShelf(props: CrateShelfProps) {
+  const { interactive = false, ...rest } = props;
+
+  if (interactive) {
+    return <InteractiveCrateShelf {...rest} />;
+  }
+
+  return <StaticCrateShelf {...rest} />;
+}
+
+export { StaticCrateShelf };

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -127,14 +127,34 @@ function CrateShelfLayout({
   );
 }
 
+function gridColumnCount(previewCount: number) {
+  if (previewCount <= 4) return 2;
+  if (previewCount <= 6) return 3;
+
+  return 4;
+}
+
 // ── Static variant ──────────────────────────────────────────────
 
 function StaticCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
-  const { crate, previewCount = 4, meta, headerSize = "genre", tactileThumbnails = false } = params;
-  const gridCols = previewCount <= 4 ? 2 : previewCount <= 6 ? 3 : 4;
+  const {
+    crate,
+    previewCount = 4,
+    meta,
+    headerSize = "genre",
+    tactileThumbnails = false,
+    className,
+  } = params;
+  const gridCols = gridColumnCount(previewCount);
+  const containerClassName = [
+    "flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <div className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left">
+    <div className={containerClassName}>
       <CrateShelfLayout
         crate={crate}
         previewCount={previewCount}
@@ -164,7 +184,7 @@ function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
     className,
     isHovered: externalHovered,
   } = params;
-  const gridCols = previewCount <= 4 ? 2 : previewCount <= 6 ? 3 : 4;
+  const gridCols = gridColumnCount(previewCount);
 
   // When wrapped by CrateCard (or another parent that manages hover), use the
   // external hover state. Otherwise, compute our own.
@@ -241,5 +261,3 @@ export default function CrateShelf(props: CrateShelfProps) {
 
   return <StaticCrateShelf {...rest} />;
 }
-
-export { StaticCrateShelf };

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -21,10 +21,6 @@ export interface CrateShelfProps {
   headerSize?: "featured" | "genre";
   /** When true, enables thumbnail hover scale on non-compact viewports. */
   tactileThumbnails?: boolean;
-  /** Additional class for the outer container (used by CrateCard to strip border). */
-  className?: string;
-  /** External hover state override — when CrateCard wraps this shelf. */
-  isHovered?: boolean;
 }
 
 // ── Shared layout skeleton ─────────────────────────────────────
@@ -161,23 +157,10 @@ function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
     openLabel,
     headerSize = "genre",
     tactileThumbnails = false,
-    className,
-    isHovered: externalHovered,
   } = params;
   const gridCols = previewCount <= 4 ? 2 : previewCount <= 6 ? 3 : 4;
 
-  // When wrapped by CrateCard (or another parent that manages hover), use the
-  // external hover state. Otherwise, compute our own.
-  const ownsHover = externalHovered === undefined;
-  const internal = useTactileHover();
-  const isHovered = ownsHover ? internal.isHovered : externalHovered!;
-  const isPressed = ownsHover ? internal.isPressed : false;
-  const containerClassName = [
-    "flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left",
-    className,
-  ]
-    .filter(Boolean)
-    .join(" ");
+  const { isHovered, isPressed, handlers } = useTactileHover();
 
   const handleSelectCrate = () => {
     onSelectCrate?.(crate.slug);
@@ -193,12 +176,12 @@ function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
 
   return (
     <motion.div
-      className={containerClassName}
+      className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left"
       animate={{
         scale: isPressed ? 0.99 : isHovered ? 1.008 : 1,
       }}
       transition={isPressed ? springPress : springTactile}
-      {...(ownsHover ? internal.handlers : {})}
+      {...handlers}
     >
       <CrateShelfLayout
         crate={crate}

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -21,6 +21,10 @@ export interface CrateShelfProps {
   headerSize?: "featured" | "genre";
   /** When true, enables thumbnail hover scale on non-compact viewports. */
   tactileThumbnails?: boolean;
+  /** Additional class for the outer container (used by CrateCard to strip border). */
+  className?: string;
+  /** External hover state override — when CrateCard wraps this shelf. */
+  isHovered?: boolean;
 }
 
 // ── Shared layout skeleton ─────────────────────────────────────
@@ -36,7 +40,7 @@ function CrateShelfLayout({
   onSelectCrate,
   tactileThumbnails,
   gridCols,
-  headerProps,
+  headerProps: { className: headerClassName, ...headerProps },
 }: {
   crate: Crate;
   previewCount: number;
@@ -79,7 +83,7 @@ function CrateShelfLayout({
   return (
     <>
       {/* Header */}
-      <div className="px-3 pt-3 pb-1.5" {...headerProps}>
+      <div className={`px-3 pt-3 pb-1.5 ${headerClassName ?? ""}`} {...headerProps}>
         {headerContent}
       </div>
 
@@ -157,10 +161,23 @@ function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
     openLabel,
     headerSize = "genre",
     tactileThumbnails = false,
+    className,
+    isHovered: externalHovered,
   } = params;
   const gridCols = previewCount <= 4 ? 2 : previewCount <= 6 ? 3 : 4;
 
-  const { isHovered, isPressed, handlers } = useTactileHover();
+  // When wrapped by CrateCard (or another parent that manages hover), use the
+  // external hover state. Otherwise, compute our own.
+  const ownsHover = externalHovered === undefined;
+  const internal = useTactileHover();
+  const isHovered = ownsHover ? internal.isHovered : externalHovered!;
+  const isPressed = ownsHover ? internal.isPressed : false;
+  const containerClassName = [
+    "flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   const handleSelectCrate = () => {
     onSelectCrate?.(crate.slug);
@@ -176,12 +193,12 @@ function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
 
   return (
     <motion.div
-      className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left"
+      className={containerClassName}
       animate={{
         scale: isPressed ? 0.99 : isHovered ? 1.008 : 1,
       }}
       transition={isPressed ? springPress : springTactile}
-      {...handlers}
+      {...(ownsHover ? internal.handlers : {})}
     >
       <CrateShelfLayout
         crate={crate}

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -21,6 +21,10 @@ export interface CrateShelfProps {
   headerSize?: "featured" | "genre";
   /** When true, enables thumbnail hover scale on non-compact viewports. */
   tactileThumbnails?: boolean;
+  /** Additional class for the outer container (used by CrateCard to strip border). */
+  className?: string;
+  /** External hover state override — when CrateCard wraps this shelf. */
+  isHovered?: boolean;
 }
 
 // ── Shared layout skeleton ─────────────────────────────────────
@@ -157,10 +161,23 @@ function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
     openLabel,
     headerSize = "genre",
     tactileThumbnails = false,
+    className,
+    isHovered: externalHovered,
   } = params;
   const gridCols = previewCount <= 4 ? 2 : previewCount <= 6 ? 3 : 4;
 
-  const { isHovered, isPressed, handlers } = useTactileHover();
+  // When wrapped by CrateCard (or another parent that manages hover), use the
+  // external hover state. Otherwise, compute our own.
+  const ownsHover = externalHovered === undefined;
+  const internal = useTactileHover();
+  const isHovered = ownsHover ? internal.isHovered : externalHovered!;
+  const isPressed = ownsHover ? internal.isPressed : false;
+  const containerClassName = [
+    "flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   const handleSelectCrate = () => {
     onSelectCrate?.(crate.slug);
@@ -176,12 +193,12 @@ function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
 
   return (
     <motion.div
-      className="flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left"
+      className={containerClassName}
       animate={{
         scale: isPressed ? 0.99 : isHovered ? 1.008 : 1,
       }}
       transition={isPressed ? springPress : springTactile}
-      {...handlers}
+      {...(ownsHover ? internal.handlers : {})}
     >
       <CrateShelfLayout
         crate={crate}

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -5,12 +5,8 @@ import { useTactileHover } from "@/hooks/use_tactile_hover";
 import { springTactile, springPress, SCALE_HOVER } from "@/lib/motion_tokens";
 import type { Crate } from "../types/inertia";
 
-export interface CrateShelfProps {
+interface BaseCrateShelfProps {
   crate: Crate;
-  /** When true, header and thumbnails become clickable for crate navigation. */
-  interactive?: boolean;
-  /** Callback for crate selection. Receives slug and optional record index. */
-  onSelectCrate?: (slug: string, startIndex?: number) => void;
   /** Maximum number of record thumbnails to show. Defaults to 4. */
   previewCount?: number;
   /** Optional meta text shown beside the crate name (e.g. today's date). */
@@ -23,9 +19,23 @@ export interface CrateShelfProps {
   tactileThumbnails?: boolean;
   /** Additional class for the outer container (used by CrateCard to strip border). */
   className?: string;
+}
+
+interface StaticCrateShelfProps extends BaseCrateShelfProps {
+  interactive?: false;
+  onSelectCrate?: never;
+  isHovered?: never;
+}
+
+interface InteractiveCrateShelfProps extends BaseCrateShelfProps {
+  interactive: true;
+  /** Callback for crate selection. Receives slug and optional record index. */
+  onSelectCrate: (slug: string, startIndex?: number) => void;
   /** External hover state override — when CrateCard wraps this shelf. */
   isHovered?: boolean;
 }
+
+export type CrateShelfProps = StaticCrateShelfProps | InteractiveCrateShelfProps;
 
 // ── Shared layout skeleton ─────────────────────────────────────
 
@@ -136,7 +146,7 @@ function gridColumnCount(previewCount: number) {
 
 // ── Static variant ──────────────────────────────────────────────
 
-function StaticCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
+function StaticCrateShelf(params: StaticCrateShelfProps) {
   const {
     crate,
     previewCount = 4,
@@ -172,7 +182,7 @@ function StaticCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
 
 // ── Interactive variant ─────────────────────────────────────────
 
-function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
+function InteractiveCrateShelf(params: InteractiveCrateShelfProps) {
   const {
     crate,
     onSelectCrate,
@@ -253,11 +263,9 @@ function InteractiveCrateShelf(params: Omit<CrateShelfProps, "interactive">) {
  * based on the `interactive` prop.
  */
 export default function CrateShelf(props: CrateShelfProps) {
-  const { interactive = false, ...rest } = props;
-
-  if (interactive) {
-    return <InteractiveCrateShelf {...rest} />;
+  if (props.interactive) {
+    return <InteractiveCrateShelf {...props} />;
   }
 
-  return <StaticCrateShelf {...rest} />;
+  return <StaticCrateShelf {...props} />;
 }

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -39,31 +39,40 @@ export type CrateShelfProps = StaticCrateShelfProps | InteractiveCrateShelfProps
 
 // ── Shared layout skeleton ─────────────────────────────────────
 
-function CrateShelfLayout({
-  crate,
-  previewCount,
-  headerSize = "genre",
-  meta,
-  openLabel,
-  isHovered,
-  interactive,
-  onSelectCrate,
-  tactileThumbnails,
-  gridCols,
-  headerProps: { className: headerClassName, ...headerProps },
-}: {
-  crate: Crate;
-  previewCount: number;
+interface ShelfHeaderConfig {
   headerSize?: "featured" | "genre";
   meta?: string;
   openLabel?: string;
-  isHovered: boolean;
+  previewCount: number;
+}
+
+interface ShelfInteractionConfig {
   interactive: boolean;
   onSelectCrate?: (slug: string, startIndex?: number) => void;
+  isHovered: boolean;
   tactileThumbnails: boolean;
+}
+
+interface ShelfGridConfig {
   gridCols: number;
+}
+
+function CrateShelfLayout({
+  crate,
+  header,
+  interaction,
+  grid,
+  headerProps: { className: headerClassName, ...headerProps },
+}: {
+  crate: Crate;
+  header: ShelfHeaderConfig;
+  interaction: ShelfInteractionConfig;
+  grid: ShelfGridConfig;
   headerProps: React.HTMLAttributes<HTMLDivElement>;
 }) {
+  const { headerSize = "genre", meta, openLabel, previewCount } = header;
+  const { interactive, onSelectCrate, isHovered, tactileThumbnails } = interaction;
+  const { gridCols } = grid;
   const innerHoverScale = 1 + (SCALE_HOVER - 1) / 2;
   const nameClass = headerSize === "featured" ? "text-base font-semibold" : "text-sm font-semibold";
 
@@ -167,13 +176,14 @@ function StaticCrateShelf(params: StaticCrateShelfProps) {
     <div className={containerClassName}>
       <CrateShelfLayout
         crate={crate}
-        previewCount={previewCount}
-        meta={meta}
-        headerSize={headerSize}
-        isHovered={false}
-        interactive={false}
-        tactileThumbnails={tactileThumbnails}
-        gridCols={gridCols}
+        header={{ headerSize, meta, previewCount }}
+        interaction={{
+          interactive: false,
+          isHovered: false,
+          onSelectCrate: undefined,
+          tactileThumbnails,
+        }}
+        grid={{ gridCols }}
         headerProps={{}}
       />
     </div>
@@ -232,15 +242,9 @@ function InteractiveCrateShelf(params: InteractiveCrateShelfProps) {
     >
       <CrateShelfLayout
         crate={crate}
-        previewCount={previewCount}
-        meta={meta}
-        openLabel={openLabel}
-        headerSize={headerSize}
-        isHovered={isHovered}
-        interactive={true}
-        onSelectCrate={onSelectCrate}
-        tactileThumbnails={tactileThumbnails}
-        gridCols={gridCols}
+        header={{ headerSize, meta, openLabel, previewCount }}
+        interaction={{ interactive: true, onSelectCrate, isHovered, tactileThumbnails }}
+        grid={{ gridCols }}
         headerProps={{
           role: "button",
           tabIndex: 0,

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -129,7 +129,6 @@ function CrateHeader({
 
 interface CardStackProps {
   isCompact: boolean;
-  records: { id: number; thumbnail_url?: string | null; cover_image_url?: string | null }[];
   visibleRecords: ReturnType<typeof buildCrateWindow<Listing>>;
   activeSlug: string;
   prefersReducedMotion: boolean;
@@ -470,7 +469,6 @@ export default function CrateView({
         <div className="flex flex-col">
           <CardStack
             isCompact={isCompact}
-            records={records}
             visibleRecords={visibleRecords}
             activeSlug={activeSlug}
             prefersReducedMotion={prefersReducedMotion}

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -142,17 +142,177 @@ interface CardStackProps {
   }) => void;
 }
 
-function CardStack({
-  isCompact,
+function HintCardStack({
   visibleRecords,
+  prefersReducedMotion,
+}: Pick<CardStackProps, "visibleRecords" | "prefersReducedMotion">) {
+  return (
+    <>
+      {visibleRecords
+        .filter((s) => !s.isActive)
+        .map((slot) => {
+          const depth = Math.abs(slot.offset);
+          const hintUrl = slot.record.thumbnail_url ?? slot.record.cover_image_url;
+          const baseX = slot.offset * 16;
+          const baseY = depth * 12;
+          const baseRotate = slot.offset * -4;
+          const scale = 1 - depth * 0.045;
+
+          return (
+            <div
+              key={`hint-${slot.record.id}`}
+              aria-hidden="true"
+              data-riffle-slot={slot.offset}
+              className="absolute inset-0 rounded-lg overflow-hidden border border-mc-border bg-mc-bg-raised shadow-lg pointer-events-none"
+              style={{
+                ...compositedLayerStyle,
+                zIndex: 10 - depth,
+                opacity: 0.38,
+                transform: `translate(${baseX}px, ${baseY}px) rotate(${baseRotate}deg) scale(${scale})`,
+                transition: prefersReducedMotion
+                  ? "transform 0.01s ease-out, opacity 0.01s ease-out"
+                  : "transform 0.2s ease-out, opacity 0.2s ease-out",
+              }}
+            >
+              {hintUrl ? (
+                <img
+                  src={hintUrl}
+                  alt=""
+                  className="w-full h-full object-cover saturate-75"
+                  draggable={false}
+                  loading="lazy"
+                  decoding="async"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-mc-text-dim text-5xl">
+                  ♪
+                </div>
+              )}
+              <div className="absolute inset-0 bg-mc-bg/35" />
+            </div>
+          );
+        })}
+    </>
+  );
+}
+
+function ActiveRecordCard({
+  slot,
+  isCompact,
   activeSlug,
   prefersReducedMotion,
   direction,
-  showGestureHint,
-  total,
   dragRotationRef,
   handleDragEnd,
-}: CardStackProps) {
+}: Pick<
+  CardStackProps,
+  "isCompact" | "activeSlug" | "prefersReducedMotion" | "direction" | "dragRotationRef" | "handleDragEnd"
+> & {
+  slot: ReturnType<typeof buildCrateWindow<Listing>>[number];
+}) {
+  return (
+    <motion.div
+      key={`active-${slot.record.id}`}
+      custom={direction.current}
+      variants={{
+        initial: (d: RiffleDirection) => riffleActiveCardMotion(d, prefersReducedMotion).initial,
+        animate: { opacity: 1, y: 0, rotate: 0, scale: 1 },
+        exit: (d: RiffleDirection) => riffleActiveCardMotion(d, prefersReducedMotion).exit,
+      }}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      transition={
+        prefersReducedMotion
+          ? reducedMotionTransition
+          : isCompact
+            ? transitionCrate
+            : transitionCrateDesktop
+      }
+      className="absolute inset-0"
+      style={{ ...activeLayerStyle, zIndex: 30 }}
+    >
+      <motion.div
+        ref={dragRotationRef}
+        data-testid="crate-drag-surface"
+        className="w-full h-full"
+        style={{
+          touchAction: "none",
+          willChange: "transform",
+          backfaceVisibility: "hidden",
+          WebkitBackfaceVisibility: "hidden",
+          rotate: "var(--drag-rotate, 0deg)",
+        }}
+        drag
+        dragConstraints={{ left: 0, right: 0, top: -180, bottom: 180 }}
+        dragElastic={0.28}
+        dragMomentum={false}
+        dragSnapToOrigin
+        whileDrag={prefersReducedMotion ? undefined : { scale: 0.985 }}
+        onDrag={(_, info) => {
+          dragRotationRef.current?.style.setProperty(
+            "--drag-rotate",
+            `${info.offset.x * ROTATION_FACTOR}deg`,
+          );
+        }}
+        onDragEnd={(_e, info) => {
+          dragRotationRef.current?.style.setProperty("--drag-rotate", "0deg");
+          handleDragEnd(info);
+        }}
+      >
+        {slot.record.thumbnail_url && (
+          <div className="absolute inset-0 rounded-lg overflow-hidden z-0 pointer-events-none">
+            <img
+              src={slot.record.thumbnail_url}
+              alt=""
+              className="w-full h-full object-cover saturate-75"
+              style={{ filter: "blur(8px)" }}
+              draggable={false}
+              onError={(e) => {
+                (e.currentTarget as HTMLElement).style.display = "none";
+              }}
+            />
+          </div>
+        )}
+        <RecordCard
+          listing={slot.record}
+          resetKey={`${activeSlug}-${slot.record.id}`}
+          className="relative z-10 rounded-lg"
+          imageLoading="eager"
+          disableFlip={!isCompact}
+          framed
+        />
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function GestureHintOverlay({
+  isCompact,
+  showGestureHint,
+  total,
+  prefersReducedMotion,
+}: Pick<CardStackProps, "isCompact" | "showGestureHint" | "total" | "prefersReducedMotion">) {
+  if (!isCompact) return null;
+  if (!showGestureHint) return null;
+  if (!isLessonEligible({ isCompact, isPopulated: total > 0 })) return null;
+
+  return <GhostFingerCue reducedMotion={prefersReducedMotion} />;
+}
+
+function CardStack(props: CardStackProps) {
+  const {
+    isCompact,
+    visibleRecords,
+    activeSlug,
+    prefersReducedMotion,
+    direction,
+    showGestureHint,
+    total,
+    dragRotationRef,
+    handleDragEnd,
+  } = props;
+
   return (
     <>
       <div
@@ -172,138 +332,31 @@ function CardStack({
             height: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
           }}
         >
-          {visibleRecords
-            .filter((s) => !s.isActive)
-            .map((slot) => {
-              const depth = Math.abs(slot.offset);
-              const hintUrl = slot.record.thumbnail_url ?? slot.record.cover_image_url;
-              const baseX = slot.offset * 16;
-              const baseY = depth * 12;
-              const baseRotate = slot.offset * -4;
-              const scale = 1 - depth * 0.045;
-
-              return (
-                <div
-                  key={`hint-${slot.record.id}`}
-                  aria-hidden="true"
-                  data-riffle-slot={slot.offset}
-                  className="absolute inset-0 rounded-lg overflow-hidden border border-mc-border bg-mc-bg-raised shadow-lg pointer-events-none"
-                  style={{
-                    ...compositedLayerStyle,
-                    zIndex: 10 - depth,
-                    opacity: 0.38,
-                    transform: `translate(${baseX}px, ${baseY}px) rotate(${baseRotate}deg) scale(${scale})`,
-                    transition: prefersReducedMotion
-                      ? "transform 0.01s ease-out, opacity 0.01s ease-out"
-                      : "transform 0.2s ease-out, opacity 0.2s ease-out",
-                  }}
-                >
-                  {hintUrl ? (
-                    <img
-                      src={hintUrl}
-                      alt=""
-                      className="w-full h-full object-cover saturate-75"
-                      draggable={false}
-                      loading="lazy"
-                      decoding="async"
-                    />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center text-mc-text-dim text-5xl">
-                      ♪
-                    </div>
-                  )}
-                  <div className="absolute inset-0 bg-mc-bg/35" />
-                </div>
-              );
-            })}
+          <HintCardStack visibleRecords={visibleRecords} prefersReducedMotion={prefersReducedMotion} />
 
           <AnimatePresence initial={!prefersReducedMotion} custom={direction.current}>
             {visibleRecords
               .filter((s) => s.isActive)
               .map((slot) => (
-                <motion.div
+                <ActiveRecordCard
                   key={`active-${slot.record.id}`}
-                  custom={direction.current}
-                  variants={{
-                    initial: (d: RiffleDirection) =>
-                      riffleActiveCardMotion(d, prefersReducedMotion).initial,
-                    animate: { opacity: 1, y: 0, rotate: 0, scale: 1 },
-                    exit: (d: RiffleDirection) =>
-                      riffleActiveCardMotion(d, prefersReducedMotion).exit,
-                  }}
-                  initial="initial"
-                  animate="animate"
-                  exit="exit"
-                  transition={
-                    prefersReducedMotion
-                      ? reducedMotionTransition
-                      : isCompact
-                        ? transitionCrate
-                        : transitionCrateDesktop
-                  }
-                  className="absolute inset-0"
-                  style={{ ...activeLayerStyle, zIndex: 30 }}
-                >
-                  <motion.div
-                    ref={dragRotationRef}
-                    data-testid="crate-drag-surface"
-                    className="w-full h-full"
-                    style={{
-                      touchAction: "none",
-                      willChange: "transform",
-                      backfaceVisibility: "hidden",
-                      WebkitBackfaceVisibility: "hidden",
-                      rotate: "var(--drag-rotate, 0deg)",
-                    }}
-                    drag
-                    dragConstraints={{ left: 0, right: 0, top: -180, bottom: 180 }}
-                    dragElastic={0.28}
-                    dragMomentum={false}
-                    dragSnapToOrigin
-                    whileDrag={prefersReducedMotion ? undefined : { scale: 0.985 }}
-                    onDrag={(_, info) => {
-                      dragRotationRef.current?.style.setProperty(
-                        "--drag-rotate",
-                        `${info.offset.x * ROTATION_FACTOR}deg`,
-                      );
-                    }}
-                    onDragEnd={(_e, info) => {
-                      dragRotationRef.current?.style.setProperty("--drag-rotate", "0deg");
-                      handleDragEnd(info);
-                    }}
-                  >
-                    {slot.record.thumbnail_url && (
-                      <div className="absolute inset-0 rounded-lg overflow-hidden z-0 pointer-events-none">
-                        <img
-                          src={slot.record.thumbnail_url}
-                          alt=""
-                          className="w-full h-full object-cover saturate-75"
-                          style={{ filter: "blur(8px)" }}
-                          draggable={false}
-                          onError={(e) => {
-                            (e.currentTarget as HTMLElement).style.display = "none";
-                          }}
-                        />
-                      </div>
-                    )}
-                    <RecordCard
-                      listing={slot.record}
-                      resetKey={`${activeSlug}-${slot.record.id}`}
-                      className="relative z-10 rounded-lg"
-                      imageLoading="eager"
-                      disableFlip={!isCompact}
-                      framed
-                    />
-                  </motion.div>
-                </motion.div>
+                  slot={slot}
+                  isCompact={isCompact}
+                  activeSlug={activeSlug}
+                  prefersReducedMotion={prefersReducedMotion}
+                  direction={direction}
+                  dragRotationRef={dragRotationRef}
+                  handleDragEnd={handleDragEnd}
+                />
               ))}
           </AnimatePresence>
 
-          {isCompact &&
-            showGestureHint &&
-            isLessonEligible({ isCompact, isPopulated: total > 0 }) && (
-              <GhostFingerCue reducedMotion={prefersReducedMotion} />
-            )}
+          <GestureHintOverlay
+            isCompact={isCompact}
+            showGestureHint={showGestureHint}
+            total={total}
+            prefersReducedMotion={prefersReducedMotion}
+          />
         </div>
       </div>
     </>

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -426,7 +426,7 @@ export default function CrateView({
     progress,
     dragRotationRef,
     handleDragEnd,
-  } = useCrateNavigation({ total, isCompact, initialIndex: startIndex });
+  } = useCrateNavigation({ total, isCompact, initialIndex: startIndex, resetKey: activeSlug });
 
   usePreload(records, index);
   const visibleRecords = useMemo(

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -1,145 +1,95 @@
-import React, { useState, useCallback, useEffect, useMemo, useRef } from "react"
-import { motion, AnimatePresence } from "framer-motion"
-import CrateTabs from "./crate_tabs"
-import GhostFingerCue from "./ghost_finger_cue"
-import RecordCard from "./record_card"
-import RecordDetails from "./record_details"
-import ScoreBreakdown from "./score_breakdown"
-import { buildCrateWindow } from "../lib/crate_window"
+import React, { useMemo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import CrateTabs from "./crate_tabs";
+import GhostFingerCue from "./ghost_finger_cue";
+import RecordCard from "./record_card";
+import RecordDetails from "./record_details";
+import ScoreBreakdown from "./score_breakdown";
+import BackButton from "./back_button";
+import { buildCrateWindow } from "../lib/crate_window";
 import {
   RIFFLE_LANGUAGE,
   riffleActiveCardMotion,
-  resolveRiffleDrag,
-  resolveRiffleMove,
   type RiffleDirection,
-} from "../lib/riffle_navigation"
-import { useViewport } from "@/hooks/use_viewport"
-import { SCALE_PRESS, springPress, transitionCrate, transitionCrateDesktop, reducedMotionTransition } from "@/lib/motion_tokens"
-import { useReducedMotionContext } from "./storefront_motion_config"
-import { isLessonEligible, markLessonLearned, isLessonLearned } from "../lib/first_swipe_lesson"
-import { usePreload } from "@/hooks/use_preload"
-import type { Crate } from "../types/inertia"
+} from "../lib/riffle_navigation";
+import { useCrateNavigation } from "@/hooks/use_crate_navigation";
+import { useViewport } from "@/hooks/use_viewport";
+import {
+  SCALE_PRESS,
+  springPress,
+  transitionCrate,
+  transitionCrateDesktop,
+  reducedMotionTransition,
+} from "@/lib/motion_tokens";
+import { useReducedMotionContext } from "./storefront_motion_config";
+import { isLessonEligible } from "../lib/first_swipe_lesson";
+import { usePreload } from "@/hooks/use_preload";
+import type { Crate, Listing } from "../types/inertia";
 
 interface Props {
-  crates: Crate[]
-  activeSlug: string
-  startIndex?: number
-  hideTabs?: boolean
-  compactHeaderOwnedByLayout?: boolean
-  onSelectCrate: (slug: string, startIndex?: number) => void
-  onBack?: () => void
+  crates: Crate[];
+  activeSlug: string;
+  startIndex?: number;
+  hideTabs?: boolean;
+  compactHeaderOwnedByLayout?: boolean;
+  onSelectCrate: (slug: string, startIndex?: number) => void;
+  onBack?: () => void;
 }
 
-const ROTATION_FACTOR = 8 / 120 // maps 120px drag to 8deg rotation
-const WINDOW_RADIUS = 2
+// ── Constants ─────────────────────────────────────────────────
+
+const ROTATION_FACTOR = 8 / 120;
+const WINDOW_RADIUS = 2;
 const compositedLayerStyle: React.CSSProperties = {
   willChange: "transform, opacity",
   backfaceVisibility: "hidden",
   WebkitBackfaceVisibility: "hidden",
   contain: "layout paint style",
-}
+};
 const activeLayerStyle: React.CSSProperties = {
   willChange: "transform, opacity",
   backfaceVisibility: "hidden",
   WebkitBackfaceVisibility: "hidden",
+};
+
+// ── Sub-components ───────────────────────────────────────────
+
+interface CrateHeaderProps {
+  isCompact: boolean;
+  onBack?: () => void;
+  crates: Crate[];
+  activeSlug: string;
+  activeCrate: Crate | undefined;
+  total: number;
+  hideTabs: boolean;
+  compactHeaderOwnedByLayout: boolean;
+  onSelectCrate: (slug: string, startIndex?: number) => void;
 }
 
-export default function CrateView({
+function CrateHeader({
+  isCompact,
+  onBack,
   crates,
   activeSlug,
-  startIndex = 0,
-  hideTabs = false,
-  compactHeaderOwnedByLayout = false,
+  activeCrate,
+  total,
+  hideTabs,
+  compactHeaderOwnedByLayout,
   onSelectCrate,
-  onBack,
-}: Props) {
-  const { isCompact } = useViewport()
-  const activeCrate = crates.find((c) => c.slug === activeSlug) ?? crates[0]
-  const records = activeCrate?.records ?? []
-  const total = records.length
-  const [index, setIndex] = useState(startIndex)
-  const [showGestureHint, setShowGestureHint] = useState(() => !isLessonLearned())
-  const [edgeStatus, setEdgeStatus] = useState<string | null>(null)
+}: CrateHeaderProps) {
+  if (isCompact) {
+    if (compactHeaderOwnedByLayout && hideTabs) return null;
 
-  const direction = useRef<RiffleDirection>("deeper")
-  const indexRef = useRef(index)
-  const prefersReducedMotion = useReducedMotionContext()
-  const dragRotationRef = useRef<HTMLDivElement>(null)
-
-  // Keep indexRef in sync so navigate callback reads the latest index
-  // even before React re-renders (critical for rapid keyboard navigation)
-  indexRef.current = index
-
-  useEffect(() => {
-    setIndex(startIndex)
-    // Only re-show the hint if the lesson hasn't been learned this session
-    setShowGestureHint(!isLessonLearned())
-    setEdgeStatus(null)
-  }, [activeSlug, startIndex])
-
-  const navigate = useCallback((riffleDirection: RiffleDirection) => {
-    const move = resolveRiffleMove({
-      currentIndex: indexRef.current,
-      total,
-      direction: riffleDirection,
-    })
-
-    if (!move.moved) {
-      setEdgeStatus(RIFFLE_LANGUAGE.edgeStatus[riffleDirection])
-      return
-    }
-
-    direction.current = riffleDirection
-    indexRef.current = move.nextIndex
-    setIndex(move.nextIndex)
-    setShowGestureHint(false)
-    setEdgeStatus(null)
-
-    // Mark the first-swipe lesson learned on successful vertical riffle
-    if (isCompact) {
-      markLessonLearned()
-    }
-  }, [total, isCompact])
-
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    const target = e.target as HTMLElement
-    if (
-      target instanceof HTMLInputElement ||
-      target instanceof HTMLTextAreaElement ||
-      target instanceof HTMLSelectElement ||
-      target.isContentEditable
-    ) return
-    if (document.querySelector('[role="dialog"][aria-modal="true"]')) return
-    if (e.key === "ArrowDown") navigate("deeper")
-    if (e.key === "ArrowUp") navigate("front")
-  }, [navigate])
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKeyDown)
-    return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [handleKeyDown])
-
-  const progress = total > 0 ? ((index + 1) / total) * 100 : 0
-  const activeRecord = records[index]
-
-  const crateHeader = isCompact ? (
-    !compactHeaderOwnedByLayout || !hideTabs ? (
+    return (
       <div className="mb-3">
         <>
           {!compactHeaderOwnedByLayout && (
             <div className="flex items-center gap-3">
-              {onBack && (
-                <button
-                  type="button"
-                  onClick={onBack}
-                  className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-mc-border bg-mc-bg-raised text-lg leading-none text-mc-text-dim transition-[color,border-color,transform] hover:border-mc-accent hover:text-mc-accent active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
-                  aria-label="Back to store"
-                >
-                  <span aria-hidden="true" className="-translate-y-px">←</span>
-                </button>
-              )}
+              {onBack && <BackButton variant="icon" onClick={onBack} label="store" />}
               <div className="min-w-0 flex-1">
-                <h1 className="truncate text-base font-semibold leading-tight">{activeCrate?.name}</h1>
+                <h1 className="truncate text-base font-semibold leading-tight">
+                  {activeCrate?.name}
+                </h1>
                 <div className="text-[11px] uppercase tracking-[0.12em] text-mc-text-dim">
                   {total === 1 ? "1 record" : `${total} records`}
                 </div>
@@ -153,70 +103,59 @@ export default function CrateView({
           )}
         </>
       </div>
-    ) : null
-  ) : (
-    <div className="mb-4">
-        <>
-          <div className="flex items-center gap-3 border-b border-mc-border pb-2 mb-3">
-            {onBack && (
-              <button
-                type="button"
-                onClick={onBack}
-                className="flex items-center gap-1.5 text-xs font-medium text-mc-text-dim bg-mc-bg-raised border border-mc-border rounded-lg hover:border-mc-accent hover:text-mc-accent transition-colors whitespace-nowrap py-1.5 px-3 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
-                aria-label="Back to store"
-              >
-                ← Store
-              </button>
-            )}
-            {onBack && !hideTabs && <div className="w-px self-stretch bg-mc-border" />}
-            <div className="min-w-0 flex-1">
-              <h1 className="truncate text-base font-semibold leading-tight">{activeCrate?.name}</h1>
-              <div className="text-[11px] uppercase tracking-[0.12em] text-mc-text-dim">
-                {total === 1 ? "1 record" : `${total} records`}
-              </div>
-            </div>
-          </div>
-          {!hideTabs && (
-            <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
-          )}
-        </>
-    </div>
-  )
-
-  usePreload(records, index)
-  const visibleRecords = useMemo(
-    () => buildCrateWindow(records, index, WINDOW_RADIUS),
-    [records, index],
-  )
-
-  const handleDragEnd = useCallback((
-    info: { offset: { x: number; y: number }; velocity: { x: number; y: number } }
-  ) => {
-    const riffleDirection = resolveRiffleDrag({
-      offsetX: info.offset.x,
-      offsetY: info.offset.y,
-      velocityY: info.velocity.y,
-    })
-
-    if (riffleDirection) {
-      navigate(riffleDirection)
-    }
-    // Horizontal swipes return no direction from resolveRiffleDrag, so
-    // nothing happens here — the cue stays floating, the record stays put.
-  }, [navigate])
-
-  if (!activeCrate || total === 0) {
-    return (
-      <div>
-        {crateHeader}
-        <div className="py-16 text-center text-mc-text-dim text-sm">No records in this crate yet.</div>
-      </div>
-    )
+    );
   }
 
-  const cardStack = (
+  return (
+    <div className="mb-4">
+      <>
+        <div className="flex items-center gap-3 border-b border-mc-border pb-2 mb-3">
+          {onBack && <BackButton variant="text" onClick={onBack} label="store" />}
+          {onBack && !hideTabs && <div className="w-px self-stretch bg-mc-border" />}
+          <div className="min-w-0 flex-1">
+            <h1 className="truncate text-base font-semibold leading-tight">{activeCrate?.name}</h1>
+            <div className="text-[11px] uppercase tracking-[0.12em] text-mc-text-dim">
+              {total === 1 ? "1 record" : `${total} records`}
+            </div>
+          </div>
+        </div>
+        {!hideTabs && (
+          <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
+        )}
+      </>
+    </div>
+  );
+}
+
+interface CardStackProps {
+  isCompact: boolean;
+  records: { id: number; thumbnail_url?: string | null; cover_image_url?: string | null }[];
+  visibleRecords: ReturnType<typeof buildCrateWindow<Listing>>;
+  activeSlug: string;
+  prefersReducedMotion: boolean;
+  direction: React.RefObject<RiffleDirection>;
+  showGestureHint: boolean;
+  total: number;
+  dragRotationRef: React.RefObject<HTMLDivElement | null>;
+  handleDragEnd: (info: {
+    offset: { x: number; y: number };
+    velocity: { x: number; y: number };
+  }) => void;
+}
+
+function CardStack({
+  isCompact,
+  visibleRecords,
+  activeSlug,
+  prefersReducedMotion,
+  direction,
+  showGestureHint,
+  total,
+  dragRotationRef,
+  handleDragEnd,
+}: CardStackProps) {
+  return (
     <>
-      {/* Front-riffle crate stack */}
       <div
         data-testid="crate-stack"
         data-viewport={isCompact ? "compact" : "wide"}
@@ -234,137 +173,169 @@ export default function CrateView({
             height: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
           }}
         >
-          {/* Hint cards as plain divs with CSS transitions (compositor thread, no JS cost) */}
-          {visibleRecords.filter((s) => !s.isActive).map((slot) => {
-            const depth = Math.abs(slot.offset)
-            const hintUrl = slot.record.thumbnail_url ?? slot.record.cover_image_url
-            const baseX = slot.offset * 16
-            const baseY = depth * 12
-            const baseRotate = slot.offset * -4
-            const scale = 1 - depth * 0.045
+          {visibleRecords
+            .filter((s) => !s.isActive)
+            .map((slot) => {
+              const depth = Math.abs(slot.offset);
+              const hintUrl = slot.record.thumbnail_url ?? slot.record.cover_image_url;
+              const baseX = slot.offset * 16;
+              const baseY = depth * 12;
+              const baseRotate = slot.offset * -4;
+              const scale = 1 - depth * 0.045;
 
-            return (
-              <div
-                key={`hint-${slot.record.id}`}
-                aria-hidden="true"
-                data-riffle-slot={slot.offset}
-                className="absolute inset-0 rounded-lg overflow-hidden border border-mc-border bg-mc-bg-raised shadow-lg pointer-events-none"
-                style={{
-                  ...compositedLayerStyle,
-                  zIndex: 10 - depth,
-                  opacity: 0.38,
-                  transform: `translate(${baseX}px, ${baseY}px) rotate(${baseRotate}deg) scale(${scale})`,
-                  transition: prefersReducedMotion
-                    ? 'transform 0.01s ease-out, opacity 0.01s ease-out'
-                    : 'transform 0.2s ease-out, opacity 0.2s ease-out',
-                }}
-              >
-                {hintUrl ? (
-                  <img
-                    src={hintUrl}
-                    alt=""
-                    className="w-full h-full object-cover saturate-75"
-                    draggable={false}
-                    loading="lazy"
-                    decoding="async"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-mc-text-dim text-5xl">♪</div>
-                )}
-                <div className="absolute inset-0 bg-mc-bg/35" />
-              </div>
-            )
-          })}
-
-          {/* Active card entry + exit animation via AnimatePresence */}
-          <AnimatePresence
-            initial={!prefersReducedMotion}
-            custom={direction.current}
-          >
-            {visibleRecords.filter((s) => s.isActive).map((slot) => (
-              <motion.div
-                key={`active-${slot.record.id}`}
-                custom={direction.current}
-                variants={{
-                  initial: (d: RiffleDirection) => (
-                    riffleActiveCardMotion(d, prefersReducedMotion).initial
-                  ),
-                  animate: { opacity: 1, y: 0, rotate: 0, scale: 1 },
-                  exit: (d: RiffleDirection) => (
-                    riffleActiveCardMotion(d, prefersReducedMotion).exit
-                  ),
-                }}
-                initial="initial"
-                animate="animate"
-                exit="exit"
-                transition={prefersReducedMotion ? reducedMotionTransition : (isCompact ? transitionCrate : transitionCrateDesktop)}
-                className="absolute inset-0"
-                style={{ ...activeLayerStyle, zIndex: 30 }}
-              >
-                <motion.div
-                  ref={dragRotationRef}
-                  data-testid="crate-drag-surface"
-                  className="w-full h-full"
+              return (
+                <div
+                  key={`hint-${slot.record.id}`}
+                  aria-hidden="true"
+                  data-riffle-slot={slot.offset}
+                  className="absolute inset-0 rounded-lg overflow-hidden border border-mc-border bg-mc-bg-raised shadow-lg pointer-events-none"
                   style={{
-                    touchAction: "none",
-                    willChange: "transform",
-                    backfaceVisibility: "hidden",
-                    WebkitBackfaceVisibility: "hidden",
-                    rotate: 'var(--drag-rotate, 0deg)',
-                  }}
-                  drag
-                  dragConstraints={{ left: 0, right: 0, top: -180, bottom: 180 }}
-                  dragElastic={0.28}
-                  dragMomentum={false}
-                  dragSnapToOrigin
-                  whileDrag={prefersReducedMotion ? undefined : { scale: 0.985 }}
-                  onDrag={(_, info) => {
-                    dragRotationRef.current?.style.setProperty('--drag-rotate', `${info.offset.x * ROTATION_FACTOR}deg`)
-                  }}
-                  onDragEnd={(_e, info) => {
-                    dragRotationRef.current?.style.setProperty('--drag-rotate', '0deg')
-                    handleDragEnd(info)
+                    ...compositedLayerStyle,
+                    zIndex: 10 - depth,
+                    opacity: 0.38,
+                    transform: `translate(${baseX}px, ${baseY}px) rotate(${baseRotate}deg) scale(${scale})`,
+                    transition: prefersReducedMotion
+                      ? "transform 0.01s ease-out, opacity 0.01s ease-out"
+                      : "transform 0.2s ease-out, opacity 0.2s ease-out",
                   }}
                 >
-                  {/* Thumbnail backdrop — visible while full-res loads */}
-                  {slot.record.thumbnail_url && (
-                    <div className="absolute inset-0 rounded-lg overflow-hidden z-0 pointer-events-none">
-                      <img
-                        src={slot.record.thumbnail_url}
-                        alt=""
-                        className="w-full h-full object-cover saturate-75"
-                        style={{ filter: 'blur(8px)' }}
-                        draggable={false}
-                        onError={(e) => {
-                          // Hide backdrop on image load failure to avoid broken-image artifact
-                          ;(e.currentTarget as HTMLElement).style.display = 'none'
-                        }}
-                      />
+                  {hintUrl ? (
+                    <img
+                      src={hintUrl}
+                      alt=""
+                      className="w-full h-full object-cover saturate-75"
+                      draggable={false}
+                      loading="lazy"
+                      decoding="async"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-mc-text-dim text-5xl">
+                      ♪
                     </div>
                   )}
-                  <RecordCard
-                    listing={slot.record}
-                    resetKey={`${activeSlug}-${slot.record.id}`}
-                    className="relative z-10 rounded-lg"
-                    imageLoading="eager"
-                    disableFlip={!isCompact}
-                    framed
-                  />
+                  <div className="absolute inset-0 bg-mc-bg/35" />
+                </div>
+              );
+            })}
+
+          <AnimatePresence initial={!prefersReducedMotion} custom={direction.current}>
+            {visibleRecords
+              .filter((s) => s.isActive)
+              .map((slot) => (
+                <motion.div
+                  key={`active-${slot.record.id}`}
+                  custom={direction.current}
+                  variants={{
+                    initial: (d: RiffleDirection) =>
+                      riffleActiveCardMotion(d, prefersReducedMotion).initial,
+                    animate: { opacity: 1, y: 0, rotate: 0, scale: 1 },
+                    exit: (d: RiffleDirection) =>
+                      riffleActiveCardMotion(d, prefersReducedMotion).exit,
+                  }}
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
+                  transition={
+                    prefersReducedMotion
+                      ? reducedMotionTransition
+                      : isCompact
+                        ? transitionCrate
+                        : transitionCrateDesktop
+                  }
+                  className="absolute inset-0"
+                  style={{ ...activeLayerStyle, zIndex: 30 }}
+                >
+                  <motion.div
+                    ref={dragRotationRef}
+                    data-testid="crate-drag-surface"
+                    className="w-full h-full"
+                    style={{
+                      touchAction: "none",
+                      willChange: "transform",
+                      backfaceVisibility: "hidden",
+                      WebkitBackfaceVisibility: "hidden",
+                      rotate: "var(--drag-rotate, 0deg)",
+                    }}
+                    drag
+                    dragConstraints={{ left: 0, right: 0, top: -180, bottom: 180 }}
+                    dragElastic={0.28}
+                    dragMomentum={false}
+                    dragSnapToOrigin
+                    whileDrag={prefersReducedMotion ? undefined : { scale: 0.985 }}
+                    onDrag={(_, info) => {
+                      dragRotationRef.current?.style.setProperty(
+                        "--drag-rotate",
+                        `${info.offset.x * ROTATION_FACTOR}deg`,
+                      );
+                    }}
+                    onDragEnd={(_e, info) => {
+                      dragRotationRef.current?.style.setProperty("--drag-rotate", "0deg");
+                      handleDragEnd(info);
+                    }}
+                  >
+                    {slot.record.thumbnail_url && (
+                      <div className="absolute inset-0 rounded-lg overflow-hidden z-0 pointer-events-none">
+                        <img
+                          src={slot.record.thumbnail_url}
+                          alt=""
+                          className="w-full h-full object-cover saturate-75"
+                          style={{ filter: "blur(8px)" }}
+                          draggable={false}
+                          onError={(e) => {
+                            (e.currentTarget as HTMLElement).style.display = "none";
+                          }}
+                        />
+                      </div>
+                    )}
+                    <RecordCard
+                      listing={slot.record}
+                      resetKey={`${activeSlug}-${slot.record.id}`}
+                      className="relative z-10 rounded-lg"
+                      imageLoading="eager"
+                      disableFlip={!isCompact}
+                      framed
+                    />
+                  </motion.div>
                 </motion.div>
-              </motion.div>
-            ))}
+              ))}
           </AnimatePresence>
 
-          {/* Ghost-finger lesson cue — overlays the active record card */}
-          {isCompact && showGestureHint && isLessonEligible({ isCompact, isPopulated: total > 0 }) && (
-            <GhostFingerCue reducedMotion={prefersReducedMotion} />
-          )}
+          {isCompact &&
+            showGestureHint &&
+            isLessonEligible({ isCompact, isPopulated: total > 0 }) && (
+              <GhostFingerCue reducedMotion={prefersReducedMotion} />
+            )}
         </div>
       </div>
+    </>
+  );
+}
 
-      {/* Progress bar */}
+interface CrateProgressProps {
+  index: number;
+  total: number;
+  progress: number;
+  edgeStatus: string | null;
+  isCompact: boolean;
+  prefersReducedMotion: boolean;
+  navigate: (dir: RiffleDirection) => void;
+}
+
+function CrateProgress({
+  index,
+  total,
+  progress,
+  edgeStatus,
+  isCompact,
+  prefersReducedMotion,
+  navigate,
+}: CrateProgressProps) {
+  return (
+    <>
       <div className={`w-full max-w-xs sm:max-w-sm mx-auto ${isCompact ? "mt-1 mb-3" : "mb-4"}`}>
-        <div className={`flex items-center justify-between text-[10px] uppercase tracking-[0.14em] text-mc-text-dim select-none ${isCompact ? "mb-1" : "mb-1.5"}`}>
+        <div
+          className={`flex items-center justify-between text-[10px] uppercase tracking-[0.14em] text-mc-text-dim select-none ${isCompact ? "mb-1" : "mb-1.5"}`}
+        >
           <span>{RIFFLE_LANGUAGE.progressStart}</span>
           <span>{RIFFLE_LANGUAGE.progressEnd}</span>
         </div>
@@ -384,7 +355,6 @@ export default function CrateView({
         </div>
       </div>
 
-      {/* Paginator */}
       <div className={`flex items-center justify-center ${isCompact ? "gap-3" : "gap-4 sm:gap-6"}`}>
         <motion.button
           type="button"
@@ -425,28 +395,109 @@ export default function CrateView({
           {edgeStatus}
         </p>
       )}
-
     </>
-  )
+  );
+}
+
+// ── Main component ────────────────────────────────────────────
+
+export default function CrateView({
+  crates,
+  activeSlug,
+  startIndex = 0,
+  hideTabs = false,
+  compactHeaderOwnedByLayout = false,
+  onSelectCrate,
+  onBack,
+}: Props) {
+  const { isCompact } = useViewport();
+  const prefersReducedMotion = useReducedMotionContext();
+  const { activeCrate, records, total } = useMemo(() => {
+    const crate = crates.find((c) => c.slug === activeSlug) ?? crates[0];
+    const recs = crate?.records ?? [];
+    return { activeCrate: crate, records: recs, total: recs.length };
+  }, [crates, activeSlug]);
+
+  const {
+    index,
+    direction,
+    navigate,
+    edgeStatus,
+    showGestureHint,
+    progress,
+    dragRotationRef,
+    handleDragEnd,
+  } = useCrateNavigation({ total, isCompact, initialIndex: startIndex });
+
+  usePreload(records, index);
+  const visibleRecords = useMemo(
+    () => buildCrateWindow<Listing>(records, index, WINDOW_RADIUS),
+    [records, index],
+  );
+
+  const activeRecord = records[index];
+
+  const header = (
+    <CrateHeader
+      isCompact={isCompact}
+      onBack={onBack}
+      crates={crates}
+      activeSlug={activeSlug}
+      activeCrate={activeCrate}
+      total={total}
+      hideTabs={hideTabs}
+      compactHeaderOwnedByLayout={compactHeaderOwnedByLayout}
+      onSelectCrate={onSelectCrate}
+    />
+  );
+
+  if (!activeCrate || total === 0) {
+    return (
+      <div>
+        {header}
+        <div className="py-16 text-center text-mc-text-dim text-sm">
+          No records in this crate yet.
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col">
-      {crateHeader}
+      {header}
 
-      {/* Mobile: single column. Desktop: centered two-column */}
       <div className="md:mx-auto md:w-full md:grid md:grid-cols-[420px_1fr] md:gap-12 md:items-start">
         <div className="flex flex-col">
-          {cardStack}
+          <CardStack
+            isCompact={isCompact}
+            records={records}
+            visibleRecords={visibleRecords}
+            activeSlug={activeSlug}
+            prefersReducedMotion={prefersReducedMotion}
+            direction={direction}
+            showGestureHint={showGestureHint}
+            total={total}
+            dragRotationRef={dragRotationRef}
+            handleDragEnd={handleDragEnd}
+          />
+          <CrateProgress
+            index={index}
+            total={total}
+            progress={progress}
+            edgeStatus={edgeStatus}
+            isCompact={isCompact}
+            prefersReducedMotion={prefersReducedMotion}
+            navigate={navigate}
+          />
         </div>
 
-        {/* Desktop details panel */}
         {activeRecord && (
           <div className="hidden md:flex md:flex-col md:pt-7">
             <RecordDetails listing={activeRecord} direction={direction.current} />
-          <ScoreBreakdown listing={activeRecord} />
+            <ScoreBreakdown listing={activeRecord} />
           </div>
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/app/frontend/components/crate_view.tsx
+++ b/app/frontend/components/crate_view.tsx
@@ -1,30 +1,17 @@
-import React, { useMemo } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import CrateTabs from "./crate_tabs";
-import GhostFingerCue from "./ghost_finger_cue";
-import RecordCard from "./record_card";
+import { useMemo } from "react";
 import RecordDetails from "./record_details";
 import ScoreBreakdown from "./score_breakdown";
-import BackButton from "./back_button";
+import CrateHeader from "./crate_view/crate_header";
+import CardStack from "./crate_view/card_stack";
+import CrateProgress from "./crate_view/crate_progress";
 import { buildCrateWindow } from "../lib/crate_window";
-import {
-  RIFFLE_LANGUAGE,
-  riffleActiveCardMotion,
-  type RiffleDirection,
-} from "../lib/riffle_navigation";
 import { useCrateNavigation } from "@/hooks/use_crate_navigation";
 import { useViewport } from "@/hooks/use_viewport";
-import {
-  SCALE_PRESS,
-  springPress,
-  transitionCrate,
-  transitionCrateDesktop,
-  reducedMotionTransition,
-} from "@/lib/motion_tokens";
 import { useReducedMotionContext } from "./storefront_motion_config";
-import { isLessonEligible } from "../lib/first_swipe_lesson";
 import { usePreload } from "@/hooks/use_preload";
 import type { Crate, Listing } from "../types/inertia";
+
+const WINDOW_RADIUS = 2;
 
 interface Props {
   crates: Crate[];
@@ -36,423 +23,10 @@ interface Props {
   onBack?: () => void;
 }
 
-// ── Constants ─────────────────────────────────────────────────
-
-const ROTATION_FACTOR = 8 / 120;
-const WINDOW_RADIUS = 2;
-const compositedLayerStyle: React.CSSProperties = {
-  willChange: "transform, opacity",
-  backfaceVisibility: "hidden",
-  WebkitBackfaceVisibility: "hidden",
-  contain: "layout paint style",
-};
-const activeLayerStyle: React.CSSProperties = {
-  willChange: "transform, opacity",
-  backfaceVisibility: "hidden",
-  WebkitBackfaceVisibility: "hidden",
-};
-
-// ── Sub-components ───────────────────────────────────────────
-
-interface CrateHeaderProps {
-  isCompact: boolean;
-  onBack?: () => void;
-  crates: Crate[];
-  activeSlug: string;
-  activeCrate: Crate | undefined;
-  total: number;
-  hideTabs: boolean;
-  compactHeaderOwnedByLayout: boolean;
-  onSelectCrate: (slug: string, startIndex?: number) => void;
-}
-
-function CrateHeader({
-  isCompact,
-  onBack,
-  crates,
-  activeSlug,
-  activeCrate,
-  total,
-  hideTabs,
-  compactHeaderOwnedByLayout,
-  onSelectCrate,
-}: CrateHeaderProps) {
-  if (isCompact) {
-    if (compactHeaderOwnedByLayout && hideTabs) return null;
-
-    return (
-      <div className="mb-3">
-        <>
-          {!compactHeaderOwnedByLayout && (
-            <div className="flex items-center gap-3">
-              {onBack && <BackButton variant="icon" onClick={onBack} label="store" />}
-              <div className="min-w-0 flex-1">
-                <h1 className="truncate text-base font-semibold leading-tight">
-                  {activeCrate?.name}
-                </h1>
-                <div className="text-[11px] uppercase tracking-[0.12em] text-mc-text-dim">
-                  {total === 1 ? "1 record" : `${total} records`}
-                </div>
-              </div>
-            </div>
-          )}
-          {!hideTabs && (
-            <div className={`${compactHeaderOwnedByLayout ? "" : "mt-2 "} -mx-1`}>
-              <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} compact />
-            </div>
-          )}
-        </>
-      </div>
-    );
-  }
-
-  return (
-    <div className="mb-4">
-      <>
-        <div className="flex items-center gap-3 border-b border-mc-border pb-2 mb-3">
-          {onBack && <BackButton variant="text" onClick={onBack} label="store" />}
-          {onBack && !hideTabs && <div className="w-px self-stretch bg-mc-border" />}
-          <div className="min-w-0 flex-1">
-            <h1 className="truncate text-base font-semibold leading-tight">{activeCrate?.name}</h1>
-            <div className="text-[11px] uppercase tracking-[0.12em] text-mc-text-dim">
-              {total === 1 ? "1 record" : `${total} records`}
-            </div>
-          </div>
-        </div>
-        {!hideTabs && (
-          <CrateTabs crates={crates} activeSlug={activeSlug} onSelect={onSelectCrate} />
-        )}
-      </>
-    </div>
-  );
-}
-
-interface CardStackProps {
-  isCompact: boolean;
-  visibleRecords: ReturnType<typeof buildCrateWindow<Listing>>;
-  activeSlug: string;
-  prefersReducedMotion: boolean;
-  direction: React.RefObject<RiffleDirection>;
-  showGestureHint: boolean;
-  total: number;
-  dragRotationRef: React.RefObject<HTMLDivElement | null>;
-  handleDragEnd: (info: {
-    offset: { x: number; y: number };
-    velocity: { x: number; y: number };
-  }) => void;
-}
-
-function HintCardStack({
-  visibleRecords,
-  prefersReducedMotion,
-}: Pick<CardStackProps, "visibleRecords" | "prefersReducedMotion">) {
-  return (
-    <>
-      {visibleRecords
-        .filter((s) => !s.isActive)
-        .map((slot) => {
-          const depth = Math.abs(slot.offset);
-          const hintUrl = slot.record.thumbnail_url ?? slot.record.cover_image_url;
-          const baseX = slot.offset * 16;
-          const baseY = depth * 12;
-          const baseRotate = slot.offset * -4;
-          const scale = 1 - depth * 0.045;
-
-          return (
-            <div
-              key={`hint-${slot.record.id}`}
-              aria-hidden="true"
-              data-riffle-slot={slot.offset}
-              className="absolute inset-0 rounded-lg overflow-hidden border border-mc-border bg-mc-bg-raised shadow-lg pointer-events-none"
-              style={{
-                ...compositedLayerStyle,
-                zIndex: 10 - depth,
-                opacity: 0.38,
-                transform: `translate(${baseX}px, ${baseY}px) rotate(${baseRotate}deg) scale(${scale})`,
-                transition: prefersReducedMotion
-                  ? "transform 0.01s ease-out, opacity 0.01s ease-out"
-                  : "transform 0.2s ease-out, opacity 0.2s ease-out",
-              }}
-            >
-              {hintUrl ? (
-                <img
-                  src={hintUrl}
-                  alt=""
-                  className="w-full h-full object-cover saturate-75"
-                  draggable={false}
-                  loading="lazy"
-                  decoding="async"
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-mc-text-dim text-5xl">
-                  ♪
-                </div>
-              )}
-              <div className="absolute inset-0 bg-mc-bg/35" />
-            </div>
-          );
-        })}
-    </>
-  );
-}
-
-function ActiveRecordCard({
-  slot,
-  isCompact,
-  activeSlug,
-  prefersReducedMotion,
-  direction,
-  dragRotationRef,
-  handleDragEnd,
-}: Pick<
-  CardStackProps,
-  "isCompact" | "activeSlug" | "prefersReducedMotion" | "direction" | "dragRotationRef" | "handleDragEnd"
-> & {
-  slot: ReturnType<typeof buildCrateWindow<Listing>>[number];
-}) {
-  return (
-    <motion.div
-      key={`active-${slot.record.id}`}
-      custom={direction.current}
-      variants={{
-        initial: (d: RiffleDirection) => riffleActiveCardMotion(d, prefersReducedMotion).initial,
-        animate: { opacity: 1, y: 0, rotate: 0, scale: 1 },
-        exit: (d: RiffleDirection) => riffleActiveCardMotion(d, prefersReducedMotion).exit,
-      }}
-      initial="initial"
-      animate="animate"
-      exit="exit"
-      transition={
-        prefersReducedMotion
-          ? reducedMotionTransition
-          : isCompact
-            ? transitionCrate
-            : transitionCrateDesktop
-      }
-      className="absolute inset-0"
-      style={{ ...activeLayerStyle, zIndex: 30 }}
-    >
-      <motion.div
-        ref={dragRotationRef}
-        data-testid="crate-drag-surface"
-        className="w-full h-full"
-        style={{
-          touchAction: "none",
-          willChange: "transform",
-          backfaceVisibility: "hidden",
-          WebkitBackfaceVisibility: "hidden",
-          rotate: "var(--drag-rotate, 0deg)",
-        }}
-        drag
-        dragConstraints={{ left: 0, right: 0, top: -180, bottom: 180 }}
-        dragElastic={0.28}
-        dragMomentum={false}
-        dragSnapToOrigin
-        whileDrag={prefersReducedMotion ? undefined : { scale: 0.985 }}
-        onDrag={(_, info) => {
-          dragRotationRef.current?.style.setProperty(
-            "--drag-rotate",
-            `${info.offset.x * ROTATION_FACTOR}deg`,
-          );
-        }}
-        onDragEnd={(_e, info) => {
-          dragRotationRef.current?.style.setProperty("--drag-rotate", "0deg");
-          handleDragEnd(info);
-        }}
-      >
-        {slot.record.thumbnail_url && (
-          <div className="absolute inset-0 rounded-lg overflow-hidden z-0 pointer-events-none">
-            <img
-              src={slot.record.thumbnail_url}
-              alt=""
-              className="w-full h-full object-cover saturate-75"
-              style={{ filter: "blur(8px)" }}
-              draggable={false}
-              onError={(e) => {
-                (e.currentTarget as HTMLElement).style.display = "none";
-              }}
-            />
-          </div>
-        )}
-        <RecordCard
-          listing={slot.record}
-          resetKey={`${activeSlug}-${slot.record.id}`}
-          className="relative z-10 rounded-lg"
-          imageLoading="eager"
-          disableFlip={!isCompact}
-          framed
-        />
-      </motion.div>
-    </motion.div>
-  );
-}
-
-function GestureHintOverlay({
-  isCompact,
-  showGestureHint,
-  total,
-  prefersReducedMotion,
-}: Pick<CardStackProps, "isCompact" | "showGestureHint" | "total" | "prefersReducedMotion">) {
-  if (!isCompact) return null;
-  if (!showGestureHint) return null;
-  if (!isLessonEligible({ isCompact, isPopulated: total > 0 })) return null;
-
-  return <GhostFingerCue reducedMotion={prefersReducedMotion} />;
-}
-
-function CardStack(props: CardStackProps) {
-  const {
-    isCompact,
-    visibleRecords,
-    activeSlug,
-    prefersReducedMotion,
-    direction,
-    showGestureHint,
-    total,
-    dragRotationRef,
-    handleDragEnd,
-  } = props;
-
-  return (
-    <>
-      <div
-        data-testid="crate-stack"
-        data-viewport={isCompact ? "compact" : "wide"}
-        className={`relative z-10 flex items-center justify-center select-none ${
-          isCompact
-            ? "min-h-[min(72svh,360px)] pt-3 pb-8"
-            : "min-h-[390px] md:min-h-[470px] py-5 sm:py-7"
-        }`}
-        style={{ touchAction: "none", overscrollBehavior: "contain" }}
-      >
-        <div
-          className="relative"
-          style={{
-            width: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
-            height: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
-          }}
-        >
-          <HintCardStack visibleRecords={visibleRecords} prefersReducedMotion={prefersReducedMotion} />
-
-          <AnimatePresence initial={!prefersReducedMotion} custom={direction.current}>
-            {visibleRecords
-              .filter((s) => s.isActive)
-              .map((slot) => (
-                <ActiveRecordCard
-                  key={`active-${slot.record.id}`}
-                  slot={slot}
-                  isCompact={isCompact}
-                  activeSlug={activeSlug}
-                  prefersReducedMotion={prefersReducedMotion}
-                  direction={direction}
-                  dragRotationRef={dragRotationRef}
-                  handleDragEnd={handleDragEnd}
-                />
-              ))}
-          </AnimatePresence>
-
-          <GestureHintOverlay
-            isCompact={isCompact}
-            showGestureHint={showGestureHint}
-            total={total}
-            prefersReducedMotion={prefersReducedMotion}
-          />
-        </div>
-      </div>
-    </>
-  );
-}
-
-interface CrateProgressProps {
-  index: number;
-  total: number;
-  progress: number;
-  edgeStatus: string | null;
-  isCompact: boolean;
-  prefersReducedMotion: boolean;
-  navigate: (dir: RiffleDirection) => void;
-}
-
-function CrateProgress({
-  index,
-  total,
-  progress,
-  edgeStatus,
-  isCompact,
-  prefersReducedMotion,
-  navigate,
-}: CrateProgressProps) {
-  return (
-    <>
-      <div className={`w-full max-w-xs sm:max-w-sm mx-auto ${isCompact ? "mt-1 mb-3" : "mb-4"}`}>
-        <div
-          className={`flex items-center justify-between text-[10px] uppercase tracking-[0.14em] text-mc-text-dim select-none ${isCompact ? "mb-1" : "mb-1.5"}`}
-        >
-          <span>{RIFFLE_LANGUAGE.progressStart}</span>
-          <span>{RIFFLE_LANGUAGE.progressEnd}</span>
-        </div>
-        <div
-          role="progressbar"
-          aria-valuenow={index + 1}
-          aria-valuemin={1}
-          aria-valuemax={total}
-          aria-label={RIFFLE_LANGUAGE.progress(index + 1, total)}
-          className="h-1.5 bg-mc-bg-raised rounded-full overflow-hidden"
-        >
-          <motion.div
-            className="h-full bg-mc-accent rounded-full"
-            animate={{ width: `${progress}%` }}
-            transition={prefersReducedMotion ? reducedMotionTransition : transitionCrate}
-          />
-        </div>
-      </div>
-
-      <div className={`flex items-center justify-center ${isCompact ? "gap-3" : "gap-4 sm:gap-6"}`}>
-        <motion.button
-          type="button"
-          onClick={() => navigate("front")}
-          disabled={index <= 0}
-          whileTap={{ scale: SCALE_PRESS }}
-          transition={springPress}
-          className={`flex items-center justify-center rounded-full bg-mc-bg-raised text-mc-text disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${isCompact ? "h-12 w-12 text-lg" : "w-14 h-14 text-xl"}`}
-          aria-label={RIFFLE_LANGUAGE.controls.front}
-        >
-          ↑
-        </motion.button>
-
-        <span
-          className={`${isCompact ? "w-16 text-xs" : "w-20 text-sm"} text-mc-text-dim tabular-nums text-center select-none`}
-          aria-label={RIFFLE_LANGUAGE.progress(index + 1, total)}
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          {RIFFLE_LANGUAGE.count(index + 1, total)}
-        </span>
-
-        <motion.button
-          type="button"
-          onClick={() => navigate("deeper")}
-          disabled={index >= total - 1}
-          whileTap={{ scale: SCALE_PRESS }}
-          transition={springPress}
-          className={`flex items-center justify-center rounded-full bg-mc-bg-raised text-mc-text disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${isCompact ? "h-12 w-12 text-lg" : "w-14 h-14 text-xl"}`}
-          aria-label={RIFFLE_LANGUAGE.controls.deeper}
-        >
-          ↓
-        </motion.button>
-      </div>
-
-      {edgeStatus && (
-        <p className="mt-2 text-center text-[11px] text-mc-text-dim" aria-live="polite">
-          {edgeStatus}
-        </p>
-      )}
-    </>
-  );
-}
-
-// ── Main component ────────────────────────────────────────────
-
+/**
+ * Orchestrates the crate browsing view: header, card stack with drag
+ * navigation, progress indicator, and desktop sidebar details.
+ */
 export default function CrateView({
   crates,
   activeSlug,
@@ -489,17 +63,22 @@ export default function CrateView({
 
   const activeRecord = records[index];
 
+  const layoutMode = compactHeaderOwnedByLayout
+    ? hideTabs
+      ? "minimal"
+      : "compact"
+    : hideTabs
+      ? "no-tabs"
+      : "full";
+
   const header = (
     <CrateHeader
       isCompact={isCompact}
       onBack={onBack}
-      crates={crates}
-      activeSlug={activeSlug}
+      tabs={{ crates, activeSlug, onSelectCrate }}
       activeCrate={activeCrate}
       total={total}
-      hideTabs={hideTabs}
-      compactHeaderOwnedByLayout={compactHeaderOwnedByLayout}
-      onSelectCrate={onSelectCrate}
+      layoutMode={layoutMode}
     />
   );
 

--- a/app/frontend/components/crate_view/active_record_card.tsx
+++ b/app/frontend/components/crate_view/active_record_card.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import RecordCard from "../record_card";
 import { compositedLayer } from "../../lib/motion_tokens";
-import {
-  riffleActiveCardMotion,
-  type RiffleDirection,
-} from "../../lib/riffle_navigation";
+import { riffleActiveCardMotion, type RiffleDirection } from "../../lib/riffle_navigation";
 import {
   transitionCrate,
   transitionCrateDesktop,
@@ -43,6 +40,12 @@ export default function ActiveRecordCard({
   dragRotationRef,
   handleDragEnd,
 }: ActiveRecordCardProps) {
+  const activeTransition = prefersReducedMotion
+    ? reducedMotionTransition
+    : isCompact
+      ? transitionCrate
+      : transitionCrateDesktop;
+
   return (
     <motion.div
       key={`active-${slot.record.id}`}
@@ -55,13 +58,7 @@ export default function ActiveRecordCard({
       initial="initial"
       animate="animate"
       exit="exit"
-      transition={
-        prefersReducedMotion
-          ? reducedMotionTransition
-          : isCompact
-            ? transitionCrate
-            : transitionCrateDesktop
-      }
+      transition={activeTransition}
       className="absolute inset-0"
       style={{ ...compositedLayer(false), zIndex: 30 }}
     >

--- a/app/frontend/components/crate_view/active_record_card.tsx
+++ b/app/frontend/components/crate_view/active_record_card.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { motion } from "framer-motion";
+import RecordCard from "../record_card";
+import { compositedLayer } from "../../lib/motion_tokens";
+import {
+  riffleActiveCardMotion,
+  type RiffleDirection,
+} from "../../lib/riffle_navigation";
+import {
+  transitionCrate,
+  transitionCrateDesktop,
+  reducedMotionTransition,
+} from "../../lib/motion_tokens";
+import type { Listing } from "../../types/inertia";
+import type { CrateWindowSlot } from "../../lib/crate_window";
+
+const ROTATION_FACTOR = 8 / 120;
+
+interface ActiveRecordCardProps {
+  slot: CrateWindowSlot<Listing>;
+  isCompact: boolean;
+  activeSlug: string;
+  prefersReducedMotion: boolean;
+  direction: React.RefObject<RiffleDirection>;
+  dragRotationRef: React.RefObject<HTMLDivElement | null>;
+  handleDragEnd: (info: {
+    offset: { x: number; y: number };
+    velocity: { x: number; y: number };
+  }) => void;
+}
+
+/**
+ * The frontmost, interactive record card in the crate stack.
+ * Supports drag-to-navigate riffle gesture, rotation during drag,
+ * and entry/exit animations for crate browsing.
+ */
+export default function ActiveRecordCard({
+  slot,
+  isCompact,
+  activeSlug,
+  prefersReducedMotion,
+  direction,
+  dragRotationRef,
+  handleDragEnd,
+}: ActiveRecordCardProps) {
+  return (
+    <motion.div
+      key={`active-${slot.record.id}`}
+      custom={direction.current}
+      variants={{
+        initial: (d: RiffleDirection) => riffleActiveCardMotion(d, prefersReducedMotion).initial,
+        animate: { opacity: 1, y: 0, rotate: 0, scale: 1 },
+        exit: (d: RiffleDirection) => riffleActiveCardMotion(d, prefersReducedMotion).exit,
+      }}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      transition={
+        prefersReducedMotion
+          ? reducedMotionTransition
+          : isCompact
+            ? transitionCrate
+            : transitionCrateDesktop
+      }
+      className="absolute inset-0"
+      style={{ ...compositedLayer(false), zIndex: 30 }}
+    >
+      <motion.div
+        ref={dragRotationRef}
+        data-testid="crate-drag-surface"
+        className="w-full h-full"
+        style={{
+          touchAction: "none",
+          willChange: "transform",
+          backfaceVisibility: "hidden",
+          WebkitBackfaceVisibility: "hidden",
+          rotate: "var(--drag-rotate, 0deg)",
+        }}
+        drag
+        dragConstraints={{ left: 0, right: 0, top: -180, bottom: 180 }}
+        dragElastic={0.28}
+        dragMomentum={false}
+        dragSnapToOrigin
+        whileDrag={prefersReducedMotion ? undefined : { scale: 0.985 }}
+        onDrag={(_, info) => {
+          dragRotationRef.current?.style.setProperty(
+            "--drag-rotate",
+            `${info.offset.x * ROTATION_FACTOR}deg`,
+          );
+        }}
+        onDragEnd={(_e, info) => {
+          dragRotationRef.current?.style.setProperty("--drag-rotate", "0deg");
+          handleDragEnd(info);
+        }}
+      >
+        {slot.record.thumbnail_url && (
+          <div className="absolute inset-0 rounded-lg overflow-hidden z-0 pointer-events-none">
+            <img
+              src={slot.record.thumbnail_url}
+              alt=""
+              className="w-full h-full object-cover saturate-75"
+              style={{ filter: "blur(8px)" }}
+              draggable={false}
+              onError={(e) => {
+                (e.currentTarget as HTMLElement).style.display = "none";
+              }}
+            />
+          </div>
+        )}
+        <RecordCard
+          listing={slot.record}
+          resetKey={`${activeSlug}-${slot.record.id}`}
+          className="relative z-10 rounded-lg"
+          imageLoading="eager"
+          disableFlip={!isCompact}
+          framed
+        />
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/app/frontend/components/crate_view/card_stack.tsx
+++ b/app/frontend/components/crate_view/card_stack.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { AnimatePresence } from "framer-motion";
+import HintCardStack from "./hint_card_stack";
+import ActiveRecordCard from "./active_record_card";
+import GestureHintOverlay from "./gesture_hint_overlay";
+import { buildCrateWindow } from "../../lib/crate_window";
+import { type RiffleDirection } from "../../lib/riffle_navigation";
+import type { Listing } from "../../types/inertia";
+
+interface CardStackProps {
+  isCompact: boolean;
+  visibleRecords: ReturnType<typeof buildCrateWindow<Listing>>;
+  activeSlug: string;
+  prefersReducedMotion: boolean;
+  direction: React.RefObject<RiffleDirection>;
+  showGestureHint: boolean;
+  total: number;
+  dragRotationRef: React.RefObject<HTMLDivElement | null>;
+  handleDragEnd: (info: {
+    offset: { x: number; y: number };
+    velocity: { x: number; y: number };
+  }) => void;
+}
+
+/**
+ * Composes the crate card stack: hint cards behind the active card,
+ * the active card with drag interaction, and a gesture hint overlay
+ * for first-time visitors on compact viewports.
+ */
+export default function CardStack(props: CardStackProps) {
+  const {
+    isCompact,
+    visibleRecords,
+    activeSlug,
+    prefersReducedMotion,
+    direction,
+    showGestureHint,
+    total,
+    dragRotationRef,
+    handleDragEnd,
+  } = props;
+
+  return (
+    <>
+      <div
+        data-testid="crate-stack"
+        data-viewport={isCompact ? "compact" : "wide"}
+        className={`relative z-10 flex items-center justify-center select-none ${
+          isCompact
+            ? "min-h-[min(72svh,360px)] pt-3 pb-8"
+            : "min-h-[390px] md:min-h-[470px] py-5 sm:py-7"
+        }`}
+        style={{ touchAction: "none", overscrollBehavior: "contain" }}
+      >
+        <div
+          className="relative"
+          style={{
+            width: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
+            height: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
+          }}
+        >
+          <HintCardStack visibleRecords={visibleRecords} prefersReducedMotion={prefersReducedMotion} />
+
+          <AnimatePresence initial={!prefersReducedMotion} custom={direction.current}>
+            {visibleRecords
+              .filter((s) => s.isActive)
+              .map((slot) => (
+                <ActiveRecordCard
+                  key={`active-${slot.record.id}`}
+                  slot={slot}
+                  isCompact={isCompact}
+                  activeSlug={activeSlug}
+                  prefersReducedMotion={prefersReducedMotion}
+                  direction={direction}
+                  dragRotationRef={dragRotationRef}
+                  handleDragEnd={handleDragEnd}
+                />
+              ))}
+          </AnimatePresence>
+
+          <GestureHintOverlay
+            isCompact={isCompact}
+            showGestureHint={showGestureHint}
+            total={total}
+            prefersReducedMotion={prefersReducedMotion}
+          />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/components/crate_view/crate_header.tsx
+++ b/app/frontend/components/crate_view/crate_header.tsx
@@ -1,0 +1,100 @@
+import CrateTabs from "../crate_tabs";
+import { IconBackButton, TextBackButton } from "../back_button";
+import type { Crate } from "../../types/inertia";
+
+interface CrateTabState {
+  crates: Crate[];
+  activeSlug: string;
+  onSelectCrate: (slug: string, startIndex?: number) => void;
+}
+
+type CrateHeaderLayoutMode = "full" | "compact" | "minimal" | "no-tabs";
+
+interface CrateHeaderProps {
+  isCompact: boolean;
+  onBack?: () => void;
+  tabs: CrateTabState;
+  activeCrate: Crate | undefined;
+  total: number;
+  layoutMode: CrateHeaderLayoutMode;
+}
+
+/**
+ * Shared header for crate views — handles both compact and desktop layouts.
+ * Displays back navigation, crate name, record count, and crate tabs.
+ *
+ * `layoutMode` replaces the old `hideTabs` + `compactHeaderOwnedByLayout` booleans:
+ * - "full": show back button, crate info, and tabs (old: hideTabs=false, compactHeaderOwnedByLayout=false)
+ * - "compact": show crate info only, tabs owned by parent (old: hideTabs=false, compactHeaderOwnedByLayout=true)
+ * - "no-tabs": show header, hide tabs (old: hideTabs=true, compactHeaderOwnedByLayout=false)
+ * - "minimal": hide header entirely (old: hideTabs=true, compactHeaderOwnedByLayout=true)
+ */
+export default function CrateHeader({
+  isCompact,
+  onBack,
+  tabs,
+  activeCrate,
+  total,
+  layoutMode,
+}: CrateHeaderProps) {
+  const hideTabs = layoutMode === "minimal" || layoutMode === "no-tabs";
+  const compactOwnedByLayout = layoutMode === "compact" || layoutMode === "minimal";
+
+  if (isCompact) {
+    if (layoutMode === "minimal") return null;
+
+    return (
+      <div className="mb-3">
+        <>
+          {!compactOwnedByLayout && (
+            <div className="flex items-center gap-3">
+              {onBack && <IconBackButton onClick={onBack} label="store" />}
+              <div className="min-w-0 flex-1">
+                <h1 className="truncate text-base font-semibold leading-tight">
+                  {activeCrate?.name}
+                </h1>
+                <div className="text-[11px] uppercase tracking-[0.12em] text-mc-text-dim">
+                  {total === 1 ? "1 record" : `${total} records`}
+                </div>
+              </div>
+            </div>
+          )}
+          {!hideTabs && (
+            <div className="-mx-1 mt-2">
+              <CrateTabs
+                crates={tabs.crates}
+                activeSlug={tabs.activeSlug}
+                onSelect={tabs.onSelectCrate}
+                compact
+              />
+            </div>
+          )}
+        </>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-4">
+      <>
+        <div className="flex items-center gap-3 border-b border-mc-border pb-2 mb-3">
+          {onBack && <TextBackButton onClick={onBack} label="store" />}
+          {onBack && !hideTabs && <div className="w-px self-stretch bg-mc-border" />}
+          <div className="min-w-0 flex-1">
+            <h1 className="truncate text-base font-semibold leading-tight">{activeCrate?.name}</h1>
+            <div className="text-[11px] uppercase tracking-[0.12em] text-mc-text-dim">
+              {total === 1 ? "1 record" : `${total} records`}
+            </div>
+          </div>
+        </div>
+        {!hideTabs && (
+          <CrateTabs
+            crates={tabs.crates}
+            activeSlug={tabs.activeSlug}
+            onSelect={tabs.onSelectCrate}
+          />
+        )}
+      </>
+    </div>
+  );
+}

--- a/app/frontend/components/crate_view/crate_progress.tsx
+++ b/app/frontend/components/crate_view/crate_progress.tsx
@@ -1,0 +1,104 @@
+import { motion } from "framer-motion";
+import {
+  SCALE_PRESS,
+  springPress,
+  transitionCrate,
+  reducedMotionTransition,
+} from "../../lib/motion_tokens";
+import {
+  RIFFLE_LANGUAGE,
+  type RiffleDirection,
+} from "../../lib/riffle_navigation";
+
+interface CrateProgressProps {
+  index: number;
+  total: number;
+  progress: number;
+  edgeStatus: string | null;
+  isCompact: boolean;
+  prefersReducedMotion: boolean;
+  navigate: (dir: RiffleDirection) => void;
+}
+
+/**
+ * Progress bar and navigation controls for crate browsing.
+ * Renders front/deeper navigation buttons with a progress bar
+ * and edge-of-crate status messages.
+ */
+export default function CrateProgress({
+  index,
+  total,
+  progress,
+  edgeStatus,
+  isCompact,
+  prefersReducedMotion,
+  navigate,
+}: CrateProgressProps) {
+  return (
+    <>
+      <div className={`w-full max-w-xs sm:max-w-sm mx-auto ${isCompact ? "mt-1 mb-3" : "mb-4"}`}>
+        <div
+          className={`flex items-center justify-between text-[10px] uppercase tracking-[0.14em] text-mc-text-dim select-none ${isCompact ? "mb-1" : "mb-1.5"}`}
+        >
+          <span>{RIFFLE_LANGUAGE.progressStart}</span>
+          <span>{RIFFLE_LANGUAGE.progressEnd}</span>
+        </div>
+        <div
+          role="progressbar"
+          aria-valuenow={index + 1}
+          aria-valuemin={1}
+          aria-valuemax={total}
+          aria-label={RIFFLE_LANGUAGE.progress(index + 1, total)}
+          className="h-1.5 bg-mc-bg-raised rounded-full overflow-hidden"
+        >
+          <motion.div
+            className="h-full bg-mc-accent rounded-full"
+            animate={{ width: `${progress}%` }}
+            transition={prefersReducedMotion ? reducedMotionTransition : transitionCrate}
+          />
+        </div>
+      </div>
+
+      <div className={`flex items-center justify-center ${isCompact ? "gap-3" : "gap-4 sm:gap-6"}`}>
+        <motion.button
+          type="button"
+          onClick={() => navigate("front")}
+          disabled={index <= 0}
+          whileTap={{ scale: SCALE_PRESS }}
+          transition={springPress}
+          className={`flex items-center justify-center rounded-full bg-mc-bg-raised text-mc-text disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${isCompact ? "h-12 w-12 text-lg" : "w-14 h-14 text-xl"}`}
+          aria-label={RIFFLE_LANGUAGE.controls.front}
+        >
+          ↑
+        </motion.button>
+
+        <span
+          className={`${isCompact ? "w-16 text-xs" : "w-20 text-sm"} text-mc-text-dim tabular-nums text-center select-none`}
+          aria-label={RIFFLE_LANGUAGE.progress(index + 1, total)}
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {RIFFLE_LANGUAGE.count(index + 1, total)}
+        </span>
+
+        <motion.button
+          type="button"
+          onClick={() => navigate("deeper")}
+          disabled={index >= total - 1}
+          whileTap={{ scale: SCALE_PRESS }}
+          transition={springPress}
+          className={`flex items-center justify-center rounded-full bg-mc-bg-raised text-mc-text disabled:opacity-20 disabled:cursor-not-allowed hover:bg-mc-bg-card transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg ${isCompact ? "h-12 w-12 text-lg" : "w-14 h-14 text-xl"}`}
+          aria-label={RIFFLE_LANGUAGE.controls.deeper}
+        >
+          ↓
+        </motion.button>
+      </div>
+
+      {edgeStatus && (
+        <p className="mt-2 text-center text-[11px] text-mc-text-dim" aria-live="polite">
+          {edgeStatus}
+        </p>
+      )}
+    </>
+  );
+}

--- a/app/frontend/components/crate_view/gesture_hint_overlay.tsx
+++ b/app/frontend/components/crate_view/gesture_hint_overlay.tsx
@@ -1,0 +1,26 @@
+import GhostFingerCue from "../ghost_finger_cue";
+import { isLessonEligible } from "../../lib/first_swipe_lesson";
+
+interface GestureHintOverlayProps {
+  isCompact: boolean;
+  showGestureHint: boolean;
+  total: number;
+  prefersReducedMotion: boolean;
+}
+
+/**
+ * Conditionally renders the ghost-finger gesture hint overlay
+ * on compact viewports for first-time crate visitors.
+ */
+export default function GestureHintOverlay({
+  isCompact,
+  showGestureHint,
+  total,
+  prefersReducedMotion,
+}: GestureHintOverlayProps) {
+  if (!isCompact) return null;
+  if (!showGestureHint) return null;
+  if (!isLessonEligible({ isCompact, isPopulated: total > 0 })) return null;
+
+  return <GhostFingerCue reducedMotion={prefersReducedMotion} />;
+}

--- a/app/frontend/components/crate_view/hint_card_stack.tsx
+++ b/app/frontend/components/crate_view/hint_card_stack.tsx
@@ -1,0 +1,66 @@
+import { compositedLayer } from "../../lib/motion_tokens";
+import type { Listing } from "../../types/inertia";
+import type { CrateWindowSlot } from "../../lib/crate_window";
+
+interface HintCardStackProps {
+  visibleRecords: CrateWindowSlot<Listing>[];
+  prefersReducedMotion: boolean;
+}
+
+/**
+ * Renders translucent hint cards behind the active record card,
+ * showing the adjacent records in the crate stack.
+ */
+export default function HintCardStack({
+  visibleRecords,
+  prefersReducedMotion,
+}: HintCardStackProps) {
+  return (
+    <>
+      {visibleRecords
+        .filter((s) => !s.isActive)
+        .map((slot) => {
+          const depth = Math.abs(slot.offset);
+          const hintUrl = slot.record.thumbnail_url ?? slot.record.cover_image_url;
+          const baseX = slot.offset * 16;
+          const baseY = depth * 12;
+          const baseRotate = slot.offset * -4;
+          const scale = 1 - depth * 0.045;
+
+          return (
+            <div
+              key={`hint-${slot.record.id}`}
+              aria-hidden="true"
+              data-riffle-slot={slot.offset}
+              className="absolute inset-0 rounded-lg overflow-hidden border border-mc-border bg-mc-bg-raised shadow-lg pointer-events-none"
+              style={{
+                ...compositedLayer(true),
+                zIndex: 10 - depth,
+                opacity: 0.38,
+                transform: `translate(${baseX}px, ${baseY}px) rotate(${baseRotate}deg) scale(${scale})`,
+                transition: prefersReducedMotion
+                  ? "transform 0.01s ease-out, opacity 0.01s ease-out"
+                  : "transform 0.2s ease-out, opacity 0.2s ease-out",
+              }}
+            >
+              {hintUrl ? (
+                <img
+                  src={hintUrl}
+                  alt=""
+                  className="w-full h-full object-cover saturate-75"
+                  draggable={false}
+                  loading="lazy"
+                  decoding="async"
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-mc-text-dim text-5xl">
+                  ♪
+                </div>
+              )}
+              <div className="absolute inset-0 bg-mc-bg/35" />
+            </div>
+          );
+        })}
+    </>
+  );
+}

--- a/app/frontend/components/crate_view/index.ts
+++ b/app/frontend/components/crate_view/index.ts
@@ -1,0 +1,1 @@
+export { default as CrateView } from "../crate_view";

--- a/app/frontend/components/discogs_connection_controls.tsx
+++ b/app/frontend/components/discogs_connection_controls.tsx
@@ -1,4 +1,5 @@
 import { actionClassName } from "./ui/action";
+import { csrfToken } from "@/lib/csrf_token";
 
 interface FormProps {
   className?: string;
@@ -16,10 +17,6 @@ const defaultDisconnectButtonClassName = actionClassName({
   size: "sm",
   className: "min-h-11",
 });
-
-function csrfToken() {
-  return document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? "";
-}
 
 export function DiscogsConnectForm({
   storeSlug,

--- a/app/frontend/components/discogs_seller_lookup_input.tsx
+++ b/app/frontend/components/discogs_seller_lookup_input.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { springTactile } from "@/lib/motion_tokens";
 import Button from "@/components/ui/button";
@@ -31,20 +32,36 @@ const easeOut = [0.25, 0.46, 0.45, 0.94] as const;
 
 // ── Status sub-components ──────────────────────────────────────
 
-function LookupLoading() {
+function LookupStatusFrame({
+  statusKey,
+  children,
+  transition = { duration: 0.2, ease: easeOut },
+}: {
+  statusKey: string;
+  children: ReactNode;
+  transition?: ComponentProps<typeof motion.div>["transition"];
+}) {
   return (
     <motion.div
-      key="loading"
+      key={statusKey}
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -4 }}
-      transition={{ duration: 0.2, ease: easeOut }}
+      transition={transition}
     >
+      {children}
+    </motion.div>
+  );
+}
+
+function LookupLoading() {
+  return (
+    <LookupStatusFrame statusKey="loading">
       <FeedbackMessage tone="progress" className="flex items-center gap-3 px-4 py-3">
         <Spinner size="md" />
         <span>Checking Discogs...</span>
       </FeedbackMessage>
-    </motion.div>
+    </LookupStatusFrame>
   );
 }
 
@@ -56,13 +73,7 @@ function LookupPreview({
   copy: Pick<Props["copy"], "seller_preview_claim">;
 }) {
   return (
-    <motion.div
-      key="preview"
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -4 }}
-      transition={springTactile}
-    >
+    <LookupStatusFrame statusKey="preview" transition={springTactile}>
       <FeedbackMessage
         tone="success"
         className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between"
@@ -87,23 +98,17 @@ function LookupPreview({
           </Button>
         </form>
       </FeedbackMessage>
-    </motion.div>
+    </LookupStatusFrame>
   );
 }
 
 function LookupNotFound({ copy }: { copy: Pick<Props["copy"], "seller_not_found"> }) {
   return (
-    <motion.div
-      key="not-found"
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -4 }}
-      transition={{ duration: 0.2, ease: easeOut }}
-    >
+    <LookupStatusFrame statusKey="not-found">
       <FeedbackMessage tone="danger" live="assertive">
         {copy.seller_not_found}
       </FeedbackMessage>
-    </motion.div>
+    </LookupStatusFrame>
   );
 }
 
@@ -115,13 +120,7 @@ function LookupActiveStore({
   copy: Pick<Props["copy"], "seller_already_active">;
 }) {
   return (
-    <motion.div
-      key="active-store"
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -4 }}
-      transition={{ duration: 0.2, ease: easeOut }}
-    >
+    <LookupStatusFrame statusKey="active-store">
       <FeedbackMessage tone="warning" live="assertive">
         {copy.seller_already_active}{" "}
         {result.store_storefront_path && (
@@ -133,23 +132,17 @@ function LookupActiveStore({
           </a>
         )}
       </FeedbackMessage>
-    </motion.div>
+    </LookupStatusFrame>
   );
 }
 
 function LookupApplicant({ copy }: { copy: Pick<Props["copy"], "seller_applicant_exists"> }) {
   return (
-    <motion.div
-      key="applicant"
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -4 }}
-      transition={{ duration: 0.2, ease: easeOut }}
-    >
+    <LookupStatusFrame statusKey="applicant">
       <FeedbackMessage tone="warning" live="assertive">
         {copy.seller_applicant_exists}
       </FeedbackMessage>
-    </motion.div>
+    </LookupStatusFrame>
   );
 }
 
@@ -161,13 +154,7 @@ function LookupApiError({
   onRetry: () => void;
 }) {
   return (
-    <motion.div
-      key="api-error"
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -4 }}
-      transition={{ duration: 0.2, ease: easeOut }}
-    >
+    <LookupStatusFrame statusKey="api-error">
       <FeedbackMessage tone="danger" live="assertive">
         {copy.seller_lookup_error}{" "}
         <button
@@ -178,7 +165,7 @@ function LookupApiError({
           Try again
         </button>
       </FeedbackMessage>
-    </motion.div>
+    </LookupStatusFrame>
   );
 }
 

--- a/app/frontend/components/discogs_seller_lookup_input.tsx
+++ b/app/frontend/components/discogs_seller_lookup_input.tsx
@@ -1,162 +1,283 @@
-import { useState, useEffect, useRef, useCallback } from "react"
-import { motion, AnimatePresence } from "framer-motion"
-import { springTactile } from "@/lib/motion_tokens"
-import Button from "@/components/ui/button"
-import FeedbackMessage from "@/components/ui/feedback_message"
-import Field from "@/components/ui/field"
-import type { DiscogsLookupResult } from "@/types/inertia"
-
-type SuccessfulLookup = DiscogsLookupResult & { found: true }
-
-type LookupState =
-  | { status: "idle" }
-  | { status: "loading" }
-  | { status: "preview"; result: SuccessfulLookup }
-  | { status: "error_not_found" }
-  | { status: "error_active_store"; result: SuccessfulLookup }
-  | { status: "error_applicant"; result: SuccessfulLookup }
-  | { status: "error_api" }
+import { useState, useEffect, useRef, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { springTactile } from "@/lib/motion_tokens";
+import Button from "@/components/ui/button";
+import FeedbackMessage from "@/components/ui/feedback_message";
+import Field from "@/components/ui/field";
+import Spinner from "@/components/spinner";
+import {
+  useDiscogsLookup,
+  csrfToken,
+  type LookupState,
+  type SuccessfulLookup,
+} from "@/hooks/use_discogs_lookup";
 
 interface Props {
   copy: {
-    seller_input_label: string
-    seller_input_placeholder: string
-    seller_submit: string
-    seller_preview_claim: string
-    seller_not_found: string
-    seller_already_active: string
-    seller_applicant_exists: string
-    seller_waitlist_fallback: string
-    seller_min_listings: string
-    seller_lookup_error: string
-  }
+    seller_input_label: string;
+    seller_input_placeholder: string;
+    seller_submit: string;
+    seller_preview_claim: string;
+    seller_not_found: string;
+    seller_already_active: string;
+    seller_applicant_exists: string;
+    seller_waitlist_fallback: string;
+    seller_min_listings: string;
+    seller_lookup_error: string;
+  };
 }
 
-function csrfToken() {
-  return document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? ""
+const easeOut = [0.25, 0.46, 0.45, 0.94] as const;
+
+// ── Status sub-components ──────────────────────────────────────
+
+function LookupLoading() {
+  return (
+    <motion.div
+      key="loading"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={{ duration: 0.2, ease: easeOut }}
+    >
+      <FeedbackMessage tone="progress" className="flex items-center gap-3 px-4 py-3">
+        <Spinner size="md" />
+        <span>Checking Discogs...</span>
+      </FeedbackMessage>
+    </motion.div>
+  );
 }
 
-const easeOut = [0.25, 0.46, 0.45, 0.94] as const
+function LookupPreview({
+  result,
+  copy,
+}: {
+  result: SuccessfulLookup;
+  copy: Pick<Props["copy"], "seller_preview_claim">;
+}) {
+  return (
+    <motion.div
+      key="preview"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={springTactile}
+    >
+      <FeedbackMessage
+        tone="success"
+        className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          {result.avatar_url && (
+            <img
+              src={result.avatar_url}
+              alt=""
+              className="h-12 w-12 shrink-0 rounded-md border border-mc-feedback-success-border object-cover"
+            />
+          )}
+          <div className="min-w-0">
+            <p className="font-semibold text-sm text-mc-text">{result.seller_name}</p>
+            <p className="text-xs text-mc-text-dim">@{result.slug}</p>
+          </div>
+        </div>
+        <form action={`/${result.slug}/authorize`} method="POST" className="shrink-0">
+          <input type="hidden" name="authenticity_token" value={csrfToken()} />
+          <Button type="submit" size="lg">
+            {copy.seller_preview_claim}
+          </Button>
+        </form>
+      </FeedbackMessage>
+    </motion.div>
+  );
+}
+
+function LookupNotFound({ copy }: { copy: Pick<Props["copy"], "seller_not_found"> }) {
+  return (
+    <motion.div
+      key="not-found"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={{ duration: 0.2, ease: easeOut }}
+    >
+      <FeedbackMessage tone="danger" live="assertive">
+        {copy.seller_not_found}
+      </FeedbackMessage>
+    </motion.div>
+  );
+}
+
+function LookupActiveStore({
+  result,
+  copy,
+}: {
+  result: SuccessfulLookup;
+  copy: Pick<Props["copy"], "seller_already_active">;
+}) {
+  return (
+    <motion.div
+      key="active-store"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={{ duration: 0.2, ease: easeOut }}
+    >
+      <FeedbackMessage tone="warning" live="assertive">
+        {copy.seller_already_active}{" "}
+        {result.store_storefront_path && (
+          <a
+            href={result.store_storefront_path}
+            className="underline hover:no-underline font-medium"
+          >
+            Visit store →
+          </a>
+        )}
+      </FeedbackMessage>
+    </motion.div>
+  );
+}
+
+function LookupApplicant({ copy }: { copy: Pick<Props["copy"], "seller_applicant_exists"> }) {
+  return (
+    <motion.div
+      key="applicant"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={{ duration: 0.2, ease: easeOut }}
+    >
+      <FeedbackMessage tone="warning" live="assertive">
+        {copy.seller_applicant_exists}
+      </FeedbackMessage>
+    </motion.div>
+  );
+}
+
+function LookupApiError({
+  copy,
+  onRetry,
+}: {
+  copy: Pick<Props["copy"], "seller_lookup_error">;
+  onRetry: () => void;
+}) {
+  return (
+    <motion.div
+      key="api-error"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={{ duration: 0.2, ease: easeOut }}
+    >
+      <FeedbackMessage tone="danger" live="assertive">
+        {copy.seller_lookup_error}{" "}
+        <button
+          type="button"
+          onClick={onRetry}
+          className="rounded font-medium underline hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus"
+        >
+          Try again
+        </button>
+      </FeedbackMessage>
+    </motion.div>
+  );
+}
+
+function LookupStatus({
+  state,
+  copy,
+  onRetry,
+}: {
+  state: LookupState;
+  copy: Props["copy"];
+  onRetry: () => void;
+}) {
+  return (
+    <AnimatePresence mode="wait">
+      {state.status === "loading" && <LookupLoading />}
+      {state.status === "preview" && <LookupPreview result={state.result} copy={copy} />}
+      {state.status === "error_not_found" && <LookupNotFound copy={copy} />}
+      {state.status === "error_active_store" && (
+        <LookupActiveStore result={state.result} copy={copy} />
+      )}
+      {state.status === "error_applicant" && <LookupApplicant copy={copy} />}
+      {state.status === "error_api" && <LookupApiError copy={copy} onRetry={onRetry} />}
+    </AnimatePresence>
+  );
+}
+
+// ── Main component ──────────────────────────────────────────────
 
 export default function DiscogsSellerLookupInput({ copy }: Props) {
-  const [username, setUsername] = useState("")
-  const [state, setState] = useState<LookupState>({ status: "idle" })
-  const [validationError, setValidationError] = useState<string | null>(null)
-  const resultRef = useRef<HTMLDivElement>(null)
-  const announcerRef = useRef<HTMLDivElement>(null)
-  const abortRef = useRef<AbortController | null>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const [username, setUsername] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const resultRef = useRef<HTMLDivElement>(null);
+  const announcerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  // Cleanup abort controller on unmount
-  useEffect(() => {
-    return () => {
-      abortRef.current?.abort()
-    }
-  }, [])
-
-  // Announce state changes to screen readers
+  // Screen-reader announcement callback for useDiscogsLookup
   const announce = useCallback((message: string) => {
     if (announcerRef.current) {
-      announcerRef.current.textContent = message
+      announcerRef.current.textContent = message;
     }
-  }, [])
+  }, []);
+
+  const { state, lookup, reset } = useDiscogsLookup(announce);
+
+  // Focus result container when lookup transitions to a terminal state
+  const prevStatusRef = useRef(state.status);
+  useEffect(() => {
+    if (prevStatusRef.current === "loading" && state.status !== "loading") {
+      requestAnimationFrame(() => {
+        resultRef.current?.focus();
+      });
+    }
+    prevStatusRef.current = state.status;
+  }, [state.status]);
 
   const handleSubmit = useCallback(
     (event: React.FormEvent) => {
-      event.preventDefault()
+      event.preventDefault();
 
-      const trimmed = username.trim()
+      const trimmed = username.trim();
       if (!trimmed) {
-        setValidationError("Enter a Discogs username.")
-        return
+        setValidationError("Enter a Discogs username.");
+        return;
       }
 
       if (trimmed.length < 3) {
-        setValidationError("Username must be at least 3 characters.")
-        return
+        setValidationError("Username must be at least 3 characters.");
+        return;
       }
 
-      setValidationError(null)
-
-      // Abort any in-flight request
-      abortRef.current?.abort()
-      const controller = new AbortController()
-      abortRef.current = controller
-
-      setState({ status: "loading" })
-      announce("Checking Discogs availability...")
-
-      const url = `/api/discogs/lookup/${encodeURIComponent(trimmed)}`
-
-      fetch(url, { signal: controller.signal })
-        .then((res) => {
-          if (!res.ok) throw new Error(`Lookup failed: ${res.status}`)
-          return res.json() as Promise<DiscogsLookupResult>
-        })
-        .then((data) => {
-          if (controller.signal.aborted) return
-
-          if (!data.found) {
-            setState({ status: "error_not_found" })
-            announce("Username not found on Discogs.")
-            return
-          }
-
-          switch (data.store_status) {
-            case "active_store":
-              setState({ status: "error_active_store", result: data })
-              announce("This store is already on Milkcrate.")
-              break
-            case "active_applicant":
-              setState({ status: "error_applicant", result: data })
-              announce("This seller has already applied.")
-              break
-            default:
-              setState({ status: "preview", result: data })
-              announce(`Found ${data.seller_name} on Discogs.`)
-          }
-
-          // Move focus to result container
-          requestAnimationFrame(() => {
-            resultRef.current?.focus()
-          })
-        })
-        .catch((err) => {
-          if (controller.signal.aborted) return
-          if (err instanceof DOMException && err.name === "AbortError") return
-
-          setState({ status: "error_api" })
-          announce("Something went wrong. Please try again.")
-        })
+      setValidationError(null);
+      lookup(trimmed);
     },
-    [username, announce],
-  )
+    [username, lookup],
+  );
 
   const handleUsernameChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setUsername(event.target.value)
-      setValidationError(null)
+      setUsername(event.target.value);
+      setValidationError(null);
       if (state.status !== "idle") {
-        setState({ status: "idle" })
+        reset();
       }
     },
-    [state.status],
-  )
+    [state.status, reset],
+  );
 
-  const isSubmitting = state.status === "loading"
+  const isSubmitting = state.status === "loading";
 
   return (
     <div className="w-full">
       {/* Screen reader announcement region */}
-      <div
-        ref={announcerRef}
-        aria-live="polite"
-        aria-atomic="true"
-        className="sr-only"
-      />
+      <div ref={announcerRef} aria-live="polite" aria-atomic="true" className="sr-only" />
 
       {/* Input form */}
-      <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-3">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-3"
+      >
         <Field
           id="seller-discogs-username"
           label={copy.seller_input_label}
@@ -175,24 +296,10 @@ export default function DiscogsSellerLookupInput({ copy }: Props) {
             spellCheck={false}
           />
         </Field>
-        <Button
-          type="submit"
-          busy={isSubmitting}
-          size="lg"
-          className="tracking-wide"
-        >
+        <Button type="submit" busy={isSubmitting} size="lg" className="tracking-wide">
           {isSubmitting ? (
             <>
-              <svg
-                className="motion-safe:animate-spin h-4 w-4 text-mc-on-accent/80"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
+              <Spinner size="sm" className="text-mc-on-accent/80" />
               <span>Checking...</span>
             </>
           ) : (
@@ -202,128 +309,9 @@ export default function DiscogsSellerLookupInput({ copy }: Props) {
       </form>
 
       {/* Result area */}
-      <div
-        ref={resultRef}
-        tabIndex={-1}
-        className="outline-none mt-4"
-        role="status"
-      >
-        <AnimatePresence mode="wait">
-          {state.status === "loading" && (
-            <motion.div
-              key="loading"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.2, ease: easeOut }}
-            >
-              <FeedbackMessage tone="progress" className="flex items-center gap-3 px-4 py-3">
-                <div className="w-5 h-5 border-2 border-mc-feedback-progress border-t-transparent rounded-full motion-safe:animate-spin" />
-                <span>Checking Discogs...</span>
-              </FeedbackMessage>
-            </motion.div>
-          )}
-
-          {state.status === "preview" && (
-            <motion.div
-              key="preview"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={springTactile}
-            >
-              <FeedbackMessage tone="success" className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex items-center gap-3 min-w-0">
-                  {state.result.avatar_url && (
-                    <img
-                      src={state.result.avatar_url}
-                      alt=""
-                      className="h-12 w-12 shrink-0 rounded-md border border-mc-feedback-success-border object-cover"
-                    />
-                  )}
-                  <div className="min-w-0">
-                    <p className="font-semibold text-sm text-mc-text">{state.result.seller_name}</p>
-                    <p className="text-xs text-mc-text-dim">@{state.result.slug}</p>
-                  </div>
-                </div>
-                <form action={`/${state.result.slug}/authorize`} method="POST" className="shrink-0">
-                  <input type="hidden" name="authenticity_token" value={csrfToken()} />
-                  <Button type="submit" size="lg">
-                    {copy.seller_preview_claim}
-                  </Button>
-                </form>
-              </FeedbackMessage>
-            </motion.div>
-          )}
-
-          {state.status === "error_not_found" && (
-            <motion.div
-              key="not-found"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.2, ease: easeOut }}
-            >
-              <FeedbackMessage tone="danger" live="assertive">{copy.seller_not_found}</FeedbackMessage>
-            </motion.div>
-          )}
-
-          {state.status === "error_active_store" && (
-            <motion.div
-              key="active-store"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.2, ease: easeOut }}
-            >
-              <FeedbackMessage tone="warning" live="assertive">
-                {copy.seller_already_active}{" "}
-                {state.result?.store_storefront_path && (
-                  <a
-                    href={state.result.store_storefront_path}
-                    className="underline hover:no-underline font-medium"
-                  >
-                    Visit store →
-                  </a>
-                )}
-              </FeedbackMessage>
-            </motion.div>
-          )}
-
-          {state.status === "error_applicant" && (
-            <motion.div
-              key="applicant"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.2, ease: easeOut }}
-            >
-              <FeedbackMessage tone="warning" live="assertive">{copy.seller_applicant_exists}</FeedbackMessage>
-            </motion.div>
-          )}
-
-          {state.status === "error_api" && (
-            <motion.div
-              key="api-error"
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: 0.2, ease: easeOut }}
-            >
-              <FeedbackMessage tone="danger" live="assertive">
-                {copy.seller_lookup_error}{" "}
-                <button
-                  type="button"
-                  onClick={() => setState({ status: "idle" })}
-                  className="rounded font-medium underline hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus"
-                >
-                  Try again
-                </button>
-              </FeedbackMessage>
-            </motion.div>
-          )}
-        </AnimatePresence>
+      <div ref={resultRef} tabIndex={-1} className="outline-none mt-4" role="status">
+        <LookupStatus state={state} copy={copy} onRetry={reset} />
       </div>
     </div>
-  )
+  );
 }

--- a/app/frontend/components/featured_crates_row.tsx
+++ b/app/frontend/components/featured_crates_row.tsx
@@ -1,33 +1,20 @@
-import CrateCard from "./crate_card"
-import type { Crate } from "../types/inertia"
-import { useViewport } from "@/hooks/use_viewport"
+import CrateSectionGrid from "./crate_section_grid";
+import type { Crate } from "../types/inertia";
 
 interface Props {
-  crates: Crate[]
-  onSelectCrate: (slug: string, startIndex?: number) => void
+  crates: Crate[];
+  onSelectCrate: (slug: string, startIndex?: number) => void;
 }
 
 export default function FeaturedCratesRow({ crates, onSelectCrate }: Props) {
-  const { isCompact, isComfy } = useViewport()
-  if (crates.length === 0) return null
-
-  // Responsive columns: compact stays 1, comfy gets more, wide fills
-  const cols = isCompact ? 1 : isComfy ? 2 : 3
-
   return (
-    <div>
-      <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-2 mb-4">
-        <span className="mc-section-name text-base font-semibold">Featured</span>
-        <span className="mc-section-count">{crates.length}</span>
-      </div>
-      <div
-        className="grid gap-4"
-        style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
-      >
-        {crates.map((crate) => (
-          <CrateCard key={crate.slug} crate={crate} variant="featured" onSelectCrate={onSelectCrate} />
-        ))}
-      </div>
-    </div>
-  )
+    <CrateSectionGrid
+      title="Featured"
+      count={crates.length}
+      crates={crates}
+      variant="featured"
+      columnCount={(isCompact, isComfy) => (isCompact ? 1 : isComfy ? 2 : 3)}
+      onSelectCrate={onSelectCrate}
+    />
+  );
 }

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -1,38 +1,21 @@
-import CrateCard from "./crate_card"
-import type { Crate } from "../types/inertia"
-import { useViewport } from "@/hooks/use_viewport"
+import CrateSectionGrid from "./crate_section_grid";
+import type { Crate } from "../types/inertia";
 
 interface Props {
-  crates: Crate[]
-  onSelectCrate: (slug: string, startIndex?: number) => void
+  crates: Crate[];
+  onSelectCrate: (slug: string, startIndex?: number) => void;
 }
 
 export default function GenreGrid({ crates, onSelectCrate }: Props) {
-  const { isCompact, isComfy } = useViewport()
-  if (crates.length === 0) return null
-
-  // Responsive columns: compact=2, comfy=3, wide=4
-  const cols = isCompact ? 2 : isComfy ? 3 : 4
-
   return (
-    <div>
-      <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-2 mb-4">
-        <span className="mc-section-name text-base font-semibold">Browse by genre</span>
-        <span className="mc-section-count">{crates.length}</span>
-      </div>
-      <div
-        className="grid gap-3 sm:gap-4"
-        style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
-      >
-        {crates.map((crate) => (
-          <CrateCard
-            key={crate.slug}
-            crate={crate}
-            variant="genre"
-            onSelectCrate={onSelectCrate}
-          />
-        ))}
-      </div>
-    </div>
-  )
+    <CrateSectionGrid
+      title="Browse by genre"
+      count={crates.length}
+      crates={crates}
+      variant="genre"
+      columnCount={(isCompact, isComfy) => (isCompact ? 2 : isComfy ? 3 : 4)}
+      onSelectCrate={onSelectCrate}
+      gap="gap-3 sm:gap-4"
+    />
+  );
 }

--- a/app/frontend/components/pile_sheet.tsx
+++ b/app/frontend/components/pile_sheet.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { usePage } from "@inertiajs/react";
 import { usePileContext } from "../contexts/pile_context";
 import { useViewport } from "@/hooks/use_viewport";
+import { useDialogFocusTrap } from "@/hooks/use_dialog_focus_trap";
 import { springDrawer } from "@/lib/motion_tokens";
 import { formatPriceValue } from "@/lib/format_price";
 import { useShopperContext } from "../contexts/shopper_context";
@@ -219,15 +220,79 @@ function ConnectedAccount({ username }: { username: string }) {
   );
 }
 
+// ── Footer sub-component ────────────────────────────────────────
+
+interface PileFooterProps {
+  pile: Listing[];
+  total: number;
+  isConnected: boolean;
+  shopper: { discogs_username: string } | null;
+  state: string;
+  wantlistResult: { wantlist_url: string | null; added: number; skipped: number } | null;
+  errorMessage: string | null;
+  storeName: string | null;
+  storeSlug: string | null;
+  handoffAvailable: boolean;
+  highlightOnMount: boolean | undefined;
+  onSendToWantlist: () => void;
+  onReset: () => void;
+}
+
+function PileFooter({
+  pile,
+  total,
+  isConnected,
+  shopper,
+  state,
+  wantlistResult,
+  errorMessage,
+  storeName,
+  storeSlug,
+  handoffAvailable,
+  highlightOnMount,
+  onSendToWantlist,
+  onReset,
+}: PileFooterProps) {
+  const isInProgress = state === "creating";
+  const showResult = state === "success" && wantlistResult;
+  const showError = state === "error";
+  const showHandoffAction = handoffAvailable && isConnected && state === "idle";
+  const showDisconnectedCta = handoffAvailable && !isConnected && state === "idle";
+
+  return (
+    <div className="flex-shrink-0 px-4 py-4 border-t border-mc-border flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-mc-text-dim uppercase tracking-wider">Total</span>
+        <span className="text-sm font-semibold">
+          {formatPriceValue(total.toFixed(2), pile[0]?.currency)}
+        </span>
+      </div>
+      {isConnected && shopper && <ConnectedAccount username={shopper.discogs_username} />}
+      {showResult && (
+        <WantlistResultView result={wantlistResult!} storeName={storeName} onDismiss={onReset} />
+      )}
+      {showError && <WantlistErrorView message={errorMessage} onRetry={onReset} />}
+      {isInProgress && <WantlistInProgressView count={pile.length} />}
+      {showHandoffAction && (
+        <WantlistHandoffAction
+          storeName={storeName}
+          onSend={onSendToWantlist}
+          highlight={highlightOnMount}
+        />
+      )}
+      {showDisconnectedCta && storeSlug && (
+        <DisconnectedCta storeName={storeName} storeSlug={storeSlug} />
+      )}
+    </div>
+  );
+}
+
 // ── Main component ──────────────────────────────────────────────
 
 export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMount }: Props) {
   const { pile, removeFromPile, clearPile } = usePileContext();
   const { isCompact } = useViewport();
   const [confirmClear, setConfirmClear] = React.useState(false);
-  const dialogRef = React.useRef<HTMLDivElement>(null);
-  const titleRef = React.useRef<HTMLSpanElement>(null);
-  const previousFocusRef = React.useRef<HTMLElement | null>(null);
 
   const page = usePage<PageProps>();
   const store = page.props.store;
@@ -238,89 +303,30 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
     useShopperContext();
 
   const total = pile.reduce((sum, l) => sum + (parseFloat(l.price) || 0), 0);
-  const isInProgress = state === "creating";
-  const showResult = state === "success" && wantlistResult;
-  const showError = state === "error";
-  const showHandoffAction = handoffAvailable && isConnected && state === "idle";
-  const showDisconnectedCta = handoffAvailable && !isConnected && state === "idle";
 
-  React.useEffect(() => {
-    if (!open) return;
+  const handleClose = React.useCallback(() => {
+    setConfirmClear(false);
+    onClose();
+  }, [onClose]);
 
-    previousFocusRef.current = document.activeElement as HTMLElement | null;
-    titleRef.current?.focus();
+  const { dialogRef, titleRef } = useDialogFocusTrap(open, handleClose, { returnFocusRef });
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setConfirmClear(false);
-        onClose();
-        return;
-      }
-
-      if (event.key !== "Tab") return;
-
-      const dialog = dialogRef.current;
-      if (!dialog) return;
-
-      const focusable = Array.from(
-        dialog.querySelectorAll<HTMLElement>(
-          'a[href], button:not([disabled]), input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ),
-      );
-
-      if (focusable.length === 0) {
-        event.preventDefault();
-        titleRef.current?.focus();
-        return;
-      }
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement;
-
-      if (
-        event.shiftKey &&
-        (active === first || active === titleRef.current || !dialog.contains(active))
-      ) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
-        event.preventDefault();
-        first.focus();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-
-    const previousFocus = previousFocusRef.current;
-    const returnFocus = returnFocusRef?.current;
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      if (previousFocus?.isConnected) {
-        previousFocus.focus();
-      } else if (returnFocus) {
-        returnFocus.focus();
-      }
-    };
-  }, [open, onClose, returnFocusRef]);
-
+  // Reset result when sheet closes
   React.useEffect(() => {
     if (!open) resetResult();
   }, [open, resetResult]);
 
+  // Re-focus title when dialog content changes
   React.useEffect(() => {
     if (!open || dialogRef.current?.contains(document.activeElement)) return;
-
     titleRef.current?.focus();
-  }, [open, pile.length, confirmClear, state]);
+  }, [open, pile.length, confirmClear, state, dialogRef, titleRef]);
 
-  const handleSendToWantlist = async () => {
+  const handleSendToWantlist = React.useCallback(async () => {
     if (!isConnected || !storeSlug) return;
     const items = pile.map((l) => ({ discogs_listing_id: l.discogs_listing_id }));
     await addToWantlist(items, storeSlug);
-  };
+  }, [isConnected, storeSlug, pile, addToWantlist]);
 
   if (!open) return null;
 
@@ -330,7 +336,7 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
         className="fixed inset-0 bg-black/50 z-40"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        onClick={onClose}
+        onClick={handleClose}
         aria-hidden="true"
       />
 
@@ -394,10 +400,7 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
               ))}
           </div>
           <button
-            onClick={() => {
-              setConfirmClear(false);
-              onClose();
-            }}
+            onClick={handleClose}
             className="inline-flex h-11 w-11 items-center justify-center rounded text-lg leading-none text-mc-text-dim transition-colors hover:bg-mc-bg-raised hover:text-mc-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus"
             aria-label="Close pile"
           >
@@ -422,34 +425,21 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
 
         {/* Footer */}
         {pile.length > 0 && (
-          <div className="flex-shrink-0 px-4 py-4 border-t border-mc-border flex flex-col gap-3">
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-mc-text-dim uppercase tracking-wider">Total</span>
-              <span className="text-sm font-semibold">
-                {formatPriceValue(total.toFixed(2), pile[0]?.currency)}
-              </span>
-            </div>
-            {isConnected && shopper && <ConnectedAccount username={shopper.discogs_username} />}
-            {showResult && (
-              <WantlistResultView
-                result={wantlistResult!}
-                storeName={store?.name ?? null}
-                onDismiss={resetResult}
-              />
-            )}
-            {showError && <WantlistErrorView message={errorMessage} onRetry={resetResult} />}
-            {isInProgress && <WantlistInProgressView count={pile.length} />}
-            {showHandoffAction && (
-              <WantlistHandoffAction
-                storeName={store?.name ?? null}
-                onSend={handleSendToWantlist}
-                highlight={highlightOnMount}
-              />
-            )}
-            {showDisconnectedCta && storeSlug && (
-              <DisconnectedCta storeName={store?.name ?? null} storeSlug={storeSlug} />
-            )}
-          </div>
+          <PileFooter
+            pile={pile}
+            total={total}
+            isConnected={isConnected}
+            shopper={shopper}
+            state={state}
+            wantlistResult={wantlistResult}
+            errorMessage={errorMessage}
+            storeName={store?.name ?? null}
+            storeSlug={storeSlug ?? null}
+            handoffAvailable={handoffAvailable}
+            highlightOnMount={highlightOnMount}
+            onSendToWantlist={handleSendToWantlist}
+            onReset={resetResult}
+          />
         )}
       </motion.div>
     </>

--- a/app/frontend/components/pile_sheet.tsx
+++ b/app/frontend/components/pile_sheet.tsx
@@ -222,37 +222,39 @@ function ConnectedAccount({ username }: { username: string }) {
 
 // ── Footer sub-component ────────────────────────────────────────
 
-interface PileFooterProps {
+interface PileFooterModel {
   pile: Listing[];
   total: number;
-  isConnected: boolean;
   shopper: { discogs_username: string } | null;
+  storeName: string | null;
+  storeSlug: string | null;
   state: string;
   wantlistResult: { wantlist_url: string | null; added: number; skipped: number } | null;
   errorMessage: string | null;
-  storeName: string | null;
-  storeSlug: string | null;
   handoffAvailable: boolean;
   highlightOnMount: boolean | undefined;
-  onSendToWantlist: () => void;
-  onReset: () => void;
+  isConnected: boolean;
 }
 
-function PileFooter({
-  pile,
-  total,
-  isConnected,
-  shopper,
-  state,
-  wantlistResult,
-  errorMessage,
-  storeName,
-  storeSlug,
-  handoffAvailable,
-  highlightOnMount,
-  onSendToWantlist,
-  onReset,
-}: PileFooterProps) {
+interface PileFooterActions {
+  sendToWantlist: () => void;
+  reset: () => void;
+}
+
+function PileFooter({ model, actions }: { model: PileFooterModel; actions: PileFooterActions }) {
+  const {
+    pile,
+    total,
+    isConnected,
+    shopper,
+    state,
+    wantlistResult,
+    errorMessage,
+    storeName,
+    storeSlug,
+    handoffAvailable,
+    highlightOnMount,
+  } = model;
   const isInProgress = state === "creating";
   const showResult = state === "success" && wantlistResult;
   const showError = state === "error";
@@ -269,14 +271,14 @@ function PileFooter({
       </div>
       {isConnected && shopper && <ConnectedAccount username={shopper.discogs_username} />}
       {showResult && (
-        <WantlistResultView result={wantlistResult!} storeName={storeName} onDismiss={onReset} />
+        <WantlistResultView result={wantlistResult!} storeName={storeName} onDismiss={actions.reset} />
       )}
-      {showError && <WantlistErrorView message={errorMessage} onRetry={onReset} />}
+      {showError && <WantlistErrorView message={errorMessage} onRetry={actions.reset} />}
       {isInProgress && <WantlistInProgressView count={pile.length} />}
       {showHandoffAction && (
         <WantlistHandoffAction
           storeName={storeName}
-          onSend={onSendToWantlist}
+          onSend={actions.sendToWantlist}
           highlight={highlightOnMount}
         />
       )}
@@ -327,6 +329,20 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
     const items = pile.map((l) => ({ discogs_listing_id: l.discogs_listing_id }));
     await addToWantlist(items, storeSlug);
   }, [isConnected, storeSlug, pile, addToWantlist]);
+
+  const footerModel: PileFooterModel = {
+    pile,
+    total,
+    isConnected,
+    shopper,
+    state,
+    wantlistResult,
+    errorMessage,
+    storeName: store?.name ?? null,
+    storeSlug: storeSlug ?? null,
+    handoffAvailable,
+    highlightOnMount,
+  };
 
   if (!open) return null;
 
@@ -426,19 +442,8 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
         {/* Footer */}
         {pile.length > 0 && (
           <PileFooter
-            pile={pile}
-            total={total}
-            isConnected={isConnected}
-            shopper={shopper}
-            state={state}
-            wantlistResult={wantlistResult}
-            errorMessage={errorMessage}
-            storeName={store?.name ?? null}
-            storeSlug={storeSlug ?? null}
-            handoffAvailable={handoffAvailable}
-            highlightOnMount={highlightOnMount}
-            onSendToWantlist={handleSendToWantlist}
-            onReset={resetResult}
+            model={footerModel}
+            actions={{ sendToWantlist: handleSendToWantlist, reset: resetResult }}
           />
         )}
       </motion.div>

--- a/app/frontend/components/pile_sheet.tsx
+++ b/app/frontend/components/pile_sheet.tsx
@@ -1,18 +1,15 @@
-import React from "react";
+import { useState, useCallback, useEffect } from "react";
 import { motion } from "framer-motion";
 import { usePage } from "@inertiajs/react";
 import { usePileContext } from "../contexts/pile_context";
 import { useViewport } from "@/hooks/use_viewport";
 import { useDialogFocusTrap } from "@/hooks/use_dialog_focus_trap";
 import { springDrawer } from "@/lib/motion_tokens";
-import { formatPriceValue } from "@/lib/format_price";
 import { useShopperContext } from "../contexts/shopper_context";
-import { DiscogsConnectForm, DiscogsDisconnectForm } from "./discogs_connection_controls";
-import Button from "./ui/button";
-import FeedbackMessage from "./ui/feedback_message";
-import { ActionLink, actionClassName } from "./ui/action";
+import { actionClassName } from "./ui/action";
+import PileRecordItem from "./pile_sheet/pile_record_item";
+import PileFooter from "./pile_sheet/pile_footer";
 import type { Store } from "../types/inertia";
-import type { Listing } from "../types/inertia";
 
 interface PageProps {
   [key: string]: unknown;
@@ -26,275 +23,15 @@ interface Props {
   highlightOnMount?: boolean;
 }
 
-// ── Sub-components ──────────────────────────────────────────────
-
-function PileRecordItem({
-  listing,
-  onRemove,
-}: {
-  listing: Listing;
-  onRemove: (id: number) => void;
-}) {
-  const src = listing.cover_image_url ?? listing.thumbnail_url;
-
-  return (
-    <li className="flex items-center gap-3 px-4 py-3 border-b border-mc-border">
-      <a
-        href={listing.discogs_url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex items-center gap-3 flex-1 min-w-0 group"
-      >
-        <div className="w-12 h-12 flex-shrink-0 rounded bg-mc-bg-raised overflow-hidden border border-mc-border">
-          {src ? (
-            <img
-              src={src}
-              alt={listing.title ?? ""}
-              className="w-full h-full object-cover group-hover:opacity-80 transition-opacity"
-            />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center text-mc-text-dim">♪</div>
-          )}
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="text-xs font-medium truncate group-hover:text-mc-accent transition-colors">
-            {listing.title}
-          </div>
-          <div className="text-xs text-mc-text-dim truncate">{listing.artist}</div>
-        </div>
-        <span className="text-xs font-medium flex-shrink-0">
-          {formatPriceValue(listing.price, listing.currency)}
-        </span>
-      </a>
-      <button
-        onClick={() => onRemove(listing.id)}
-        className="ml-2 inline-flex h-11 w-11 flex-shrink-0 items-center justify-center rounded text-sm leading-none text-mc-text-dim transition-colors hover:text-mc-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus"
-        aria-label={`Remove ${listing.title ?? "record"} from pile`}
-      >
-        ×
-      </button>
-    </li>
-  );
-}
-
-function WantlistResultView({
-  result,
-  storeName,
-  onDismiss,
-}: {
-  result: { wantlist_url: string | null; added: number; skipped: number };
-  storeName: string | null;
-  onDismiss: () => void;
-}) {
-  return (
-    <FeedbackMessage tone="success" live="polite" className="flex flex-col gap-2">
-      <p className="text-xs font-medium">
-        {result.skipped > 0
-          ? `${result.added} of ${result.added + result.skipped} releases added to your Wantlist`
-          : `${result.added} release${result.added === 1 ? "" : "s"} added to your Wantlist`}
-      </p>
-      <p className="text-[11px] text-mc-text-dim">
-        {result.wantlist_url ? (
-          <>Ready to shop from {storeName ?? "this store"} on Discogs.</>
-        ) : (
-          <>
-            Added to your Wantlist. Shop from this store on Discogs by selecting their seller
-            filter.
-          </>
-        )}
-      </p>
-      {result.wantlist_url ? (
-        <ActionLink
-          href={result.wantlist_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          size="lg"
-          className="w-full"
-        >
-          Shop My Wants ↗
-        </ActionLink>
-      ) : (
-        <Button onClick={onDismiss} variant="secondary" size="lg" className="w-full">
-          Keep browsing
-        </Button>
-      )}
-    </FeedbackMessage>
-  );
-}
-
-function WantlistErrorView({ message, onRetry }: { message: string | null; onRetry: () => void }) {
-  return (
-    <FeedbackMessage tone="danger" live="assertive" className="flex flex-col gap-2">
-      <p className="text-xs font-medium">{message || "Something went wrong."}</p>
-      <Button onClick={onRetry} variant="secondary" size="lg" className="w-full">
-        Try again
-      </Button>
-    </FeedbackMessage>
-  );
-}
-
-function WantlistInProgressView({ count }: { count: number }) {
-  return (
-    <FeedbackMessage tone="progress" live="polite" className="flex flex-col gap-2">
-      <Button busy size="lg" className="w-full">
-        Adding to Wantlist…
-      </Button>
-      <p className="text-[11px] text-mc-text-dim text-center">
-        Adding {count} {count === 1 ? "release" : "releases"} to your Wantlist
-      </p>
-    </FeedbackMessage>
-  );
-}
-
-function WantlistHandoffAction({
-  storeName,
-  onSend,
-  highlight,
-}: {
-  storeName: string | null;
-  onSend: () => void;
-  highlight?: boolean;
-}) {
-  const [pulsing, setPulsing] = React.useState(highlight);
-
-  React.useEffect(() => {
-    if (!pulsing) return;
-    const timer = setTimeout(() => setPulsing(false), 2500);
-    return () => clearTimeout(timer);
-  }, [pulsing]);
-
-  return (
-    <div className="flex flex-col gap-2">
-      <p className="text-[11px] text-mc-text-dim leading-relaxed">
-        Get these records from {storeName ?? "this store"} on Discogs.
-      </p>
-      <Button
-        onClick={onSend}
-        size="lg"
-        variant="success"
-        className={
-          pulsing
-            ? "animate-pulse transition-all duration-500"
-            : "transition-all duration-500 opacity-100"
-        }
-      >
-        Send to Discogs Wantlist
-      </Button>
-    </div>
-  );
-}
-
-function DisconnectedCta({
-  storeName,
-  storeSlug,
-}: {
-  storeName: string | null;
-  storeSlug: string;
-}) {
-  const crateSlug =
-    typeof window !== "undefined"
-      ? (window.history.state as { crateSlug?: string } | null)?.crateSlug
-      : undefined;
-
-  return (
-    <div className="flex flex-col gap-2">
-      <p className="text-[11px] text-mc-text-dim leading-relaxed">
-        Connect with Discogs to send these releases to your Wantlist and shop from{" "}
-        {storeName ?? "this store"}.
-      </p>
-      <DiscogsConnectForm
-        storeSlug={storeSlug}
-        crateSlug={crateSlug}
-        buttonClassName={actionClassName({ variant: "danger", size: "lg", className: "w-full" })}
-      />
-    </div>
-  );
-}
-
-function ConnectedAccount({ username }: { username: string }) {
-  return (
-    <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] text-mc-text-dim">
-      <span>Connected to Discogs as @{username}</span>
-      <DiscogsDisconnectForm />
-    </div>
-  );
-}
-
-// ── Footer sub-component ────────────────────────────────────────
-
-interface PileFooterModel {
-  pile: Listing[];
-  total: number;
-  shopper: { discogs_username: string } | null;
-  storeName: string | null;
-  storeSlug: string | null;
-  state: string;
-  wantlistResult: { wantlist_url: string | null; added: number; skipped: number } | null;
-  errorMessage: string | null;
-  handoffAvailable: boolean;
-  highlightOnMount: boolean | undefined;
-  isConnected: boolean;
-}
-
-interface PileFooterActions {
-  sendToWantlist: () => void;
-  reset: () => void;
-}
-
-function PileFooter({ model, actions }: { model: PileFooterModel; actions: PileFooterActions }) {
-  const {
-    pile,
-    total,
-    isConnected,
-    shopper,
-    state,
-    wantlistResult,
-    errorMessage,
-    storeName,
-    storeSlug,
-    handoffAvailable,
-    highlightOnMount,
-  } = model;
-  const isInProgress = state === "creating";
-  const showResult = state === "success" && wantlistResult;
-  const showError = state === "error";
-  const showHandoffAction = handoffAvailable && isConnected && state === "idle";
-  const showDisconnectedCta = handoffAvailable && !isConnected && state === "idle";
-
-  return (
-    <div className="flex-shrink-0 px-4 py-4 border-t border-mc-border flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-mc-text-dim uppercase tracking-wider">Total</span>
-        <span className="text-sm font-semibold">
-          {formatPriceValue(total.toFixed(2), pile[0]?.currency)}
-        </span>
-      </div>
-      {isConnected && shopper && <ConnectedAccount username={shopper.discogs_username} />}
-      {showResult && (
-        <WantlistResultView result={wantlistResult!} storeName={storeName} onDismiss={actions.reset} />
-      )}
-      {showError && <WantlistErrorView message={errorMessage} onRetry={actions.reset} />}
-      {isInProgress && <WantlistInProgressView count={pile.length} />}
-      {showHandoffAction && (
-        <WantlistHandoffAction
-          storeName={storeName}
-          onSend={actions.sendToWantlist}
-          highlight={highlightOnMount}
-        />
-      )}
-      {showDisconnectedCta && storeSlug && (
-        <DisconnectedCta storeName={storeName} storeSlug={storeSlug} />
-      )}
-    </div>
-  );
-}
-
-// ── Main component ──────────────────────────────────────────────
-
+/**
+ * Slide-in sheet for managing the user's record pile.
+ * Handles opening/closing animation, focus trapping, pile CRUD,
+ * and the Discogs Wantlist submission flow.
+ */
 export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMount }: Props) {
   const { pile, removeFromPile, clearPile } = usePileContext();
   const { isCompact } = useViewport();
-  const [confirmClear, setConfirmClear] = React.useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
 
   const page = usePage<PageProps>();
   const store = page.props.store;
@@ -306,43 +43,27 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
 
   const total = pile.reduce((sum, l) => sum + (parseFloat(l.price) || 0), 0);
 
-  const handleClose = React.useCallback(() => {
+  const handleClose = useCallback(() => {
     setConfirmClear(false);
     onClose();
   }, [onClose]);
 
   const { dialogRef, titleRef } = useDialogFocusTrap(open, handleClose, { returnFocusRef });
 
-  // Reset result when sheet closes
-  React.useEffect(() => {
+  useEffect(() => {
     if (!open) resetResult();
   }, [open, resetResult]);
 
-  // Re-focus title when dialog content changes
-  React.useEffect(() => {
+  useEffect(() => {
     if (!open || dialogRef.current?.contains(document.activeElement)) return;
     titleRef.current?.focus();
   }, [open, pile.length, confirmClear, state, dialogRef, titleRef]);
 
-  const handleSendToWantlist = React.useCallback(async () => {
+  const handleSendToWantlist = useCallback(async () => {
     if (!isConnected || !storeSlug) return;
     const items = pile.map((l) => ({ discogs_listing_id: l.discogs_listing_id }));
     await addToWantlist(items, storeSlug);
   }, [isConnected, storeSlug, pile, addToWantlist]);
-
-  const footerModel: PileFooterModel = {
-    pile,
-    total,
-    isConnected,
-    shopper,
-    state,
-    wantlistResult,
-    errorMessage,
-    storeName: store?.name ?? null,
-    storeSlug: storeSlug ?? null,
-    handoffAvailable,
-    highlightOnMount,
-  };
 
   if (!open) return null;
 
@@ -442,8 +163,23 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
         {/* Footer */}
         {pile.length > 0 && (
           <PileFooter
-            model={footerModel}
-            actions={{ sendToWantlist: handleSendToWantlist, reset: resetResult }}
+            pileSize={pile.length}
+            header={{ total, currency: pile[0]?.currency }}
+            shopper={{
+              isConnected,
+              username: shopper?.discogs_username ?? null,
+              storeName: store?.name ?? null,
+              storeSlug: storeSlug ?? null,
+            }}
+            submission={{
+              status: state,
+              wantlistResult,
+              errorMessage,
+            }}
+            handoffAvailable={handoffAvailable}
+            highlightOnMount={highlightOnMount}
+            onSendToWantlist={handleSendToWantlist}
+            onReset={resetResult}
           />
         )}
       </motion.div>

--- a/app/frontend/components/pile_sheet/index.ts
+++ b/app/frontend/components/pile_sheet/index.ts
@@ -1,0 +1,1 @@
+export { default as PileSheet } from "../pile_sheet";

--- a/app/frontend/components/pile_sheet/pile_footer.tsx
+++ b/app/frontend/components/pile_sheet/pile_footer.tsx
@@ -1,0 +1,89 @@
+import { formatPriceValue } from "../../lib/format_price";
+import { ConnectedAccount } from "./wantlist_handoff";
+import { WantlistResultView, WantlistErrorView, WantlistInProgressView } from "./wantlist_views";
+import { WantlistHandoffAction, DisconnectedCta } from "./wantlist_handoff";
+
+interface PileHeaderInfo {
+  total: number;
+  currency?: string;
+}
+
+interface ShopperState {
+  isConnected: boolean;
+  username: string | null;
+  storeName: string | null;
+  storeSlug: string | null;
+}
+
+interface SubmissionState {
+  status: string;
+  wantlistResult: { wantlist_url: string | null; added: number; skipped: number } | null;
+  errorMessage: string | null;
+}
+
+interface PileFooterProps {
+  pileSize: number;
+  header: PileHeaderInfo;
+  shopper: ShopperState;
+  submission: SubmissionState;
+  handoffAvailable: boolean;
+  highlightOnMount: boolean | undefined;
+  onSendToWantlist: () => void;
+  onReset: () => void;
+}
+
+/**
+ * Footer section of the pile sheet showing total price, Discogs connection
+ * status, and contextual CTAs based on the current wantlist submission state.
+ */
+export default function PileFooter({
+  pileSize,
+  header,
+  shopper,
+  submission,
+  handoffAvailable,
+  highlightOnMount,
+  onSendToWantlist,
+  onReset,
+}: PileFooterProps) {
+  const isInProgress = submission.status === "creating";
+  const showResult = submission.status === "success" && submission.wantlistResult;
+  const showError = submission.status === "error";
+  const showHandoffAction = handoffAvailable && shopper.isConnected && submission.status === "idle";
+  const showDisconnectedCta = handoffAvailable && !shopper.isConnected && submission.status === "idle";
+
+  return (
+    <div className="flex-shrink-0 px-4 py-4 border-t border-mc-border flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-mc-text-dim uppercase tracking-wider">Total</span>
+        <span className="text-sm font-semibold">
+          {formatPriceValue(header.total.toFixed(2), header.currency)}
+        </span>
+      </div>
+      {shopper.isConnected && shopper.username && (
+        <ConnectedAccount username={shopper.username} />
+      )}
+      {showResult && (
+        <WantlistResultView
+          result={submission.wantlistResult!}
+          storeName={shopper.storeName}
+          onDismiss={onReset}
+        />
+      )}
+      {showError && (
+        <WantlistErrorView message={submission.errorMessage} onRetry={onReset} />
+      )}
+      {isInProgress && <WantlistInProgressView count={pileSize} />}
+      {showHandoffAction && (
+        <WantlistHandoffAction
+          storeName={shopper.storeName}
+          onSend={onSendToWantlist}
+          highlight={highlightOnMount}
+        />
+      )}
+      {showDisconnectedCta && shopper.storeSlug && (
+        <DisconnectedCta storeName={shopper.storeName} storeSlug={shopper.storeSlug} />
+      )}
+    </div>
+  );
+}

--- a/app/frontend/components/pile_sheet/pile_record_item.tsx
+++ b/app/frontend/components/pile_sheet/pile_record_item.tsx
@@ -1,0 +1,54 @@
+import type { Listing } from "../../types/inertia";
+import { formatPriceValue } from "../../lib/format_price";
+
+interface PileRecordItemProps {
+  listing: Listing;
+  onRemove: (id: number) => void;
+}
+
+/**
+ * A single record entry in the pile sheet list.
+ * Displays cover thumbnail, title, artist, price, and a remove button.
+ */
+export default function PileRecordItem({ listing, onRemove }: PileRecordItemProps) {
+  const src = listing.cover_image_url ?? listing.thumbnail_url;
+
+  return (
+    <li className="flex items-center gap-3 px-4 py-3 border-b border-mc-border">
+      <a
+        href={listing.discogs_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-3 flex-1 min-w-0 group"
+      >
+        <div className="w-12 h-12 flex-shrink-0 rounded bg-mc-bg-raised overflow-hidden border border-mc-border">
+          {src ? (
+            <img
+              src={src}
+              alt={listing.title ?? ""}
+              className="w-full h-full object-cover group-hover:opacity-80 transition-opacity"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-mc-text-dim">♪</div>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-xs font-medium truncate group-hover:text-mc-accent transition-colors">
+            {listing.title}
+          </div>
+          <div className="text-xs text-mc-text-dim truncate">{listing.artist}</div>
+        </div>
+        <span className="text-xs font-medium flex-shrink-0">
+          {formatPriceValue(listing.price, listing.currency)}
+        </span>
+      </a>
+      <button
+        onClick={() => onRemove(listing.id)}
+        className="ml-2 inline-flex h-11 w-11 flex-shrink-0 items-center justify-center rounded text-sm leading-none text-mc-text-dim transition-colors hover:text-mc-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus"
+        aria-label={`Remove ${listing.title ?? "record"} from pile`}
+      >
+        ×
+      </button>
+    </li>
+  );
+}

--- a/app/frontend/components/pile_sheet/wantlist_handoff.tsx
+++ b/app/frontend/components/pile_sheet/wantlist_handoff.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from "react";
+import Button from "../ui/button";
+import { DiscogsConnectForm, DiscogsDisconnectForm } from "../discogs_connection_controls";
+import { actionClassName } from "../ui/action";
+
+export function WantlistHandoffAction({
+  storeName,
+  onSend,
+  highlight,
+}: {
+  storeName: string | null;
+  onSend: () => void;
+  highlight?: boolean;
+}) {
+  const [pulsing, setPulsing] = useState(highlight);
+
+  useEffect(() => {
+    if (!pulsing) return;
+    const timer = setTimeout(() => setPulsing(false), 2500);
+    return () => clearTimeout(timer);
+  }, [pulsing]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-[11px] text-mc-text-dim leading-relaxed">
+        Get these records from {storeName ?? "this store"} on Discogs.
+      </p>
+      <Button
+        onClick={onSend}
+        size="lg"
+        variant="success"
+        className={
+          pulsing
+            ? "animate-pulse transition-all duration-500"
+            : "transition-all duration-500 opacity-100"
+        }
+      >
+        Send to Discogs Wantlist
+      </Button>
+    </div>
+  );
+}
+
+export function DisconnectedCta({
+  storeName,
+  storeSlug,
+}: {
+  storeName: string | null;
+  storeSlug: string;
+}) {
+  const crateSlug =
+    typeof window !== "undefined"
+      ? (window.history.state as { crateSlug?: string } | null)?.crateSlug
+      : undefined;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-[11px] text-mc-text-dim leading-relaxed">
+        Connect with Discogs to send these releases to your Wantlist and shop from{" "}
+        {storeName ?? "this store"}.
+      </p>
+      <DiscogsConnectForm
+        storeSlug={storeSlug}
+        crateSlug={crateSlug}
+        buttonClassName={actionClassName({ variant: "danger", size: "lg", className: "w-full" })}
+      />
+    </div>
+  );
+}
+
+export function ConnectedAccount({ username }: { username: string }) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] text-mc-text-dim">
+      <span>Connected to Discogs as @{username}</span>
+      <DiscogsDisconnectForm />
+    </div>
+  );
+}

--- a/app/frontend/components/pile_sheet/wantlist_views.tsx
+++ b/app/frontend/components/pile_sheet/wantlist_views.tsx
@@ -1,0 +1,84 @@
+import Button from "../ui/button";
+import FeedbackMessage from "../ui/feedback_message";
+import { ActionLink } from "../ui/action";
+
+interface WantlistResult {
+  wantlist_url: string | null;
+  added: number;
+  skipped: number;
+}
+
+export function WantlistResultView({
+  result,
+  storeName,
+  onDismiss,
+}: {
+  result: WantlistResult;
+  storeName: string | null;
+  onDismiss: () => void;
+}) {
+  return (
+    <FeedbackMessage tone="success" live="polite" className="flex flex-col gap-2">
+      <p className="text-xs font-medium">
+        {result.skipped > 0
+          ? `${result.added} of ${result.added + result.skipped} releases added to your Wantlist`
+          : `${result.added} release${result.added === 1 ? "" : "s"} added to your Wantlist`}
+      </p>
+      <p className="text-[11px] text-mc-text-dim">
+        {result.wantlist_url ? (
+          <>Ready to shop from {storeName ?? "this store"} on Discogs.</>
+        ) : (
+          <>
+            Added to your Wantlist. Shop from this store on Discogs by selecting their seller
+            filter.
+          </>
+        )}
+      </p>
+      {result.wantlist_url ? (
+        <ActionLink
+          href={result.wantlist_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          size="lg"
+          className="w-full"
+        >
+          Shop My Wants ↗
+        </ActionLink>
+      ) : (
+        <Button onClick={onDismiss} variant="secondary" size="lg" className="w-full">
+          Keep browsing
+        </Button>
+      )}
+    </FeedbackMessage>
+  );
+}
+
+export function WantlistErrorView({
+  message,
+  onRetry,
+}: {
+  message: string | null;
+  onRetry: () => void;
+}) {
+  return (
+    <FeedbackMessage tone="danger" live="assertive" className="flex flex-col gap-2">
+      <p className="text-xs font-medium">{message || "Something went wrong."}</p>
+      <Button onClick={onRetry} variant="secondary" size="lg" className="w-full">
+        Try again
+      </Button>
+    </FeedbackMessage>
+  );
+}
+
+export function WantlistInProgressView({ count }: { count: number }) {
+  return (
+    <FeedbackMessage tone="progress" live="polite" className="flex flex-col gap-2">
+      <Button busy size="lg" className="w-full">
+        Adding to Wantlist…
+      </Button>
+      <p className="text-[11px] text-mc-text-dim text-center">
+        Adding {count} {count === 1 ? "release" : "releases"} to your Wantlist
+      </p>
+    </FeedbackMessage>
+  );
+}

--- a/app/frontend/components/record_card.tsx
+++ b/app/frontend/components/record_card.tsx
@@ -1,61 +1,131 @@
-import React, { useEffect, useRef, useState } from "react"
-import { motion } from "framer-motion"
-import { usePileContext } from "../contexts/pile_context"
-import { springFlip } from "@/lib/motion_tokens"
-import { formatPrice } from "@/lib/format_price"
-import Button from "@/components/ui/button"
-import { ActionLink } from "@/components/ui/action"
-import type { Listing } from "../types/inertia"
+import { useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { usePileContext } from "../contexts/pile_context";
+import { springFlip } from "@/lib/motion_tokens";
+import { formatPrice } from "@/lib/format_price";
+import Button from "@/components/ui/button";
+import { ActionLink } from "@/components/ui/action";
+import type { Listing } from "../types/inertia";
 
-interface Props {
-  listing: Listing
-  resetKey?: string | number
-  className?: string
-  imageLoading?: "eager" | "lazy"
-  disableFlip?: boolean
-  framed?: boolean
+interface RecordCardProps {
+  listing: Listing;
+  resetKey?: string | number;
+  className?: string;
+  imageLoading?: "eager" | "lazy";
+  disableFlip?: boolean;
+  framed?: boolean;
 }
 
-export default function RecordCard({ listing, resetKey, className = "", imageLoading = "lazy", disableFlip = false, framed = false }: Props) {
-  const [flipped, setFlipped] = useState(false)
-  const pointerDown = useRef<{ x: number; y: number } | null>(null)
-  const { inPile, addToPile, removeFromPile } = usePileContext()
-  const canFlip = !disableFlip
+interface RecordCardBackProps {
+  listing: Listing;
+  meta: string;
+  inPile: (id: number) => boolean;
+  addToPile: (listing: Listing) => void;
+  removeFromPile: (id: number) => void;
+}
+
+function RecordCardBack({ listing, meta, inPile, addToPile, removeFromPile }: RecordCardBackProps) {
+  return (
+    <div
+      className="rounded-lg overflow-hidden shadow-xl bg-mc-bg-card"
+      style={{
+        position: "absolute",
+        inset: 0,
+        backfaceVisibility: "hidden",
+        WebkitBackfaceVisibility: "hidden",
+        transform: "rotateY(180deg)",
+        contain: "paint",
+      }}
+    >
+      <div className="flex flex-col h-full p-4 gap-2">
+        <div className="text-sm font-semibold leading-tight line-clamp-3">{listing.title}</div>
+        <div className="text-xs text-mc-text leading-tight">{listing.artist}</div>
+        {meta && <div className="text-xs text-mc-text-dim">{meta}</div>}
+        {listing.genres.length > 0 && (
+          <div className="flex gap-1 flex-wrap">
+            {listing.genres.slice(0, 3).map((g) => (
+              <span
+                key={g}
+                className="text-[10px] px-1.5 py-0.5 rounded bg-mc-bg-raised text-mc-text-dim"
+              >
+                {g}
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="text-sm font-medium mt-auto">{formatPrice(listing)}</div>
+        <div className="flex gap-1 mt-1" onClick={(e) => e.stopPropagation()}>
+          {inPile(listing.id) ? (
+            <Button variant="secondary" size="sm" onClick={() => removeFromPile(listing.id)}>
+              ✓ In pile
+            </Button>
+          ) : (
+            <Button size="sm" onClick={() => addToPile(listing)}>
+              + Pile
+            </Button>
+          )}
+          <ActionLink
+            variant="secondary"
+            size="sm"
+            href={listing.discogs_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Discogs ↗
+          </ActionLink>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function RecordCard({
+  listing,
+  resetKey,
+  className = "",
+  imageLoading = "lazy",
+  disableFlip = false,
+  framed = false,
+}: RecordCardProps) {
+  const [flipped, setFlipped] = useState(false);
+  const pointerDown = useRef<{ x: number; y: number } | null>(null);
+  const { inPile, addToPile, removeFromPile } = usePileContext();
+  const canFlip = !disableFlip;
 
   useEffect(() => {
-    setFlipped(false)
-  }, [resetKey])
+    setFlipped(false);
+  }, [resetKey]);
 
   const handlePointerDown = (e: React.PointerEvent) => {
-    pointerDown.current = { x: e.clientX, y: e.clientY }
-  }
+    pointerDown.current = { x: e.clientX, y: e.clientY };
+  };
 
   const movedSincePointerDown = (e: React.MouseEvent) => {
-    if (!pointerDown.current) return false
-    const deltaX = Math.abs(e.clientX - pointerDown.current.x)
-    const deltaY = Math.abs(e.clientY - pointerDown.current.y)
-    pointerDown.current = null
-    return Math.hypot(deltaX, deltaY) > 8
-  }
+    if (!pointerDown.current) return false;
+    const deltaX = Math.abs(e.clientX - pointerDown.current.x);
+    const deltaY = Math.abs(e.clientY - pointerDown.current.y);
+    pointerDown.current = null;
+    return Math.hypot(deltaX, deltaY) > 8;
+  };
 
   const handleFlip = (e: React.MouseEvent) => {
-    if (!canFlip) return
-    if ((e.target as HTMLElement).closest("a, button, form")) return
-    if (movedSincePointerDown(e)) return
-    setFlipped((f) => !f)
-  }
+    if (!canFlip) return;
+    if ((e.target as HTMLElement).closest("a, button, form")) return;
+    if (movedSincePointerDown(e)) return;
+    setFlipped((f) => !f);
+  };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!canFlip) return
-    if ((e.target as HTMLElement).closest("a, button, form")) return
+    if (!canFlip) return;
+    if ((e.target as HTMLElement).closest("a, button, form")) return;
 
     if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault()
-      setFlipped((f) => !f)
+      e.preventDefault();
+      setFlipped((f) => !f);
     }
-  }
+  };
 
-  const meta = [listing.label, listing.year, listing.condition].filter(Boolean).join(" · ")
+  const meta = [listing.label, listing.year, listing.condition].filter(Boolean).join(" · ");
 
   return (
     <div
@@ -63,7 +133,11 @@ export default function RecordCard({ listing, resetKey, className = "", imageLoa
       style={{ perspective: 800, touchAction: "none" }}
       role={canFlip ? "button" : undefined}
       tabIndex={canFlip ? 0 : undefined}
-      aria-label={canFlip ? `${flipped ? "Show cover for" : "Show details for"} ${listing.title ?? "record"}` : undefined}
+      aria-label={
+        canFlip
+          ? `${flipped ? "Show cover for" : "Show details for"} ${listing.title ?? "record"}`
+          : undefined
+      }
       aria-pressed={canFlip ? flipped : undefined}
       onPointerDown={handlePointerDown}
       onDragStart={(e) => e.preventDefault()}
@@ -106,61 +180,20 @@ export default function RecordCard({ listing, resetKey, className = "", imageLoa
               decoding="async"
             />
           ) : (
-            <div className="w-full h-full flex items-center justify-center bg-mc-bg-raised text-mc-text-dim text-5xl">♪</div>
+            <div className="w-full h-full flex items-center justify-center bg-mc-bg-raised text-mc-text-dim text-5xl">
+              ♪
+            </div>
           )}
         </div>
 
-        {/* Back */}
-        <div
-          className="rounded-lg overflow-hidden shadow-xl bg-mc-bg-card"
-          style={{
-            position: "absolute",
-            inset: 0,
-            backfaceVisibility: "hidden",
-            WebkitBackfaceVisibility: "hidden",
-            transform: "rotateY(180deg)",
-            contain: "paint",
-          }}
-        >
-          <div className="flex flex-col h-full p-4 gap-2">
-            <div className="text-sm font-semibold leading-tight line-clamp-3">
-              {listing.title}
-            </div>
-            <div className="text-xs text-mc-text leading-tight">
-              {listing.artist}
-            </div>
-            {meta && (
-              <div className="text-xs text-mc-text-dim">{meta}</div>
-            )}
-            {listing.genres.length > 0 && (
-              <div className="flex gap-1 flex-wrap">
-                {listing.genres.slice(0, 3).map((g) => (
-                  <span key={g} className="text-[10px] px-1.5 py-0.5 rounded bg-mc-bg-raised text-mc-text-dim">
-                    {g}
-                  </span>
-                ))}
-              </div>
-            )}
-            <div className="text-sm font-medium mt-auto">
-              {formatPrice(listing)}
-            </div>
-            <div className="flex gap-1 mt-1" onClick={(e) => e.stopPropagation()}>
-              {inPile(listing.id) ? (
-                <Button variant="secondary" size="sm" onClick={() => removeFromPile(listing.id)}>
-                  ✓ In pile
-                </Button>
-              ) : (
-                <Button size="sm" onClick={() => addToPile(listing)}>
-                  + Pile
-                </Button>
-              )}
-              <ActionLink variant="secondary" size="sm" href={listing.discogs_url} target="_blank" rel="noopener noreferrer">
-                Discogs ↗
-              </ActionLink>
-            </div>
-          </div>
-        </div>
+        <RecordCardBack
+          listing={listing}
+          meta={meta}
+          inPile={inPile}
+          addToPile={addToPile}
+          removeFromPile={removeFromPile}
+        />
       </motion.div>
     </div>
-  )
+  );
 }

--- a/app/frontend/components/spinner.test.tsx
+++ b/app/frontend/components/spinner.test.tsx
@@ -1,0 +1,20 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render } from "@testing-library/react"
+import Spinner from "./spinner"
+
+describe("Spinner", () => {
+  it("renders an SVG with aria-hidden", () => {
+    const { container } = render(<Spinner />)
+    const svg = container.querySelector("svg")
+    expect(svg).toBeDefined()
+    expect(svg?.getAttribute("aria-hidden")).toBe("true")
+  })
+
+  it("accepts size prop", () => {
+    const { container } = render(<Spinner size="lg" />)
+    const svg = container.querySelector("svg")
+    expect(svg?.getAttribute("class")).toContain("h-8")
+    expect(svg?.getAttribute("class")).toContain("w-8")
+  })
+})

--- a/app/frontend/components/spinner.tsx
+++ b/app/frontend/components/spinner.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+
+interface SpinnerProps {
+  size?: "sm" | "md" | "lg"
+  className?: string
+}
+
+const sizeClasses = {
+  sm: "h-4 w-4",
+  md: "h-5 w-5",
+  lg: "h-8 w-8",
+} as const
+
+/**
+ * Shared loading spinner. Replaces all inline SVG copies across the app.
+ */
+export default function Spinner({ size = "md", className = "" }: SpinnerProps) {
+  return (
+    <svg
+      className={`motion-safe:animate-spin text-mc-accent/80 ${sizeClasses[size]} ${className}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+  )
+}

--- a/app/frontend/components/spinner.tsx
+++ b/app/frontend/components/spinner.tsx
@@ -1,15 +1,13 @@
-import React from "react"
-
 interface SpinnerProps {
-  size?: "sm" | "md" | "lg"
-  className?: string
+  size?: "sm" | "md" | "lg";
+  className?: string;
 }
 
 const sizeClasses = {
   sm: "h-4 w-4",
   md: "h-5 w-5",
   lg: "h-8 w-8",
-} as const
+} as const;
 
 /**
  * Shared loading spinner. Replaces all inline SVG copies across the app.
@@ -24,7 +22,11 @@ export default function Spinner({ size = "md", className = "" }: SpinnerProps) {
       aria-hidden="true"
     >
       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
     </svg>
-  )
+  );
 }

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -1,16 +1,16 @@
-import { motion } from "framer-motion"
-import CrateShelf from "./crate_shelf"
-import FeaturedCratesRow from "./featured_crates_row"
-import GenreGrid from "./genre_grid"
-import { useTactileHover } from "@/hooks/use_tactile_hover"
-import { useViewport } from "@/hooks/use_viewport"
-import { springTactile, springPress, SCALE_HOVER, SCALE_PRESS } from "@/lib/motion_tokens"
-import type { Crate } from "../types/inertia"
-import type { StorefrontSection } from "../types/inertia"
+import { motion } from "framer-motion";
+import CrateShelf from "./crate_shelf";
+import FeaturedCratesRow from "./featured_crates_row";
+import GenreGrid from "./genre_grid";
+import { useTactileHover } from "@/hooks/use_tactile_hover";
+import { useViewport } from "@/hooks/use_viewport";
+import { springTactile, springPress, SCALE_HOVER, SCALE_PRESS } from "@/lib/motion_tokens";
+import type { Crate } from "../types/inertia";
+import type { StorefrontSection } from "../types/inertia";
 
 interface Props {
-  sections: StorefrontSection[]
-  onSelectCrate: (slug: string, startIndex?: number) => void
+  sections: StorefrontSection[];
+  onSelectCrate: (slug: string, startIndex?: number) => void;
 }
 
 /**
@@ -23,15 +23,25 @@ function PicksShelf({
   picksPreviewCount,
   today,
 }: {
-  crate: Crate
-  onSelectCrate: (slug: string, startIndex?: number) => void
-  picksPreviewCount: number
-  today: string
+  crate: Crate;
+  onSelectCrate: (slug: string, startIndex?: number) => void;
+  picksPreviewCount: number;
+  today: string;
 }) {
-  const { isCompact } = useViewport()
-  const { isHovered, isPressed, handlers } = useTactileHover()
+  const { isCompact } = useViewport();
+  const { isHovered, isPressed, handlers } = useTactileHover();
 
-  const shelf = (
+  const shelf = isCompact ? (
+    <CrateShelf
+      crate={crate}
+      interactive
+      onSelectCrate={onSelectCrate}
+      previewCount={picksPreviewCount}
+      meta={today}
+      openLabel="DIG →"
+      tactileThumbnails={false}
+    />
+  ) : (
     <CrateShelf
       crate={crate}
       interactive
@@ -40,10 +50,12 @@ function PicksShelf({
       meta={today}
       openLabel="DIG →"
       tactileThumbnails={!isCompact}
+      className="border-0 rounded-none"
+      isHovered={isHovered}
     />
-  )
+  );
 
-  if (isCompact) return shelf
+  if (isCompact) return shelf;
 
   return (
     <motion.div
@@ -59,21 +71,21 @@ function PicksShelf({
     >
       {shelf}
     </motion.div>
-  )
+  );
 }
 
 export default function StoreFloor({ sections, onSelectCrate }: Props) {
-  const { isCompact } = useViewport()
+  const { isCompact } = useViewport();
 
   // Tier-specific preview density: compact shows fewer, wide shows more
-  const picksPreviewCount = isCompact ? 4 : 8
+  const picksPreviewCount = isCompact ? 4 : 8;
 
   return (
     <div className="flex flex-col gap-8 sm:gap-10">
       {sections.map((section) => {
         if (section.key === "picks_wall") {
-          const picks = section.crate
-          const today = new Date().toLocaleDateString("en-US", { month: "short", day: "numeric" })
+          const picks = section.crate;
+          const today = new Date().toLocaleDateString("en-US", { month: "short", day: "numeric" });
 
           return (
             picks.records.length > 0 && (
@@ -85,19 +97,25 @@ export default function StoreFloor({ sections, onSelectCrate }: Props) {
                 today={today}
               />
             )
-          )
+          );
         }
 
         if (section.key === "featured_crates") {
-          return <FeaturedCratesRow key="featured" crates={section.crates} onSelectCrate={onSelectCrate} />
+          return (
+            <FeaturedCratesRow
+              key="featured"
+              crates={section.crates}
+              onSelectCrate={onSelectCrate}
+            />
+          );
         }
 
         if (section.key === "genre_grid") {
-          return <GenreGrid key="genres" crates={section.crates} onSelectCrate={onSelectCrate} />
+          return <GenreGrid key="genres" crates={section.crates} onSelectCrate={onSelectCrate} />;
         }
 
-        return null
+        return null;
       })}
     </div>
-  )
+  );
 }

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -13,11 +13,7 @@ interface Props {
   onSelectCrate: (slug: string, startIndex?: number) => void;
 }
 
-/**
- * Wraps the picks CrateShelf in a tactile container on desktop viewports.
- * On compact, renders the shelf directly without animation wrapper.
- */
-function PicksShelf({
+function CompactPicksShelf({
   crate,
   onSelectCrate,
   picksPreviewCount,
@@ -28,10 +24,7 @@ function PicksShelf({
   picksPreviewCount: number;
   today: string;
 }) {
-  const { isCompact } = useViewport();
-  const { isHovered, isPressed, handlers } = useTactileHover();
-
-  const shelf = isCompact ? (
+  return (
     <CrateShelf
       crate={crate}
       interactive
@@ -41,21 +34,21 @@ function PicksShelf({
       openLabel="DIG →"
       tactileThumbnails={false}
     />
-  ) : (
-    <CrateShelf
-      crate={crate}
-      interactive
-      onSelectCrate={onSelectCrate}
-      previewCount={picksPreviewCount}
-      meta={today}
-      openLabel="DIG →"
-      tactileThumbnails={!isCompact}
-      className="border-0 rounded-none"
-      isHovered={isHovered}
-    />
   );
+}
 
-  if (isCompact) return shelf;
+function DesktopPicksShelf({
+  crate,
+  onSelectCrate,
+  picksPreviewCount,
+  today,
+}: {
+  crate: Crate;
+  onSelectCrate: (slug: string, startIndex?: number) => void;
+  picksPreviewCount: number;
+  today: string;
+}) {
+  const { isHovered, isPressed, handlers } = useTactileHover();
 
   return (
     <motion.div
@@ -69,8 +62,52 @@ function PicksShelf({
       transition={isPressed ? springPress : springTactile}
       {...handlers}
     >
-      {shelf}
+      <CrateShelf
+        crate={crate}
+        interactive
+        onSelectCrate={onSelectCrate}
+        previewCount={picksPreviewCount}
+        meta={today}
+        openLabel="DIG →"
+        tactileThumbnails
+        className="border-0 rounded-none"
+        isHovered={isHovered}
+      />
     </motion.div>
+  );
+}
+
+function PicksShelf({
+  crate,
+  onSelectCrate,
+  picksPreviewCount,
+  today,
+}: {
+  crate: Crate;
+  onSelectCrate: (slug: string, startIndex?: number) => void;
+  picksPreviewCount: number;
+  today: string;
+}) {
+  const { isCompact } = useViewport();
+
+  if (isCompact) {
+    return (
+      <CompactPicksShelf
+        crate={crate}
+        onSelectCrate={onSelectCrate}
+        picksPreviewCount={picksPreviewCount}
+        today={today}
+      />
+    );
+  }
+
+  return (
+    <DesktopPicksShelf
+      crate={crate}
+      onSelectCrate={onSelectCrate}
+      picksPreviewCount={picksPreviewCount}
+      today={today}
+    />
   );
 }
 

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -13,70 +13,6 @@ interface Props {
   onSelectCrate: (slug: string, startIndex?: number) => void;
 }
 
-function CompactPicksShelf({
-  crate,
-  onSelectCrate,
-  picksPreviewCount,
-  today,
-}: {
-  crate: Crate;
-  onSelectCrate: (slug: string, startIndex?: number) => void;
-  picksPreviewCount: number;
-  today: string;
-}) {
-  return (
-    <CrateShelf
-      crate={crate}
-      interactive
-      onSelectCrate={onSelectCrate}
-      previewCount={picksPreviewCount}
-      meta={today}
-      openLabel="DIG →"
-      tactileThumbnails={false}
-    />
-  );
-}
-
-function DesktopPicksShelf({
-  crate,
-  onSelectCrate,
-  picksPreviewCount,
-  today,
-}: {
-  crate: Crate;
-  onSelectCrate: (slug: string, startIndex?: number) => void;
-  picksPreviewCount: number;
-  today: string;
-}) {
-  const { isHovered, isPressed, handlers } = useTactileHover();
-
-  return (
-    <motion.div
-      className="w-full rounded-lg overflow-hidden border"
-      animate={{
-        borderColor: isHovered ? "var(--mc-accent)" : "var(--mc-border)",
-        scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
-        y: isHovered ? -3 : 0,
-        rotate: isHovered ? 0 : -0.5,
-      }}
-      transition={isPressed ? springPress : springTactile}
-      {...handlers}
-    >
-      <CrateShelf
-        crate={crate}
-        interactive
-        onSelectCrate={onSelectCrate}
-        previewCount={picksPreviewCount}
-        meta={today}
-        openLabel="DIG →"
-        tactileThumbnails
-        className="border-0 rounded-none"
-        isHovered={isHovered}
-      />
-    </motion.div>
-  );
-}
-
 function PicksShelf({
   crate,
   onSelectCrate,
@@ -90,25 +26,42 @@ function PicksShelf({
 }) {
   const { isCompact } = useViewport();
 
-  if (isCompact) {
+  const shelf = (
+    <CrateShelf
+      crate={crate}
+      interactive
+      onSelectCrate={onSelectCrate}
+      previewCount={picksPreviewCount}
+      meta={today}
+      openLabel="DIG →"
+      tactileThumbnails={!isCompact}
+      className={!isCompact ? "border-0 rounded-none" : undefined}
+    />
+  );
+
+  // Desktop: wrap in a hover-animated motion container
+  if (!isCompact) {
+    const { isHovered, isPressed, handlers } = useTactileHover();
+
     return (
-      <CompactPicksShelf
-        crate={crate}
-        onSelectCrate={onSelectCrate}
-        picksPreviewCount={picksPreviewCount}
-        today={today}
-      />
+      <motion.div
+        className="w-full rounded-lg overflow-hidden border"
+        animate={{
+          borderColor: isHovered ? "var(--mc-accent)" : "var(--mc-border)",
+          scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
+          y: isHovered ? -3 : 0,
+          rotate: isHovered ? 0 : -0.5,
+        }}
+        transition={isPressed ? springPress : springTactile}
+        {...handlers}
+      >
+        {shelf}
+      </motion.div>
     );
   }
 
-  return (
-    <DesktopPicksShelf
-      crate={crate}
-      onSelectCrate={onSelectCrate}
-      picksPreviewCount={picksPreviewCount}
-      today={today}
-    />
-  );
+  // Compact: plain shelf, no hover wrapper
+  return shelf;
 }
 
 export default function StoreFloor({ sections, onSelectCrate }: Props) {

--- a/app/frontend/hooks/use_admin_discogs_lookup.ts
+++ b/app/frontend/hooks/use_admin_discogs_lookup.ts
@@ -1,0 +1,123 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+
+export type AdminDiscogsLookupResponse = {
+  status: "creatable";
+  creatable: true;
+  username: string;
+  seller_name?: string | null;
+  avatar_url?: string | null;
+} | {
+  status: "invalid" | "lookup_error";
+  creatable: false;
+  reason?: string;
+} | {
+  status: "already_active";
+  creatable: false;
+  username: string;
+  store: {
+    id: number;
+    name: string;
+    discogs_username: string;
+  };
+} | {
+  status: "existing_applicant";
+  creatable: false;
+  username: string;
+  applicant: {
+    id: number;
+    name: string;
+    discogs_username: string;
+  };
+};
+
+type AdminLookupState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "result"; result: AdminDiscogsLookupResponse };
+
+interface UseAdminDiscogsLookupResult {
+  state: AdminLookupState;
+  lookup: (username: string) => void;
+  reset: () => void;
+}
+
+/**
+ * Manages the admin Discogs username lookup lifecycle: fetch, abort,
+ * timeout, and state machine. Mirrors useDiscogsLookup's pattern but
+ * uses the admin-specific API endpoint and response format.
+ */
+export function useAdminDiscogsLookup(
+  lookupPath: string,
+): UseAdminDiscogsLookupResult {
+  const [state, setState] = useState<AdminLookupState>({ status: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const lookup = useCallback(
+    (username: string) => {
+      abortRef.current?.abort();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setState({ status: "loading" });
+
+      const url = new URL(lookupPath, window.location.origin);
+      url.searchParams.set("username", username);
+
+      timeoutRef.current = setTimeout(() => {
+        if (abortRef.current !== controller) return;
+        controller.abort();
+        abortRef.current = null;
+        timeoutRef.current = null;
+        setState({ status: "error" });
+      }, 10_000);
+
+      fetch(url.toString(), {
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`Lookup failed with ${res.status}`);
+          return res.json() as Promise<AdminDiscogsLookupResponse>;
+        })
+        .then((data) => {
+          if (abortRef.current !== controller) return;
+          if (controller.signal.aborted) return;
+          if (timeoutRef.current) clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+          abortRef.current = null;
+          setState({ status: "result", result: data });
+        })
+        .catch((err) => {
+          if (abortRef.current !== controller) return;
+          if (controller.signal.aborted) return;
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          if (timeoutRef.current) clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+          abortRef.current = null;
+          setState({ status: "error" });
+        });
+    },
+    [lookupPath],
+  );
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
+    setState({ status: "idle" });
+  }, []);
+
+  return { state, lookup, reset };
+}

--- a/app/frontend/hooks/use_crate_navigation.ts
+++ b/app/frontend/hooks/use_crate_navigation.ts
@@ -19,7 +19,6 @@ interface UseCrateNavigationResult {
   index: number;
   direction: React.RefObject<RiffleDirection>;
   navigate: (riffleDirection: RiffleDirection) => void;
-  handleKeyDown: (e: KeyboardEvent) => void;
   handleDragEnd: (info: {
     offset: { x: number; y: number };
     velocity: { x: number; y: number };
@@ -28,7 +27,56 @@ interface UseCrateNavigationResult {
   showGestureHint: boolean;
   progress: number;
   dragRotationRef: React.RefObject<HTMLDivElement | null>;
-  indexRef: React.MutableRefObject<number>;
+}
+
+interface DragEndInfo {
+  offset: { x: number; y: number };
+  velocity: { x: number; y: number };
+}
+
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    target.isContentEditable
+  );
+}
+
+function useDragNavigation(navigate: (direction: RiffleDirection) => void) {
+  return useCallback(
+    (info: DragEndInfo) => {
+      const riffleDirection = resolveRiffleDrag({
+        offsetX: info.offset.x,
+        offsetY: info.offset.y,
+        velocityY: info.velocity.y,
+      });
+
+      if (!riffleDirection) return;
+
+      navigate(riffleDirection);
+    },
+    [navigate],
+  );
+}
+
+function useKeyboardNavigation(navigate: (direction: RiffleDirection) => void) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      if (e.key === "ArrowDown") navigate("deeper");
+      if (e.key === "ArrowUp") navigate("front");
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 }
 
 /**
@@ -88,42 +136,8 @@ export function useCrateNavigation({
     [total, isCompact],
   );
 
-  const handleDragEnd = useCallback(
-    (info: { offset: { x: number; y: number }; velocity: { x: number; y: number } }) => {
-      const riffleDirection = resolveRiffleDrag({
-        offsetX: info.offset.x,
-        offsetY: info.offset.y,
-        velocityY: info.velocity.y,
-      });
-
-      if (riffleDirection) {
-        navigate(riffleDirection);
-      }
-    },
-    [navigate],
-  );
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement;
-      if (
-        target instanceof HTMLInputElement ||
-        target instanceof HTMLTextAreaElement ||
-        target instanceof HTMLSelectElement ||
-        target.isContentEditable
-      )
-        return;
-      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
-      if (e.key === "ArrowDown") navigate("deeper");
-      if (e.key === "ArrowUp") navigate("front");
-    },
-    [navigate],
-  );
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
+  const handleDragEnd = useDragNavigation(navigate);
+  useKeyboardNavigation(navigate);
 
   const progress = total > 0 ? ((index + 1) / total) * 100 : 0;
 
@@ -131,12 +145,10 @@ export function useCrateNavigation({
     index,
     direction,
     navigate,
-    handleKeyDown,
     handleDragEnd,
     edgeStatus,
     showGestureHint,
     progress,
     dragRotationRef,
-    indexRef,
   };
 }

--- a/app/frontend/hooks/use_crate_navigation.ts
+++ b/app/frontend/hooks/use_crate_navigation.ts
@@ -11,6 +11,8 @@ interface UseCrateNavigationOptions {
   total: number;
   isCompact: boolean;
   initialIndex: number;
+  /** Changing this key resets index, edge, and gesture state (e.g., activeSlug). */
+  resetKey: string;
 }
 
 interface UseCrateNavigationResult {
@@ -39,6 +41,7 @@ export function useCrateNavigation({
   total,
   isCompact,
   initialIndex,
+  resetKey,
 }: UseCrateNavigationOptions): UseCrateNavigationResult {
   const [index, setIndex] = useState(initialIndex);
   const [showGestureHint, setShowGestureHint] = useState(() => !isLessonLearned());
@@ -56,7 +59,7 @@ export function useCrateNavigation({
     setIndex(initialIndex);
     setShowGestureHint(!isLessonLearned());
     setEdgeStatus(null);
-  }, [initialIndex]);
+  }, [initialIndex, resetKey]);
 
   const navigate = useCallback(
     (riffleDirection: RiffleDirection) => {

--- a/app/frontend/hooks/use_crate_navigation.ts
+++ b/app/frontend/hooks/use_crate_navigation.ts
@@ -1,0 +1,139 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import {
+  RIFFLE_LANGUAGE,
+  resolveRiffleMove,
+  resolveRiffleDrag,
+  type RiffleDirection,
+} from "@/lib/riffle_navigation";
+import { markLessonLearned, isLessonLearned } from "@/lib/first_swipe_lesson";
+
+interface UseCrateNavigationOptions {
+  total: number;
+  isCompact: boolean;
+  initialIndex: number;
+}
+
+interface UseCrateNavigationResult {
+  index: number;
+  direction: React.RefObject<RiffleDirection>;
+  navigate: (riffleDirection: RiffleDirection) => void;
+  handleKeyDown: (e: KeyboardEvent) => void;
+  handleDragEnd: (info: {
+    offset: { x: number; y: number };
+    velocity: { x: number; y: number };
+  }) => void;
+  edgeStatus: string | null;
+  showGestureHint: boolean;
+  progress: number;
+  dragRotationRef: React.RefObject<HTMLDivElement | null>;
+  indexRef: React.MutableRefObject<number>;
+}
+
+/**
+ * Owns the crate navigation state machine: index, direction, edge detection,
+ * keyboard bindings, gesture-hint lifecycle, and progress computation.
+ * Exposes a ref-based index (indexRef) so the navigate callback always reads
+ * the latest index — critical for rapid keyboard navigation.
+ */
+export function useCrateNavigation({
+  total,
+  isCompact,
+  initialIndex,
+}: UseCrateNavigationOptions): UseCrateNavigationResult {
+  const [index, setIndex] = useState(initialIndex);
+  const [showGestureHint, setShowGestureHint] = useState(() => !isLessonLearned());
+  const [edgeStatus, setEdgeStatus] = useState<string | null>(null);
+
+  const direction = useRef<RiffleDirection>("deeper");
+  const indexRef = useRef(index);
+  const dragRotationRef = useRef<HTMLDivElement>(null);
+
+  // Keep indexRef in sync so navigate callback reads the latest index
+  // even before React re-renders (critical for rapid keyboard navigation)
+  indexRef.current = index;
+
+  useEffect(() => {
+    setIndex(initialIndex);
+    setShowGestureHint(!isLessonLearned());
+    setEdgeStatus(null);
+  }, [initialIndex]);
+
+  const navigate = useCallback(
+    (riffleDirection: RiffleDirection) => {
+      const move = resolveRiffleMove({
+        currentIndex: indexRef.current,
+        total,
+        direction: riffleDirection,
+      });
+
+      if (!move.moved) {
+        setEdgeStatus(RIFFLE_LANGUAGE.edgeStatus[riffleDirection]);
+        return;
+      }
+
+      direction.current = riffleDirection;
+      indexRef.current = move.nextIndex;
+      setIndex(move.nextIndex);
+      setShowGestureHint(false);
+      setEdgeStatus(null);
+
+      // Mark the first-swipe lesson learned on successful vertical riffle
+      if (isCompact) {
+        markLessonLearned();
+      }
+    },
+    [total, isCompact],
+  );
+
+  const handleDragEnd = useCallback(
+    (info: { offset: { x: number; y: number }; velocity: { x: number; y: number } }) => {
+      const riffleDirection = resolveRiffleDrag({
+        offsetX: info.offset.x,
+        offsetY: info.offset.y,
+        velocityY: info.velocity.y,
+      });
+
+      if (riffleDirection) {
+        navigate(riffleDirection);
+      }
+    },
+    [navigate],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLSelectElement ||
+        target.isContentEditable
+      )
+        return;
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      if (e.key === "ArrowDown") navigate("deeper");
+      if (e.key === "ArrowUp") navigate("front");
+    },
+    [navigate],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  const progress = total > 0 ? ((index + 1) / total) * 100 : 0;
+
+  return {
+    index,
+    direction,
+    navigate,
+    handleKeyDown,
+    handleDragEnd,
+    edgeStatus,
+    showGestureHint,
+    progress,
+    dragRotationRef,
+    indexRef,
+  };
+}

--- a/app/frontend/hooks/use_crate_routing.test.ts
+++ b/app/frontend/hooks/use_crate_routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useCrateRouting } from "./use_crate_routing";
+import type { Crate } from "@/types/inertia";
+
+const crates: Crate[] = [
+  { slug: "jazz", name: "Jazz", count: 0, records: [] },
+  { slug: "soul", name: "Soul", count: 0, records: [] },
+];
+
+function setUrl(path: string, state: object = {}) {
+  history.replaceState(state, "", path);
+}
+
+describe("useCrateRouting", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setUrl("/stores/test");
+  });
+
+  it("preserves existing history state when selecting a crate", () => {
+    setUrl("/stores/test", { inertia: "keep-me" });
+    const pushState = vi.spyOn(history, "pushState");
+
+    const { result } = renderHook(() => useCrateRouting({ crates, storefront_sections: [] }));
+
+    act(() => {
+      result.current.selectCrate("jazz", 1);
+    });
+
+    expect(pushState).toHaveBeenCalledWith(
+      { inertia: "keep-me", crateSlug: "jazz", startIndex: 1 },
+      "",
+    );
+  });
+
+  it("uses replaceState for rapid second crate selection before rerender", () => {
+    setUrl("/stores/test");
+    const pushState = vi.spyOn(history, "pushState");
+    const replaceState = vi.spyOn(history, "replaceState");
+
+    const { result } = renderHook(() => useCrateRouting({ crates, storefront_sections: [] }));
+
+    act(() => {
+      result.current.selectCrate("jazz");
+      result.current.selectCrate("soul");
+    });
+
+    expect(pushState).toHaveBeenCalledTimes(1);
+    expect(replaceState).toHaveBeenCalledWith({ crateSlug: "soul", startIndex: 0 }, "");
+  });
+
+  it("returns to the store floor without leaving the app for direct crate links", () => {
+    setUrl("/stores/test?crate=jazz");
+    const replaceState = vi.spyOn(history, "replaceState");
+
+    const { result } = renderHook(() => useCrateRouting({ crates, storefront_sections: [] }));
+
+    expect(result.current.activeSlug).toBe("jazz");
+
+    act(() => {
+      result.current.backToStore();
+    });
+
+    expect(result.current.activeSlug).toBeNull();
+    expect(result.current.startIndex).toBe(0);
+    expect(replaceState).toHaveBeenCalledWith({}, "", "/stores/test");
+  });
+});

--- a/app/frontend/hooks/use_crate_routing.ts
+++ b/app/frontend/hooks/use_crate_routing.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import type { Crate, StorefrontSection } from "@/types/inertia";
+
+interface UseCrateRoutingOptions {
+  crates: Crate[];
+  storefront_sections: StorefrontSection[];
+}
+
+interface UseCrateRoutingResult {
+  activeSlug: string | null;
+  activeCrate: Crate | null;
+  startIndex: number;
+  selectCrate: (slug: string, index?: number) => void;
+  allCrates: Crate[];
+}
+
+export function useCrateRouting({
+  crates,
+  storefront_sections,
+}: UseCrateRoutingOptions): UseCrateRoutingResult {
+  const [activeSlug, setActiveSlug] = useState<string | null>(() => {
+    const fromParam =
+      typeof window !== "undefined"
+        ? new URLSearchParams(window.location.search).get("crate")
+        : null;
+    if (fromParam) return fromParam;
+
+    const raw = history.state?.crateSlug;
+    return typeof raw === "string" && raw.length > 0 ? raw : null;
+  });
+
+  const [startIndex, setStartIndex] = useState(() => {
+    const raw = history.state?.startIndex;
+    return Number.isFinite(raw) && (raw as number) >= 0 ? (raw as number) : 0;
+  });
+
+  const allCrates = useMemo(() => {
+    if (crates.length > 0) return crates;
+    if (!storefront_sections?.length) return [];
+    return storefront_sections.flatMap((s) => ("crate" in s ? [s.crate] : s.crates));
+  }, [crates, storefront_sections]);
+
+  const activeCrate =
+    activeSlug === null
+      ? null
+      : (allCrates.find((crate) => crate.slug === activeSlug) ?? allCrates[0]);
+
+  const selectCrate = useCallback(
+    (slug: string, index = 0) => {
+      setStartIndex(index);
+      setActiveSlug(slug);
+      if (activeSlug === null) {
+        history.pushState({ crateSlug: slug, startIndex: index }, "");
+      } else {
+        history.replaceState({ crateSlug: slug, startIndex: index }, "");
+      }
+    },
+    [activeSlug],
+  );
+
+  useEffect(() => {
+    const handlePop = (e: PopStateEvent) => {
+      const slug = e.state?.crateSlug ?? null;
+      setActiveSlug(slug);
+      setStartIndex(e.state?.startIndex ?? 0);
+    };
+    window.addEventListener("popstate", handlePop);
+    return () => window.removeEventListener("popstate", handlePop);
+  }, []);
+
+  return { activeSlug, activeCrate, startIndex, selectCrate, allCrates };
+}

--- a/app/frontend/hooks/use_crate_routing.ts
+++ b/app/frontend/hooks/use_crate_routing.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import type { Crate, StorefrontSection } from "@/types/inertia";
 
 interface UseCrateRoutingOptions {
@@ -11,7 +11,21 @@ interface UseCrateRoutingResult {
   activeCrate: Crate | null;
   startIndex: number;
   selectCrate: (slug: string, index?: number) => void;
+  backToStore: () => void;
   allCrates: Crate[];
+}
+
+function historyStateWithCrate(slug: string, startIndex: number) {
+  return { ...(history.state ?? {}), crateSlug: slug, startIndex };
+}
+
+function historyStateWithoutCrate() {
+  const { crateSlug: _crateSlug, startIndex: _startIndex, ...rest } = history.state ?? {};
+  return rest;
+}
+
+function storeFloorUrl() {
+  return `${window.location.pathname}${window.location.hash}`;
 }
 
 export function useCrateRouting({
@@ -33,6 +47,7 @@ export function useCrateRouting({
     const raw = history.state?.startIndex;
     return Number.isFinite(raw) && (raw as number) >= 0 ? (raw as number) : 0;
   });
+  const activeSlugRef = useRef(activeSlug);
 
   const allCrates = useMemo(() => {
     if (crates.length > 0) return crates;
@@ -47,20 +62,33 @@ export function useCrateRouting({
 
   const selectCrate = useCallback(
     (slug: string, index = 0) => {
+      const wasOnStoreFloor = activeSlugRef.current === null;
+      activeSlugRef.current = slug;
       setStartIndex(index);
       setActiveSlug(slug);
-      if (activeSlug === null) {
-        history.pushState({ crateSlug: slug, startIndex: index }, "");
-      } else {
-        history.replaceState({ crateSlug: slug, startIndex: index }, "");
+
+      const nextState = historyStateWithCrate(slug, index);
+      if (wasOnStoreFloor) {
+        history.pushState(nextState, "");
+        return;
       }
+
+      history.replaceState(nextState, "");
     },
-    [activeSlug],
+    [],
   );
+
+  const backToStore = useCallback(() => {
+    activeSlugRef.current = null;
+    setActiveSlug(null);
+    setStartIndex(0);
+    history.replaceState(historyStateWithoutCrate(), "", storeFloorUrl());
+  }, []);
 
   useEffect(() => {
     const handlePop = (e: PopStateEvent) => {
       const slug = e.state?.crateSlug ?? null;
+      activeSlugRef.current = slug;
       setActiveSlug(slug);
       setStartIndex(e.state?.startIndex ?? 0);
     };
@@ -68,5 +96,5 @@ export function useCrateRouting({
     return () => window.removeEventListener("popstate", handlePop);
   }, []);
 
-  return { activeSlug, activeCrate, startIndex, selectCrate, allCrates };
+  return { activeSlug, activeCrate, startIndex, selectCrate, backToStore, allCrates };
 }

--- a/app/frontend/hooks/use_dialog_focus_trap.test.ts
+++ b/app/frontend/hooks/use_dialog_focus_trap.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useDialogFocusTrap } from "./use_dialog_focus_trap"
+
+describe("useDialogFocusTrap", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn()
+    const dialog = document.createElement("div")
+    dialog.setAttribute("role", "dialog")
+    dialog.setAttribute("aria-modal", "true")
+    document.body.appendChild(dialog)
+
+    const title = document.createElement("span")
+    dialog.appendChild(title)
+
+    const { result, unmount } = renderHook(() => useDialogFocusTrap(true, onClose))
+    ;(result.current.dialogRef as React.MutableRefObject<HTMLDivElement | null>).current = dialog
+    ;(result.current.titleRef as React.MutableRefObject<HTMLSpanElement | null>).current = title
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }))
+    })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
+  it("cycles Tab forward within the dialog", () => {
+    const onClose = vi.fn()
+    const dialog = document.createElement("div")
+    dialog.setAttribute("role", "dialog")
+    dialog.setAttribute("aria-modal", "true")
+    const btn1 = document.createElement("button")
+    const btn2 = document.createElement("button")
+    dialog.append(btn1, btn2)
+    document.body.appendChild(dialog)
+    btn1.focus()
+
+    const { result, unmount } = renderHook(() => useDialogFocusTrap(true, onClose))
+    ;(result.current.dialogRef as React.MutableRefObject<HTMLDivElement | null>).current = dialog
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }))
+    })
+
+    expect(document.activeElement).toStrictEqual(btn2)
+    unmount()
+  })
+
+  it("cycles Tab backward within the dialog", () => {
+    const onClose = vi.fn()
+    const dialog = document.createElement("div")
+    dialog.setAttribute("role", "dialog")
+    dialog.setAttribute("aria-modal", "true")
+    const btn1 = document.createElement("button")
+    const btn2 = document.createElement("button")
+    dialog.append(btn1, btn2)
+    document.body.appendChild(dialog)
+    btn1.focus()
+
+    const { result, unmount } = renderHook(() => useDialogFocusTrap(true, onClose))
+    ;(result.current.dialogRef as React.MutableRefObject<HTMLDivElement | null>).current = dialog
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }),
+      )
+    })
+
+    expect(document.activeElement).toStrictEqual(btn2)
+    unmount()
+  })
+
+  it("handles dialog with no focusable elements", () => {
+    const onClose = vi.fn()
+    const dialog = document.createElement("div")
+    dialog.setAttribute("role", "dialog")
+    dialog.setAttribute("aria-modal", "true")
+    document.body.appendChild(dialog)
+
+    const title = document.createElement("span")
+    dialog.appendChild(title)
+
+    const { result, unmount } = renderHook(() => useDialogFocusTrap(true, onClose))
+    ;(result.current.dialogRef as React.MutableRefObject<HTMLDivElement | null>).current = dialog
+    ;(result.current.titleRef as React.MutableRefObject<HTMLSpanElement | null>).current = title
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }))
+    })
+
+    // When no focusable elements exist, focus should stay on (or return to) the title element.
+    // In jsdom this is not guaranteed, so we verify the handler didn't throw.
+    expect(onClose).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it("returns focus to the previous element when the dialog closes", () => {
+    const onClose = vi.fn()
+    const previousBtn = document.createElement("button")
+    document.body.appendChild(previousBtn)
+    previousBtn.focus()
+
+    const { rerender, unmount } = renderHook(
+      ({ open }) => useDialogFocusTrap(open, onClose),
+      { initialProps: { open: true } },
+    )
+
+    rerender({ open: false })
+
+    expect(document.activeElement).toStrictEqual(previousBtn)
+    unmount()
+  })
+})

--- a/app/frontend/hooks/use_dialog_focus_trap.ts
+++ b/app/frontend/hooks/use_dialog_focus_trap.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from "react"
+
+interface UseDialogFocusTrapOptions {
+  /** Ref to the element that should receive focus when the dialog closes. */
+  returnFocusRef?: React.RefObject<HTMLElement | null>
+}
+
+interface UseDialogFocusTrapResult {
+  dialogRef: React.RefObject<HTMLDivElement | null>
+  titleRef: React.RefObject<HTMLSpanElement | null>
+}
+
+/**
+ * Manages focus trapping inside a dialog: stores previous focus, cycles Tab
+ * within the dialog, handles Escape, and returns focus on close.
+ */
+export function useDialogFocusTrap(
+  open: boolean,
+  onClose: () => void,
+  options: UseDialogFocusTrapOptions = {},
+): UseDialogFocusTrapResult {
+  const { returnFocusRef } = options
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const titleRef = useRef<HTMLSpanElement>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null
+    titleRef.current?.focus()
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault()
+        onClose()
+        return
+      }
+
+      if (event.key !== "Tab") return
+
+      const dialog = dialogRef.current
+      if (!dialog) return
+
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      )
+
+      if (focusable.length === 0) {
+        event.preventDefault()
+        titleRef.current?.focus()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const active = document.activeElement
+
+      if (
+        event.shiftKey &&
+        (active === first || active === titleRef.current || !dialog.contains(active))
+      ) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+
+    const previousFocus = previousFocusRef.current
+    const returnFocus = returnFocusRef?.current
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown)
+      if (previousFocus?.isConnected) {
+        previousFocus.focus()
+      } else if (returnFocus) {
+        returnFocus.focus()
+      }
+    }
+  }, [open, onClose, returnFocusRef])
+
+  return { dialogRef, titleRef }
+}

--- a/app/frontend/hooks/use_discogs_lookup.test.ts
+++ b/app/frontend/hooks/use_discogs_lookup.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useDiscogsLookup } from "./use_discogs_lookup"
+
+describe("useDiscogsLookup", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("starts in idle state", () => {
+    const { result } = renderHook(() => useDiscogsLookup())
+    expect(result.current.state.status).toBe("idle")
+  })
+
+  it("transitions to loading when lookup is called", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ found: true, seller_name: "Test", store_status: null }), {
+        status: 200,
+      }),
+    )
+
+    const { result } = renderHook(() => useDiscogsLookup())
+
+    await act(async () => {
+      result.current.lookup("testuser")
+    })
+
+    expect(result.current.state.status).toBe("preview")
+  })
+
+  it("returns error_not_found when Discogs returns not found", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ found: false }), { status: 200 }),
+    )
+
+    const { result } = renderHook(() => useDiscogsLookup())
+
+    await act(async () => {
+      result.current.lookup("nonexistent")
+    })
+
+    expect(result.current.state.status).toBe("error_not_found")
+  })
+
+  it("returns error_api on fetch failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Network error"))
+
+    const { result } = renderHook(() => useDiscogsLookup())
+
+    await act(async () => {
+      result.current.lookup("testuser")
+    })
+
+    expect(result.current.state.status).toBe("error_api")
+  })
+
+  it("resets to idle on reset call", () => {
+    const { result } = renderHook(() => useDiscogsLookup())
+
+    act(() => {
+      result.current.reset()
+    })
+
+    expect(result.current.state.status).toBe("idle")
+  })
+})

--- a/app/frontend/hooks/use_discogs_lookup.test.ts
+++ b/app/frontend/hooks/use_discogs_lookup.test.ts
@@ -4,13 +4,27 @@ import { useDiscogsLookup } from "./use_discogs_lookup";
 
 const originalFetch = globalThis.fetch;
 
+function deferredResponse() {
+  let resolve!: (value: Response) => void;
+  const promise = new Promise<Response>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function lookupResponse(body: object) {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
 describe("useDiscogsLookup", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     globalThis.fetch = originalFetch;
   });
 
@@ -20,16 +34,20 @@ describe("useDiscogsLookup", () => {
   });
 
   it("transitions to loading when lookup is called", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValueOnce(
-      new Response(JSON.stringify({ found: true, seller_name: "Test", store_status: null }), {
-        status: 200,
-      }),
-    );
+    const request = deferredResponse();
+    globalThis.fetch = vi.fn().mockReturnValueOnce(request.promise);
 
     const { result } = renderHook(() => useDiscogsLookup());
 
-    await act(async () => {
+    act(() => {
       result.current.lookup("testuser");
+    });
+
+    expect(result.current.state.status).toBe("loading");
+
+    await act(async () => {
+      request.resolve(lookupResponse({ found: true, seller_name: "Test", store_status: null }));
+      await request.promise;
     });
 
     expect(result.current.state.status).toBe("preview");
@@ -69,5 +87,46 @@ describe("useDiscogsLookup", () => {
     });
 
     expect(result.current.state.status).toBe("idle");
+  });
+
+  it("does not let a reset request update state after it resolves", async () => {
+    const oldRequest = deferredResponse();
+    globalThis.fetch = vi.fn().mockReturnValueOnce(oldRequest.promise);
+
+    const { result } = renderHook(() => useDiscogsLookup());
+
+    act(() => {
+      result.current.lookup("old-seller");
+    });
+    expect(result.current.state.status).toBe("loading");
+
+    act(() => {
+      result.current.reset();
+    });
+
+    await act(async () => {
+      oldRequest.resolve(lookupResponse({ found: true, seller_name: "Old Seller" }));
+      await oldRequest.promise;
+    });
+
+    expect(result.current.state.status).toBe("idle");
+  });
+
+  it("times out a stalled lookup", async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = vi.fn().mockReturnValueOnce(new Promise<Response>(() => {}));
+
+    const { result } = renderHook(() => useDiscogsLookup());
+
+    act(() => {
+      result.current.lookup("slow-seller");
+    });
+    expect(result.current.state.status).toBe("loading");
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(result.current.state.status).toBe("error_api");
   });
 });

--- a/app/frontend/hooks/use_discogs_lookup.test.ts
+++ b/app/frontend/hooks/use_discogs_lookup.test.ts
@@ -1,70 +1,73 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
-import { renderHook, act } from "@testing-library/react"
-import { useDiscogsLookup } from "./use_discogs_lookup"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDiscogsLookup } from "./use_discogs_lookup";
+
+const originalFetch = globalThis.fetch;
 
 describe("useDiscogsLookup", () => {
   beforeEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
 
   it("starts in idle state", () => {
-    const { result } = renderHook(() => useDiscogsLookup())
-    expect(result.current.state.status).toBe("idle")
-  })
+    const { result } = renderHook(() => useDiscogsLookup());
+    expect(result.current.state.status).toBe("idle");
+  });
 
   it("transitions to loading when lookup is called", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
       new Response(JSON.stringify({ found: true, seller_name: "Test", store_status: null }), {
         status: 200,
       }),
-    )
+    );
 
-    const { result } = renderHook(() => useDiscogsLookup())
+    const { result } = renderHook(() => useDiscogsLookup());
 
     await act(async () => {
-      result.current.lookup("testuser")
-    })
+      result.current.lookup("testuser");
+    });
 
-    expect(result.current.state.status).toBe("preview")
-  })
+    expect(result.current.state.status).toBe("preview");
+  });
 
   it("returns error_not_found when Discogs returns not found", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ found: false }), { status: 200 }),
-    )
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ found: false }), { status: 200 }));
 
-    const { result } = renderHook(() => useDiscogsLookup())
+    const { result } = renderHook(() => useDiscogsLookup());
 
     await act(async () => {
-      result.current.lookup("nonexistent")
-    })
+      result.current.lookup("nonexistent");
+    });
 
-    expect(result.current.state.status).toBe("error_not_found")
-  })
+    expect(result.current.state.status).toBe("error_not_found");
+  });
 
   it("returns error_api on fetch failure", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Network error"))
+    globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
 
-    const { result } = renderHook(() => useDiscogsLookup())
+    const { result } = renderHook(() => useDiscogsLookup());
 
     await act(async () => {
-      result.current.lookup("testuser")
-    })
+      result.current.lookup("testuser");
+    });
 
-    expect(result.current.state.status).toBe("error_api")
-  })
+    expect(result.current.state.status).toBe("error_api");
+  });
 
   it("resets to idle on reset call", () => {
-    const { result } = renderHook(() => useDiscogsLookup())
+    const { result } = renderHook(() => useDiscogsLookup());
 
     act(() => {
-      result.current.reset()
-    })
+      result.current.reset();
+    });
 
-    expect(result.current.state.status).toBe("idle")
-  })
-})
+    expect(result.current.state.status).toBe("idle");
+  });
+});

--- a/app/frontend/hooks/use_discogs_lookup.ts
+++ b/app/frontend/hooks/use_discogs_lookup.ts
@@ -28,6 +28,7 @@ interface UseDiscogsLookupResult {
 export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDiscogsLookupResult {
   const [state, setState] = useState<LookupState>({ status: "idle" });
   const abortRef = useRef<AbortController | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const announce = useCallback(
     (message: string) => {
@@ -40,12 +41,15 @@ export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDis
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, []);
 
   const lookup = useCallback(
     (username: string) => {
       abortRef.current?.abort();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
       const controller = new AbortController();
       abortRef.current = controller;
 
@@ -54,13 +58,27 @@ export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDis
 
       const url = `/api/discogs/lookup/${encodeURIComponent(username)}`;
 
+      timeoutRef.current = setTimeout(() => {
+        if (abortRef.current !== controller) return;
+
+        controller.abort();
+        abortRef.current = null;
+        timeoutRef.current = null;
+        setState({ status: "error_api" });
+        announce("Something went wrong. Please try again.");
+      }, 10_000);
+
       fetch(url, { signal: controller.signal })
         .then((res) => {
           if (!res.ok) throw new Error(`Lookup failed: ${res.status}`);
           return res.json() as Promise<DiscogsLookupResult>;
         })
         .then((data) => {
+          if (abortRef.current !== controller) return;
           if (controller.signal.aborted) return;
+          if (timeoutRef.current) clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+          abortRef.current = null;
 
           if (!data.found) {
             setState({ status: "error_not_found" });
@@ -83,8 +101,12 @@ export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDis
           }
         })
         .catch((err) => {
+          if (abortRef.current !== controller) return;
           if (controller.signal.aborted) return;
           if (err instanceof DOMException && err.name === "AbortError") return;
+          if (timeoutRef.current) clearTimeout(timeoutRef.current);
+          timeoutRef.current = null;
+          abortRef.current = null;
 
           setState({ status: "error_api" });
           announce("Something went wrong. Please try again.");
@@ -94,6 +116,10 @@ export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDis
   );
 
   const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
     setState({ status: "idle" });
   }, []);
 

--- a/app/frontend/hooks/use_discogs_lookup.ts
+++ b/app/frontend/hooks/use_discogs_lookup.ts
@@ -25,7 +25,21 @@ interface UseDiscogsLookupResult {
  * and screen-reader announcements. The consuming component owns the input UI
  * and renders status branches based on the returned state.
  */
-export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDiscogsLookupResult {
+export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDiscogsLookupResult;
+/**
+ * Overload: accepts a custom lookup URL (e.g., admin endpoint).
+ * When `lookupUrl` is provided, the hook calls that URL with
+ * `username` as a query parameter.
+ */
+export function useDiscogsLookup(
+  onAnnounce?: ((message: string) => void) | string,
+): UseDiscogsLookupResult;
+
+export function useDiscogsLookup(
+  onAnnounceOrUrl?: ((message: string) => void) | string,
+): UseDiscogsLookupResult {
+  const onAnnounce = typeof onAnnounceOrUrl === "function" ? onAnnounceOrUrl : undefined;
+  const lookupUrl = typeof onAnnounceOrUrl === "string" ? onAnnounceOrUrl : undefined;
   const [state, setState] = useState<LookupState>({ status: "idle" });
   const abortRef = useRef<AbortController | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -56,7 +70,9 @@ export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDis
       setState({ status: "loading" });
       announce("Checking Discogs availability...");
 
-      const url = `/api/discogs/lookup/${encodeURIComponent(username)}`;
+      const url = lookupUrl
+        ? `${lookupUrl}?username=${encodeURIComponent(username)}`
+        : `/api/discogs/lookup/${encodeURIComponent(username)}`;
 
       timeoutRef.current = setTimeout(() => {
         if (abortRef.current !== controller) return;
@@ -112,7 +128,7 @@ export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDis
           announce("Something went wrong. Please try again.");
         });
     },
-    [announce],
+    [announce, lookupUrl],
   );
 
   const reset = useCallback(() => {

--- a/app/frontend/hooks/use_discogs_lookup.ts
+++ b/app/frontend/hooks/use_discogs_lookup.ts
@@ -1,0 +1,107 @@
+import { useState, useCallback, useEffect, useRef } from "react"
+import type { DiscogsLookupResult } from "@/types/inertia"
+
+export type SuccessfulLookup = DiscogsLookupResult & { found: true }
+
+export type LookupState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "preview"; result: SuccessfulLookup }
+  | { status: "error_not_found" }
+  | { status: "error_active_store"; result: SuccessfulLookup }
+  | { status: "error_applicant"; result: SuccessfulLookup }
+  | { status: "error_api" }
+
+interface UseDiscogsLookupResult {
+  state: LookupState
+  /** Trigger a lookup for the given username. */
+  lookup: (username: string) => void
+  /** Reset to idle state. */
+  reset: () => void
+}
+
+function csrfToken() {
+  return document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? ""
+}
+
+/**
+ * Manages the Discogs username lookup lifecycle: fetch, abort, state machine,
+ * and screen-reader announcements. The consuming component owns the input UI
+ * and renders status branches based on the returned state.
+ */
+export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDiscogsLookupResult {
+  const [state, setState] = useState<LookupState>({ status: "idle" })
+  const abortRef = useRef<AbortController | null>(null)
+
+  const announce = useCallback(
+    (message: string) => {
+      onAnnounce?.(message)
+    },
+    [onAnnounce],
+  )
+
+  // Cleanup abort controller on unmount
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+    }
+  }, [])
+
+  const lookup = useCallback(
+    (username: string) => {
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      setState({ status: "loading" })
+      announce("Checking Discogs availability...")
+
+      const url = `/api/discogs/lookup/${encodeURIComponent(username)}`
+
+      fetch(url, { signal: controller.signal })
+        .then((res) => {
+          if (!res.ok) throw new Error(`Lookup failed: ${res.status}`)
+          return res.json() as Promise<DiscogsLookupResult>
+        })
+        .then((data) => {
+          if (controller.signal.aborted) return
+
+          if (!data.found) {
+            setState({ status: "error_not_found" })
+            announce("Username not found on Discogs.")
+            return
+          }
+
+          switch (data.store_status) {
+            case "active_store":
+              setState({ status: "error_active_store", result: data })
+              announce("This store is already on Milkcrate.")
+              break
+            case "active_applicant":
+              setState({ status: "error_applicant", result: data })
+              announce("This seller has already applied.")
+              break
+            default:
+              setState({ status: "preview", result: data })
+              announce(`Found ${data.seller_name} on Discogs.`)
+          }
+        })
+        .catch((err) => {
+          if (controller.signal.aborted) return
+          if (err instanceof DOMException && err.name === "AbortError") return
+
+          setState({ status: "error_api" })
+          announce("Something went wrong. Please try again.")
+        })
+    },
+    [announce],
+  )
+
+  const reset = useCallback(() => {
+    setState({ status: "idle" })
+  }, [])
+
+  return { state, lookup, reset }
+}
+
+export { csrfToken }

--- a/app/frontend/hooks/use_discogs_lookup.ts
+++ b/app/frontend/hooks/use_discogs_lookup.ts
@@ -1,7 +1,7 @@
-import { useState, useCallback, useEffect, useRef } from "react"
-import type { DiscogsLookupResult } from "@/types/inertia"
+import { useState, useCallback, useEffect, useRef } from "react";
+import type { DiscogsLookupResult } from "@/types/inertia";
 
-export type SuccessfulLookup = DiscogsLookupResult & { found: true }
+export type SuccessfulLookup = DiscogsLookupResult & { found: true };
 
 export type LookupState =
   | { status: "idle" }
@@ -10,18 +10,14 @@ export type LookupState =
   | { status: "error_not_found" }
   | { status: "error_active_store"; result: SuccessfulLookup }
   | { status: "error_applicant"; result: SuccessfulLookup }
-  | { status: "error_api" }
+  | { status: "error_api" };
 
 interface UseDiscogsLookupResult {
-  state: LookupState
+  state: LookupState;
   /** Trigger a lookup for the given username. */
-  lookup: (username: string) => void
+  lookup: (username: string) => void;
   /** Reset to idle state. */
-  reset: () => void
-}
-
-function csrfToken() {
-  return document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? ""
+  reset: () => void;
 }
 
 /**
@@ -30,78 +26,78 @@ function csrfToken() {
  * and renders status branches based on the returned state.
  */
 export function useDiscogsLookup(onAnnounce?: (message: string) => void): UseDiscogsLookupResult {
-  const [state, setState] = useState<LookupState>({ status: "idle" })
-  const abortRef = useRef<AbortController | null>(null)
+  const [state, setState] = useState<LookupState>({ status: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
 
   const announce = useCallback(
     (message: string) => {
-      onAnnounce?.(message)
+      onAnnounce?.(message);
     },
     [onAnnounce],
-  )
+  );
 
   // Cleanup abort controller on unmount
   useEffect(() => {
     return () => {
-      abortRef.current?.abort()
-    }
-  }, [])
+      abortRef.current?.abort();
+    };
+  }, []);
 
   const lookup = useCallback(
     (username: string) => {
-      abortRef.current?.abort()
-      const controller = new AbortController()
-      abortRef.current = controller
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
 
-      setState({ status: "loading" })
-      announce("Checking Discogs availability...")
+      setState({ status: "loading" });
+      announce("Checking Discogs availability...");
 
-      const url = `/api/discogs/lookup/${encodeURIComponent(username)}`
+      const url = `/api/discogs/lookup/${encodeURIComponent(username)}`;
 
       fetch(url, { signal: controller.signal })
         .then((res) => {
-          if (!res.ok) throw new Error(`Lookup failed: ${res.status}`)
-          return res.json() as Promise<DiscogsLookupResult>
+          if (!res.ok) throw new Error(`Lookup failed: ${res.status}`);
+          return res.json() as Promise<DiscogsLookupResult>;
         })
         .then((data) => {
-          if (controller.signal.aborted) return
+          if (controller.signal.aborted) return;
 
           if (!data.found) {
-            setState({ status: "error_not_found" })
-            announce("Username not found on Discogs.")
-            return
+            setState({ status: "error_not_found" });
+            announce("Username not found on Discogs.");
+            return;
           }
 
           switch (data.store_status) {
             case "active_store":
-              setState({ status: "error_active_store", result: data })
-              announce("This store is already on Milkcrate.")
-              break
+              setState({ status: "error_active_store", result: data });
+              announce("This store is already on Milkcrate.");
+              break;
             case "active_applicant":
-              setState({ status: "error_applicant", result: data })
-              announce("This seller has already applied.")
-              break
+              setState({ status: "error_applicant", result: data });
+              announce("This seller has already applied.");
+              break;
             default:
-              setState({ status: "preview", result: data })
-              announce(`Found ${data.seller_name} on Discogs.`)
+              setState({ status: "preview", result: data });
+              announce(`Found ${data.seller_name} on Discogs.`);
           }
         })
         .catch((err) => {
-          if (controller.signal.aborted) return
-          if (err instanceof DOMException && err.name === "AbortError") return
+          if (controller.signal.aborted) return;
+          if (err instanceof DOMException && err.name === "AbortError") return;
 
-          setState({ status: "error_api" })
-          announce("Something went wrong. Please try again.")
-        })
+          setState({ status: "error_api" });
+          announce("Something went wrong. Please try again.");
+        });
     },
     [announce],
-  )
+  );
 
   const reset = useCallback(() => {
-    setState({ status: "idle" })
-  }, [])
+    setState({ status: "idle" });
+  }, []);
 
-  return { state, lookup, reset }
+  return { state, lookup, reset };
 }
 
-export { csrfToken }
+export { csrfToken } from "@/lib/csrf_token";

--- a/app/frontend/hooks/use_pointer_proximity.test.ts
+++ b/app/frontend/hooks/use_pointer_proximity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { renderHook, act } from "@testing-library/react"
 import { usePointerProximity } from "./use_pointer_proximity"
 
@@ -98,5 +98,50 @@ describe("usePointerProximity", () => {
     })
 
     expect(result.current.proximity).toBe(0)
+  })
+
+  it("uses snapshotted pointer data when the rAF callback runs later", () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => usePointerProximity())
+
+    const el = document.createElement("div")
+    Object.defineProperty(el, "getBoundingClientRect", {
+      value: () => ({ left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200 }),
+    })
+
+    const event = makePointerEvent("pointermove", { clientX: 100, clientY: 100 })
+    Object.defineProperty(event, "currentTarget", { value: el, configurable: true })
+
+    act(() => {
+      result.current.handlers.onPointerMove(event)
+      Object.defineProperty(event, "currentTarget", { value: null, configurable: true })
+      vi.advanceTimersByTime(16)
+    })
+
+    expect(result.current.proximity).toBeGreaterThan(0)
+    vi.useRealTimers()
+  })
+
+  it("cancels queued animation frames on unmount", () => {
+    vi.useFakeTimers()
+    const cancelAnimationFrameSpy = vi.spyOn(window, "cancelAnimationFrame")
+    const { result, unmount } = renderHook(() => usePointerProximity())
+
+    const el = document.createElement("div")
+    Object.defineProperty(el, "getBoundingClientRect", {
+      value: () => ({ left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200 }),
+    })
+
+    const event = makePointerEvent("pointermove", { clientX: 100, clientY: 100 })
+    Object.defineProperty(event, "currentTarget", { value: el })
+
+    act(() => {
+      result.current.handlers.onPointerMove(event)
+    })
+
+    unmount()
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalled()
+    vi.useRealTimers()
   })
 })

--- a/app/frontend/hooks/use_pointer_proximity.test.ts
+++ b/app/frontend/hooks/use_pointer_proximity.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { usePointerProximity } from "./use_pointer_proximity"
+
+function makePointerEvent(type: string, opts: Partial<PointerEventInit> = {}): React.PointerEvent {
+  return new PointerEvent(type, {
+    pointerType: "mouse",
+    clientX: 100,
+    clientY: 100,
+    bubbles: true,
+    ...opts,
+  }) as unknown as React.PointerEvent
+}
+
+describe("usePointerProximity", () => {
+  it("returns proximity 0 initially", () => {
+    const { result } = renderHook(() => usePointerProximity())
+    expect(result.current.proximity).toBe(0)
+  })
+
+  it("updates proximity on pointer enter", () => {
+    const { result } = renderHook(() => usePointerProximity())
+
+    const el = document.createElement("div")
+    Object.defineProperty(el, "getBoundingClientRect", {
+      value: () => ({ left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200 }),
+    })
+
+    const event = makePointerEvent("pointerenter", { clientX: 100, clientY: 100 })
+    Object.defineProperty(event, "currentTarget", { value: el })
+
+    act(() => {
+      result.current.handlers.onPointerEnter(event)
+    })
+
+    expect(result.current.proximity).toBeGreaterThan(0)
+  })
+
+  it("resets proximity on pointer leave", () => {
+    const { result } = renderHook(() => usePointerProximity())
+
+    const el = document.createElement("div")
+    Object.defineProperty(el, "getBoundingClientRect", {
+      value: () => ({ left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200 }),
+    })
+
+    const enterEvent = makePointerEvent("pointerenter", { clientX: 100, clientY: 100 })
+    Object.defineProperty(enterEvent, "currentTarget", { value: el })
+
+    act(() => {
+      result.current.handlers.onPointerEnter(enterEvent)
+    })
+
+    expect(result.current.proximity).toBeGreaterThan(0)
+
+    act(() => {
+      result.current.handlers.onPointerLeave(makePointerEvent("pointerleave"))
+    })
+
+    expect(result.current.proximity).toBe(0)
+  })
+
+  it("sets proximity to 0 on touch devices", () => {
+    const { result } = renderHook(() => usePointerProximity())
+
+    const el = document.createElement("div")
+    Object.defineProperty(el, "getBoundingClientRect", {
+      value: () => ({ left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200 }),
+    })
+
+    const event = makePointerEvent("pointerenter", {
+      clientX: 100,
+      clientY: 100,
+      pointerType: "touch",
+    })
+    Object.defineProperty(event, "currentTarget", { value: el })
+
+    act(() => {
+      result.current.handlers.onPointerEnter(event)
+    })
+
+    expect(result.current.proximity).toBe(0)
+  })
+
+  it("returns proximity 0 when disabled", () => {
+    const { result } = renderHook(() => usePointerProximity({ disabled: true }))
+
+    const el = document.createElement("div")
+    Object.defineProperty(el, "getBoundingClientRect", {
+      value: () => ({ left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200 }),
+    })
+
+    const event = makePointerEvent("pointerenter", { clientX: 100, clientY: 100 })
+    Object.defineProperty(event, "currentTarget", { value: el })
+
+    act(() => {
+      result.current.handlers.onPointerEnter(event)
+    })
+
+    expect(result.current.proximity).toBe(0)
+  })
+})

--- a/app/frontend/hooks/use_pointer_proximity.ts
+++ b/app/frontend/hooks/use_pointer_proximity.ts
@@ -1,0 +1,95 @@
+import { useState, useCallback, useRef } from "react"
+
+const isBrowser = typeof window !== "undefined"
+
+interface PointerProximityHandlers {
+  onPointerEnter: (e: React.PointerEvent) => void
+  onPointerLeave: (e: React.PointerEvent) => void
+  onPointerMove: (e: React.PointerEvent) => void
+}
+
+interface UsePointerProximityOptions {
+  /** Disable proximity tracking entirely (e.g., when reduced motion is active). */
+  disabled?: boolean
+}
+
+interface UsePointerProximityResult {
+  /** Cursor proximity to element center, 0 (idle) to 1 (centered). */
+  proximity: number
+  /** Pointer event handlers to spread onto a motion element. */
+  handlers: PointerProximityHandlers
+}
+
+function computeProximity(e: React.PointerEvent): number {
+  const el = e.currentTarget as HTMLElement | null
+  if (!el) return 0
+  const rect = el.getBoundingClientRect()
+
+  const cx = rect.left + rect.width / 2
+  const cy = rect.top + rect.height / 2
+  const dx = e.clientX - cx
+  const dy = e.clientY - cy
+  const dist = Math.hypot(dx, dy)
+  const maxDist = Math.hypot(rect.width, rect.height) * 0.6
+
+  return Math.max(0, Math.min(1, 1 - dist / maxDist))
+}
+
+/**
+ * Tracks pointer position relative to the element center and returns a
+ * continuous 0–1 proximity value. Falls back to zero-proximity on touch
+ * devices and when disabled (e.g., reduced motion).
+ */
+export function usePointerProximity(
+  options: UsePointerProximityOptions = {},
+): UsePointerProximityResult {
+  const { disabled = false } = options
+  const [proximity, setProximity] = useState(0)
+  const isTouchRef = useRef(false)
+  const rafRef = useRef<number | null>(null)
+
+  const enter = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isBrowser || disabled) return
+      const isTouch = e.pointerType !== "mouse"
+      isTouchRef.current = isTouch
+      if (isTouch) {
+        setProximity(0)
+        return
+      }
+      setProximity(computeProximity(e))
+    },
+    [disabled],
+  )
+
+  const move = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isBrowser || disabled || isTouchRef.current) return
+
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+      }
+
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null
+        if (e.currentTarget) {
+          setProximity(computeProximity(e))
+        }
+      })
+    },
+    [disabled],
+  )
+
+  const leave = useCallback(() => {
+    if (!isBrowser) return
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+    setProximity(0)
+  }, [])
+
+  const handlers = { onPointerEnter: enter, onPointerLeave: leave, onPointerMove: move }
+
+  return { proximity, handlers }
+}

--- a/app/frontend/hooks/use_pointer_proximity.ts
+++ b/app/frontend/hooks/use_pointer_proximity.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
 
 const isBrowser = typeof window !== "undefined"
 
@@ -20,19 +20,28 @@ interface UsePointerProximityResult {
   handlers: PointerProximityHandlers
 }
 
+function computeProximityFromRect(rect: DOMRect | {
+  left: number
+  top: number
+  width: number
+  height: number
+}, clientX: number, clientY: number): number {
+  const cx = rect.left + rect.width / 2
+  const cy = rect.top + rect.height / 2
+  const dx = clientX - cx
+  const dy = clientY - cy
+  const dist = Math.hypot(dx, dy)
+  const maxDist = Math.hypot(rect.width, rect.height) * 0.6
+
+  return Math.max(0, Math.min(1, 1 - dist / maxDist))
+}
+
 function computeProximity(e: React.PointerEvent): number {
   const el = e.currentTarget as HTMLElement | null
   if (!el) return 0
   const rect = el.getBoundingClientRect()
 
-  const cx = rect.left + rect.width / 2
-  const cy = rect.top + rect.height / 2
-  const dx = e.clientX - cx
-  const dy = e.clientY - cy
-  const dist = Math.hypot(dx, dy)
-  const maxDist = Math.hypot(rect.width, rect.height) * 0.6
-
-  return Math.max(0, Math.min(1, 1 - dist / maxDist))
+  return computeProximityFromRect(rect, e.clientX, e.clientY)
 }
 
 /**
@@ -65,6 +74,10 @@ export function usePointerProximity(
   const move = useCallback(
     (e: React.PointerEvent) => {
       if (!isBrowser || disabled || isTouchRef.current) return
+      const target = e.currentTarget as HTMLElement | null
+      if (!target) return
+      const rect = target.getBoundingClientRect()
+      const { clientX, clientY } = e
 
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current)
@@ -72,9 +85,7 @@ export function usePointerProximity(
 
       rafRef.current = requestAnimationFrame(() => {
         rafRef.current = null
-        if (e.currentTarget) {
-          setProximity(computeProximity(e))
-        }
+        setProximity(computeProximityFromRect(rect, clientX, clientY))
       })
     },
     [disabled],
@@ -90,6 +101,15 @@ export function usePointerProximity(
   }, [])
 
   const handlers = { onPointerEnter: enter, onPointerLeave: leave, onPointerMove: move }
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current === null) return
+
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+  }, [])
 
   return { proximity, handlers }
 }

--- a/app/frontend/hooks/use_tactile_hover.ts
+++ b/app/frontend/hooks/use_tactile_hover.ts
@@ -1,171 +1,99 @@
-import { useState, useCallback, useMemo, useRef } from "react"
-import type { MotionStyle, Transition } from "framer-motion"
-import {
-  SCALE_PRESS,
-  SCALE_HOVER,
-  LIFT_HOVER,
-  TILT_HOVER,
-  springTactile,
-  springPress,
-} from "@/lib/motion_tokens"
-import { useReducedMotionContext } from "@/components/storefront_motion_config"
+import { useState, useCallback, useMemo } from "react";
+import type { MotionStyle, Transition } from "framer-motion";
+import { useReducedMotionContext } from "@/components/storefront_motion_config";
+import { usePointerProximity } from "./use_pointer_proximity";
+import { useTactileTransform } from "./use_tactile_transform";
+import { springTactile, springPress } from "@/lib/motion_tokens";
 
 interface UseTactileHoverOptions {
   /** Resting tilt in degrees when not hovered. Default 0. */
-  restingTilt?: number
+  restingTilt?: number;
   /** Disable tilt entirely — rotate always stays at 0. */
-  disableTilt?: boolean
+  disableTilt?: boolean;
 }
 
 interface TactileHandlers {
-  onPointerEnter: (e: React.PointerEvent) => void
-  onPointerLeave: (e: React.PointerEvent) => void
-  onPointerDown: (e: React.PointerEvent) => void
-  onPointerUp: (e: React.PointerEvent) => void
-  onPointerMove: (e: React.PointerEvent) => void
+  onPointerEnter: (e: React.PointerEvent) => void;
+  onPointerLeave: (e: React.PointerEvent) => void;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
 }
 
 interface TactileState {
   /** True when proximity > 0 (derived — not a separate state). */
-  isHovered: boolean
-  isPressed: boolean
+  isHovered: boolean;
+  isPressed: boolean;
   /** Cursor proximity to element center, 0 (idle) to 1 (centered). */
-  proximity: number
+  proximity: number;
   /** Framer Motion animate target — updated reactively. */
-  transform: MotionStyle
+  transform: MotionStyle;
   /** Transition to use for the current state — snappier on press. */
-  transition: Transition
+  transition: Transition;
   /** Pointer event handlers to spread onto a motion element. */
-  handlers: TactileHandlers
+  handlers: TactileHandlers;
 }
-
-const isBrowser = typeof window !== "undefined"
 
 /**
  * Cursor-proximity hover hook. Tracks pointer position relative to
  * the element center and returns a continuous 0–1 proximity value.
  * Falls back to zero-proximity on touch devices and when reduced
  * motion is active (no hover flash — press state handles feedback).
+ *
+ * Composes usePointerProximity (pointer tracking) and
+ * useTactileTransform (motion value computation).
  */
-export function useTactileHover(
-  options: UseTactileHoverOptions = {},
-): TactileState {
-  const { restingTilt = 0, disableTilt = false } = options
-  const reducedMotion = useReducedMotionContext()
+export function useTactileHover(options: UseTactileHoverOptions = {}): TactileState {
+  const { restingTilt = 0, disableTilt = false } = options;
+  const reducedMotion = useReducedMotionContext();
 
-  const [proximity, setProximity] = useState(0)
-  const [isPressed, setIsPressed] = useState(false)
-  const isTouchRef = useRef(false)
-  const rafRef = useRef<number | null>(null)
+  const { proximity, handlers: proximityHandlers } = usePointerProximity({
+    disabled: reducedMotion,
+  });
 
-  // ── Proximity math ───────────────────────────────────────
-
-  const updateProximity = useCallback((e: React.PointerEvent) => {
-    const el = e.currentTarget as HTMLElement | null
-    if (!el) return 0
-    const rect = el.getBoundingClientRect()
-
-    const cx = rect.left + rect.width / 2
-    const cy = rect.top + rect.height / 2
-    const dx = e.clientX - cx
-    const dy = e.clientY - cy
-    const dist = Math.hypot(dx, dy)
-    const maxDist = Math.hypot(rect.width, rect.height) * 0.6
-
-    return Math.max(0, Math.min(1, 1 - dist / maxDist))
-  }, [])
-
-  // ── Pointer handlers ──────────────────────────────────────
-
-  const enter = useCallback(
-    (e: React.PointerEvent) => {
-      if (!isBrowser) return
-      const isTouch = e.pointerType !== "mouse"
-      isTouchRef.current = isTouch
-
-      if (reducedMotion || isTouch) {
-        setProximity(0)
-        return
-      }
-      // Mouse: compute proximity from the enter event's position
-      setProximity(updateProximity(e))
-    },
-    [reducedMotion, updateProximity],
-  )
-
-  const move = useCallback(
-    (e: React.PointerEvent) => {
-      if (!isBrowser || reducedMotion || isTouchRef.current) return
-
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current)
-      }
-
-      rafRef.current = requestAnimationFrame(() => {
-        rafRef.current = null
-        if (e.currentTarget) {
-          setProximity(updateProximity(e))
-        }
-      })
-    },
-    [reducedMotion, updateProximity],
-  )
-
-  const leave = useCallback(() => {
-    if (!isBrowser) return
-    if (rafRef.current !== null) {
-      cancelAnimationFrame(rafRef.current)
-      rafRef.current = null
-    }
-    setProximity(0)
-    setIsPressed(false)
-  }, [])
+  const [isPressed, setIsPressed] = useState(false);
 
   const down = useCallback(() => {
-    if (!isBrowser || reducedMotion) return
-    setIsPressed(true)
-  }, [reducedMotion])
+    if (reducedMotion) return;
+    setIsPressed(true);
+  }, [reducedMotion]);
 
   const up = useCallback(() => {
-    if (!isBrowser) return
-    setIsPressed(false)
-  }, [])
+    setIsPressed(false);
+  }, []);
+
+  const leaveWithPressReset = useCallback(
+    (e: React.PointerEvent) => {
+      proximityHandlers.onPointerLeave(e);
+      setIsPressed(false);
+    },
+    [proximityHandlers],
+  );
 
   const handlers = useMemo<TactileHandlers>(
     () => ({
-      onPointerEnter: enter,
-      onPointerLeave: leave,
+      onPointerEnter: proximityHandlers.onPointerEnter,
+      onPointerLeave: leaveWithPressReset,
       onPointerDown: down,
       onPointerUp: up,
-      onPointerMove: move,
+      onPointerMove: proximityHandlers.onPointerMove,
     }),
-    [enter, leave, down, up, move],
-  )
+    [
+      proximityHandlers.onPointerEnter,
+      proximityHandlers.onPointerMove,
+      leaveWithPressReset,
+      down,
+      up,
+    ],
+  );
 
-  // ── Derived state ─────────────────────────────────────────
+  const { transform } = useTactileTransform(proximity, isPressed, {
+    restingTilt,
+    disableTilt,
+    reducedMotion,
+  });
 
-  const isHovered = proximity > 0
-
-  const transform = useMemo<MotionStyle>(() => {
-    if (reducedMotion) {
-      return { rotate: 0, scale: 1, y: 0 }
-    }
-
-    // Tilt: straightens as cursor approaches
-    const rotate = disableTilt
-      ? 0
-      : restingTilt * (TILT_HOVER / 1.5) * (1 - proximity)
-
-    // Scale: SCALE_PRESS when pressed, otherwise interpolate
-    const scale = isPressed
-      ? SCALE_PRESS
-      : 1 + (SCALE_HOVER - 1) * proximity
-
-    // Lift: increases as cursor approaches
-    const y = proximity === 0 ? 0 : -LIFT_HOVER * proximity
-
-    return { rotate, scale, y }
-  }, [reducedMotion, disableTilt, isPressed, restingTilt, proximity])
+  const isHovered = proximity > 0;
 
   return {
     isHovered,
@@ -174,5 +102,5 @@ export function useTactileHover(
     transform,
     transition: isPressed ? springPress : springTactile,
     handlers,
-  }
+  };
 }

--- a/app/frontend/hooks/use_tactile_hover.ts
+++ b/app/frontend/hooks/use_tactile_hover.ts
@@ -3,7 +3,6 @@ import type { MotionStyle, Transition } from "framer-motion";
 import { useReducedMotionContext } from "@/components/storefront_motion_config";
 import { usePointerProximity } from "./use_pointer_proximity";
 import { useTactileTransform } from "./use_tactile_transform";
-import { springTactile, springPress } from "@/lib/motion_tokens";
 
 interface UseTactileHoverOptions {
   /** Resting tilt in degrees when not hovered. Default 0. */
@@ -87,7 +86,7 @@ export function useTactileHover(options: UseTactileHoverOptions = {}): TactileSt
     ],
   );
 
-  const { transform } = useTactileTransform(proximity, isPressed, {
+  const { transform, transition } = useTactileTransform(proximity, isPressed, {
     restingTilt,
     disableTilt,
     reducedMotion,
@@ -100,7 +99,7 @@ export function useTactileHover(options: UseTactileHoverOptions = {}): TactileSt
     isPressed,
     proximity,
     transform,
-    transition: isPressed ? springPress : springTactile,
+    transition,
     handlers,
   };
 }

--- a/app/frontend/hooks/use_tactile_transform.test.ts
+++ b/app/frontend/hooks/use_tactile_transform.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { useTactileTransform } from "./use_tactile_transform"
+
+describe("useTactileTransform", () => {
+  it("returns identity transform when proximity is 0", () => {
+    const { result } = renderHook(() => useTactileTransform(0, false))
+
+    expect(result.current.transform.rotate).toBe(0)
+    expect(result.current.transform.scale).toBe(1)
+    expect(result.current.transform.y).toBe(0)
+  })
+
+  it("returns reduced-motion identity when reducedMotion is true", () => {
+    const { result } = renderHook(() =>
+      useTactileTransform(0.8, false, { reducedMotion: true }),
+    )
+
+    expect(result.current.transform.rotate).toBe(0)
+    expect(result.current.transform.scale).toBe(1)
+    expect(result.current.transform.y).toBe(0)
+  })
+
+  it("scales down when pressed", () => {
+    const { result: notPressed } = renderHook(() => useTactileTransform(0.8, false))
+    const { result: pressed } = renderHook(() => useTactileTransform(0.8, true))
+
+    expect(pressed.current.transform.scale).toBeLessThan(
+      notPressed.current.transform.scale as number,
+    )
+  })
+
+  it("computes tilt inversely to proximity", () => {
+    const hovertiltNorm = 1.5 // TILT_HOVER / 1.5 from the hook
+
+    const { result: far } = renderHook(() => useTactileTransform(0, false))
+    const { result: near } = renderHook(() => useTactileTransform(0.9, false))
+
+    // Far from center = more tilt; near center = less tilt
+    expect(Math.abs(far.current.transform.rotate as number)).toBeGreaterThanOrEqual(
+      Math.abs(near.current.transform.rotate as number),
+    )
+  })
+})

--- a/app/frontend/hooks/use_tactile_transform.ts
+++ b/app/frontend/hooks/use_tactile_transform.ts
@@ -1,0 +1,66 @@
+import { useMemo } from "react"
+import type { MotionStyle, Transition } from "framer-motion"
+import {
+  SCALE_PRESS,
+  SCALE_HOVER,
+  LIFT_HOVER,
+  TILT_HOVER,
+  springTactile,
+  springPress,
+} from "@/lib/motion_tokens"
+
+interface UseTactileTransformOptions {
+  /** Resting tilt in degrees when not hovered. Default 0. */
+  restingTilt?: number
+  /** Disable tilt entirely — rotate always stays at 0. */
+  disableTilt?: boolean
+  /** Disable all animations — returns identity transforms. */
+  reducedMotion?: boolean
+}
+
+interface UseTactileTransformResult {
+  /** Framer Motion animate target. */
+  transform: MotionStyle
+  /** Transition to use for the current state — snappier on press. */
+  transition: Transition
+}
+
+/**
+ * Pure computation hook: derives Framer Motion style values from proximity
+ * and press state. Does not track pointer position — pair with usePointerProximity.
+ */
+export function useTactileTransform(
+  proximity: number,
+  isPressed: boolean,
+  options: UseTactileTransformOptions = {},
+): UseTactileTransformResult {
+  const { restingTilt = 0, disableTilt = false, reducedMotion = false } = options
+
+  const isHovered = proximity > 0
+
+  const transform = useMemo<MotionStyle>(() => {
+    if (reducedMotion) {
+      return { rotate: 0, scale: 1, y: 0 }
+    }
+
+    // Tilt: straightens as cursor approaches
+    const rotate = disableTilt
+      ? 0
+      : restingTilt * (TILT_HOVER / 1.5) * (1 - proximity)
+
+    // Scale: SCALE_PRESS when pressed, otherwise interpolate
+    const scale = isPressed
+      ? SCALE_PRESS
+      : 1 + (SCALE_HOVER - 1) * proximity
+
+    // Lift: increases as cursor approaches
+    const y = proximity === 0 ? 0 : -LIFT_HOVER * proximity
+
+    return { rotate, scale, y }
+  }, [reducedMotion, disableTilt, isPressed, restingTilt, proximity])
+
+  return {
+    transform,
+    transition: isPressed ? springPress : isHovered ? springTactile : springPress,
+  }
+}

--- a/app/frontend/hooks/use_tactile_transform.ts
+++ b/app/frontend/hooks/use_tactile_transform.ts
@@ -36,8 +36,6 @@ export function useTactileTransform(
 ): UseTactileTransformResult {
   const { restingTilt = 0, disableTilt = false, reducedMotion = false } = options
 
-  const isHovered = proximity > 0
-
   const transform = useMemo<MotionStyle>(() => {
     if (reducedMotion) {
       return { rotate: 0, scale: 1, y: 0 }
@@ -61,6 +59,6 @@ export function useTactileTransform(
 
   return {
     transform,
-    transition: isPressed ? springPress : isHovered ? springTactile : springPress,
+    transition: isPressed ? springPress : springTactile,
   }
 }

--- a/app/frontend/hooks/use_turnstile.ts
+++ b/app/frontend/hooks/use_turnstile.ts
@@ -46,6 +46,7 @@ export function useTurnstile({
 
   useEffect(() => {
     if (!enabled || !siteKey || !turnstileRef.current) return;
+    let scriptWithListener: HTMLScriptElement | null = null;
 
     const renderWidget = () => {
       if (!window.turnstile || !turnstileRef.current || widgetIdRef.current !== null) return;
@@ -65,6 +66,7 @@ export function useTurnstile({
       if (window.turnstile) {
         renderWidget();
       } else {
+        scriptWithListener = existingScript;
         existingScript.addEventListener("load", renderWidget, { once: true });
       }
     } else {
@@ -73,12 +75,13 @@ export function useTurnstile({
       script.async = true;
       script.defer = true;
       script.dataset.turnstileScript = "true";
-      script.onload = renderWidget;
+      scriptWithListener = script;
+      script.addEventListener("load", renderWidget, { once: true });
       document.head.appendChild(script);
     }
 
     return () => {
-      existingScript?.removeEventListener("load", renderWidget);
+      scriptWithListener?.removeEventListener("load", renderWidget);
       if (widgetIdRef.current !== null) {
         window.turnstile?.remove?.(widgetIdRef.current);
         widgetIdRef.current = null;

--- a/app/frontend/hooks/use_turnstile.ts
+++ b/app/frontend/hooks/use_turnstile.ts
@@ -41,6 +41,8 @@ export function useTurnstile({
 }: UseTurnstileOptions): UseTurnstileResult {
   const turnstileRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<TurnstileWidgetId | null>(null);
+  const onTokenRef = useRef(onToken);
+  onTokenRef.current = onToken;
 
   useEffect(() => {
     if (!enabled || !siteKey || !turnstileRef.current) return;
@@ -50,9 +52,9 @@ export function useTurnstile({
 
       widgetIdRef.current = window.turnstile.render(turnstileRef.current, {
         sitekey: siteKey,
-        callback: onToken,
-        "expired-callback": () => onToken(""),
-        "error-callback": () => onToken(""),
+        callback: (token) => onTokenRef.current(token),
+        "expired-callback": () => onTokenRef.current(""),
+        "error-callback": () => onTokenRef.current(""),
       });
     };
 
@@ -82,7 +84,7 @@ export function useTurnstile({
         widgetIdRef.current = null;
       }
     };
-  }, [enabled, siteKey, onToken]);
+  }, [enabled, siteKey]);
 
   return { turnstileRef, isReady: enabled && !!siteKey };
 }

--- a/app/frontend/hooks/use_turnstile.ts
+++ b/app/frontend/hooks/use_turnstile.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "react";
+
+type TurnstileWidgetId = string | number;
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        element: HTMLElement,
+        options: {
+          sitekey: string;
+          callback: (token: string) => void;
+          "expired-callback": () => void;
+          "error-callback": () => void;
+        },
+      ) => TurnstileWidgetId;
+      remove?: (widgetId: TurnstileWidgetId) => void;
+    };
+  }
+}
+
+interface UseTurnstileOptions {
+  enabled: boolean;
+  siteKey: string | null | undefined;
+  onToken: (token: string) => void;
+}
+
+interface UseTurnstileResult {
+  turnstileRef: React.RefObject<HTMLDivElement | null>;
+  isReady: boolean;
+}
+
+/**
+ * Manages Cloudflare Turnstile widget lifecycle: script injection,
+ * widget render, token callbacks, and cleanup.
+ */
+export function useTurnstile({
+  enabled,
+  siteKey,
+  onToken,
+}: UseTurnstileOptions): UseTurnstileResult {
+  const turnstileRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<TurnstileWidgetId | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !siteKey || !turnstileRef.current) return;
+
+    const renderWidget = () => {
+      if (!window.turnstile || !turnstileRef.current || widgetIdRef.current !== null) return;
+
+      widgetIdRef.current = window.turnstile.render(turnstileRef.current, {
+        sitekey: siteKey,
+        callback: onToken,
+        "expired-callback": () => onToken(""),
+        "error-callback": () => onToken(""),
+      });
+    };
+
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      "script[data-turnstile-script]",
+    );
+    if (existingScript) {
+      if (window.turnstile) {
+        renderWidget();
+      } else {
+        existingScript.addEventListener("load", renderWidget, { once: true });
+      }
+    } else {
+      const script = document.createElement("script");
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+      script.async = true;
+      script.defer = true;
+      script.dataset.turnstileScript = "true";
+      script.onload = renderWidget;
+      document.head.appendChild(script);
+    }
+
+    return () => {
+      existingScript?.removeEventListener("load", renderWidget);
+      if (widgetIdRef.current !== null) {
+        window.turnstile?.remove?.(widgetIdRef.current);
+        widgetIdRef.current = null;
+      }
+    };
+  }, [enabled, siteKey, onToken]);
+
+  return { turnstileRef, isReady: enabled && !!siteKey };
+}

--- a/app/frontend/layouts/app_layout.tsx
+++ b/app/frontend/layouts/app_layout.tsx
@@ -7,7 +7,7 @@ import StorefrontMotionConfig from "@/components/storefront_motion_config";
 import { ViewportProvider } from "@/contexts/viewport_context";
 import { useViewport } from "@/hooks/use_viewport";
 import BrandMark from "@/components/brand_mark";
-import BackButton from "@/components/back_button";
+import { IconBackButton } from "@/components/back_button";
 import MilkcrateShell from "@/layouts/milkcrate_shell";
 import { ShopperProvider, useShopperContext } from "@/contexts/shopper_context";
 import { DiscogsDisconnectForm } from "@/components/discogs_connection_controls";
@@ -61,12 +61,7 @@ function AppHeader({
       <div className="flex min-w-0 items-center leading-none">
         {compactCrateLocation ? (
           <>
-            <BackButton
-              variant="icon"
-              label="store"
-              onClick={compactCrateLocation.onBack}
-              className="mr-3"
-            />
+            <IconBackButton label="store" onClick={compactCrateLocation.onBack} className="mr-3" />
             <div className="min-w-0">
               <span className="mc-brand-title block truncate text-base font-bold text-mc-text">
                 {compactCrateLocation.name}

--- a/app/frontend/layouts/app_layout.tsx
+++ b/app/frontend/layouts/app_layout.tsx
@@ -7,6 +7,7 @@ import StorefrontMotionConfig from "@/components/storefront_motion_config";
 import { ViewportProvider } from "@/contexts/viewport_context";
 import { useViewport } from "@/hooks/use_viewport";
 import BrandMark from "@/components/brand_mark";
+import BackButton from "@/components/back_button";
 import MilkcrateShell from "@/layouts/milkcrate_shell";
 import { ShopperProvider, useShopperContext } from "@/contexts/shopper_context";
 import { DiscogsDisconnectForm } from "@/components/discogs_connection_controls";
@@ -24,29 +25,34 @@ interface AppLayoutProps {
   compactLocation?: CompactStoreLocation;
 }
 
-export function AppLayoutContent({ children, compactLocation }: AppLayoutProps) {
-  const page = usePage<{
-    notice?: string;
-    alert?: string;
-    store?: Pick<Store, "name" | "discogs_username">;
-    shopper?: { discogs_username: string } | null;
-  }>();
-  const notice = page.props.notice;
-  const alertMsg = page.props.alert;
-  const storeName = page.props.store?.name;
-  const discogsUsername = page.props.store?.discogs_username;
-  const { theme, toggle } = useTheme();
-  const { isCompact } = useViewport();
-  const { pile } = usePileContext();
-  const { shopper } = useShopperContext();
-  const autoOpenPile =
-    typeof window !== "undefined" && new URLSearchParams(window.location.search).has("open_pile");
-  const [pileOpen, setPileOpen] = useState(autoOpenPile);
-  const handleClosePile = React.useCallback(() => setPileOpen(false), []);
-  const compactCrateLocation = isCompact ? compactLocation : undefined;
-  const contextFocusRef = React.useRef<HTMLElement>(null);
+// ── Internal sub-components ───────────────────────────────────
 
-  const header = (
+interface AppHeaderProps {
+  compactCrateLocation?: CompactStoreLocation;
+  storeName?: string;
+  discogsUsername?: string;
+  isCompact: boolean;
+  pile: { length: number };
+  pileOpen: boolean;
+  theme: "light" | "dark";
+  toggle: () => void;
+  setPileOpen: (open: boolean) => void;
+  contextFocusRef: React.RefObject<HTMLElement | null>;
+}
+
+function AppHeader({
+  compactCrateLocation,
+  storeName,
+  discogsUsername,
+  isCompact,
+  pile,
+  pileOpen,
+  theme,
+  toggle,
+  setPileOpen,
+  contextFocusRef,
+}: AppHeaderProps) {
+  return (
     <header
       ref={contextFocusRef}
       tabIndex={-1}
@@ -55,16 +61,12 @@ export function AppLayoutContent({ children, compactLocation }: AppLayoutProps) 
       <div className="flex min-w-0 items-center leading-none">
         {compactCrateLocation ? (
           <>
-            <button
-              type="button"
+            <BackButton
+              variant="icon"
+              label="store"
               onClick={compactCrateLocation.onBack}
-              className="mr-3 flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full border border-mc-border bg-mc-bg-raised text-lg leading-none text-mc-text-dim transition-[color,border-color,transform] hover:border-mc-accent hover:text-mc-accent active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
-              aria-label="Back to store"
-            >
-              <span aria-hidden="true" className="-translate-y-px">
-                ←
-              </span>
-            </button>
+              className="mr-3"
+            />
             <div className="min-w-0">
               <span className="mc-brand-title block truncate text-base font-bold text-mc-text">
                 {compactCrateLocation.name}
@@ -129,6 +131,44 @@ export function AppLayoutContent({ children, compactLocation }: AppLayoutProps) 
         )}
       </div>
     </header>
+  );
+}
+
+export function AppLayoutContent({ children, compactLocation }: AppLayoutProps) {
+  const page = usePage<{
+    notice?: string;
+    alert?: string;
+    store?: Pick<Store, "name" | "discogs_username">;
+    shopper?: { discogs_username: string } | null;
+  }>();
+  const notice = page.props.notice;
+  const alertMsg = page.props.alert;
+  const storeName = page.props.store?.name;
+  const discogsUsername = page.props.store?.discogs_username;
+  const { theme, toggle } = useTheme();
+  const { isCompact } = useViewport();
+  const { pile } = usePileContext();
+  const { shopper } = useShopperContext();
+  const autoOpenPile =
+    typeof window !== "undefined" && new URLSearchParams(window.location.search).has("open_pile");
+  const [pileOpen, setPileOpen] = useState(autoOpenPile);
+  const handleClosePile = React.useCallback(() => setPileOpen(false), []);
+  const compactCrateLocation = isCompact ? compactLocation : undefined;
+  const contextFocusRef = React.useRef<HTMLElement>(null);
+
+  const header = (
+    <AppHeader
+      compactCrateLocation={compactCrateLocation}
+      storeName={storeName}
+      discogsUsername={discogsUsername}
+      isCompact={isCompact}
+      pile={pile}
+      pileOpen={pileOpen}
+      theme={theme}
+      toggle={toggle}
+      setPileOpen={setPileOpen}
+      contextFocusRef={contextFocusRef}
+    />
   );
 
   const footer = (

--- a/app/frontend/lib/csrf_token.test.ts
+++ b/app/frontend/lib/csrf_token.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { csrfToken } from "./csrf_token";
+
+describe("csrfToken", () => {
+  it("returns an empty string when document is not available", () => {
+    const originalDocument = globalThis.document;
+
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      expect(csrfToken()).toBe("");
+    } finally {
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
+  });
+});

--- a/app/frontend/lib/csrf_token.test.ts
+++ b/app/frontend/lib/csrf_token.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "node:test";
+import assert from "node:assert";
 import { csrfToken } from "./csrf_token";
 
 describe("csrfToken", () => {
@@ -11,7 +12,7 @@ describe("csrfToken", () => {
     });
 
     try {
-      expect(csrfToken()).toBe("");
+      assert.strictEqual(csrfToken(), "");
     } finally {
       Object.defineProperty(globalThis, "document", {
         configurable: true,

--- a/app/frontend/lib/csrf_token.ts
+++ b/app/frontend/lib/csrf_token.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns the CSRF token from the meta tag in the document head.
+ * Returns empty string if not found (SSR-safe).
+ */
+export function csrfToken(): string {
+  return document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? "";
+}

--- a/app/frontend/lib/csrf_token.ts
+++ b/app/frontend/lib/csrf_token.ts
@@ -3,5 +3,7 @@
  * Returns empty string if not found (SSR-safe).
  */
 export function csrfToken(): string {
+  if (typeof document === "undefined") return "";
+
   return document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content ?? "";
 }

--- a/app/frontend/lib/motion_tokens.ts
+++ b/app/frontend/lib/motion_tokens.ts
@@ -11,36 +11,36 @@ export const springTactile = {
   type: "spring" as const,
   stiffness: 300,
   damping: 26,
-}
+};
 
 export const springPress = {
   type: "spring" as const,
   stiffness: 400,
   damping: 28,
-}
+};
 
 export const springFlip = {
   type: "spring" as const,
   stiffness: 260,
   damping: 24,
-}
+};
 
 export const springDrawer = {
   type: "spring" as const,
   stiffness: 300,
   damping: 32,
-}
+};
 
 // ── Scale constants ───────────────────────────────────────────
 
-export const SCALE_PRESS = 0.985
-export const SCALE_HOVER = 1.025
-export const SCALE_INNER_HOVER = 1.015
+export const SCALE_PRESS = 0.985;
+export const SCALE_HOVER = 1.025;
+export const SCALE_INNER_HOVER = 1.015;
 
 // ── Lift / tilt magnitudes ────────────────────────────────────
 
-export const LIFT_HOVER = 2 // px
-export const TILT_HOVER = 1.5 // deg
+export const LIFT_HOVER = 2; // px
+export const TILT_HOVER = 1.5; // deg
 
 // ── Transition presets ────────────────────────────────────────
 // Convenience exports so consumers reference the preset, not the
@@ -50,17 +50,40 @@ export const transitionCrate = {
   type: "spring" as const,
   stiffness: 350,
   damping: 30,
-}
+};
 
 /** Bouncier crate transition for desktop — slight overshoot feels organic. */
 export const transitionCrateDesktop = {
   type: "spring" as const,
   stiffness: 280,
   damping: 22,
-}
+};
 
 // ── Reduced-motion overrides ──────────────────────────────────
 // When prefers-reduced-motion is active, transitions collapse to
 // instant and scales collapse to identity.
 
-export const reducedMotionTransition = { duration: 0 } as const
+export const reducedMotionTransition = { duration: 0 } as const;
+
+// ── Composited layer styles ────────────────────────────────────
+// Shared CSS style objects for card stack layers.
+// CSSProperties cant be imported in this file without adding a React dep;
+// use a record type that satisfies the style contract.
+
+/**
+ * Returns a composited layer style object with will-change and backface-visibility.
+ * Pass `contain: true` for hint/background cards that benefit from containment.
+ */
+export function compositedLayer(contain = false) {
+  const base = {
+    willChange: "transform, opacity" as const,
+    backfaceVisibility: "hidden" as const,
+    WebkitBackfaceVisibility: "hidden" as const,
+  };
+
+  if (contain) {
+    return { ...base, contain: "layout paint style" as const };
+  }
+
+  return base;
+}

--- a/app/frontend/pages/admin/dashboard.tsx
+++ b/app/frontend/pages/admin/dashboard.tsx
@@ -1,84 +1,38 @@
-import React, { useRef, useState, useEffect } from "react"
-import { router } from "@inertiajs/react"
-import type { AdminApplicantSummary, AdminDashboardProps, AdminHealthSeverity, AdminStoreSummary } from "@/types/inertia"
-import Badge from "@/components/ui/badge"
-import Button from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import EmptyState from "@/components/ui/empty_state"
-import FeedbackMessage, { type FeedbackTone } from "@/components/ui/feedback_message"
-import Field from "@/components/ui/field"
-import SectionHeader from "@/components/ui/section_header"
-import StatusDot from "@/components/ui/status_dot"
-import JobProgressBar from "@/components/ui/job_progress_bar"
-import Metric from "@/components/ui/metric"
-import MilkcrateShell from "@/layouts/milkcrate_shell"
+import { useEffect } from "react";
+import { router } from "@inertiajs/react";
+import type { AdminDashboardProps } from "@/types/inertia";
+import EmptyState from "@/components/ui/empty_state";
+import FeedbackMessage from "@/components/ui/feedback_message";
+import SectionHeader from "@/components/ui/section_header";
+import Metric from "@/components/ui/metric";
+import MilkcrateShell from "@/layouts/milkcrate_shell";
+import { DiscogsOnboardingPanel } from "./dashboard/discogs_onboarding_panel";
+import StoreCard from "./dashboard/store_card";
+import ApplicantCard from "./dashboard/applicant_card";
 
-function formatTime(value: string | null) {
-  if (!value) return "Not yet"
+export default function Dashboard({
+  active_stores,
+  applicants,
+  discogs_onboarding,
+  notice,
+  alert,
+}: AdminDashboardProps) {
+  const healthyCount = active_stores.filter((store) => store.health.key === "healthy").length;
+  const attentionCount = active_stores.filter((store) =>
+    ["failed", "stale", "partial"].includes(store.health.key),
+  ).length;
+  const processingCount = active_stores.filter((store) => store.health.key === "processing").length;
 
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(new Date(value))
-}
-
-function listingText(count: number | null) {
-  if (count === null) return "Listings pending"
-  return `${count.toLocaleString()} ${count === 1 ? "listing" : "listings"}`
-}
-
-function severityVariant(severity: AdminHealthSeverity) {
-  return severity
-}
-
-type AdminDiscogsLookupResponse = {
-  status: "creatable"
-  creatable: true
-  username: string
-  seller_name?: string | null
-  avatar_url?: string | null
-} | {
-  status: "invalid" | "lookup_error"
-  creatable: false
-  reason?: string
-} | {
-  status: "already_active"
-  creatable: false
-  username: string
-  store: {
-    id: number
-    name: string
-    discogs_username: string
-  }
-} | {
-  status: "existing_applicant"
-  creatable: false
-  username: string
-  applicant: {
-    id: number
-    name: string
-    discogs_username: string
-  }
-}
-
-export default function Dashboard({ active_stores, applicants, discogs_onboarding, notice, alert }: AdminDashboardProps) {
-  const healthyCount = active_stores.filter((store) => store.health.key === "healthy").length
-  const attentionCount = active_stores.filter((store) => ["failed", "stale", "partial"].includes(store.health.key)).length
-  const processingCount = active_stores.filter((store) => store.health.key === "processing").length
-
-  // Poll for live progress updates while any store has active jobs
   const hasActiveJobs = active_stores.some(
-    (s) => s.sync_status === "syncing" || s.enrichment_status === "enriching"
-  )
+    (s) => s.sync_status === "syncing" || s.enrichment_status === "enriching",
+  );
   useEffect(() => {
-    if (!hasActiveJobs) return
+    if (!hasActiveJobs) return;
     const interval = setInterval(() => {
-      router.reload({ only: ["active_stores"] })
-    }, 3000)
-    return () => clearInterval(interval)
-  }, [hasActiveJobs])
+      router.reload({ only: ["active_stores"] });
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [hasActiveJobs]);
 
   const header = (
     <header className="border-b border-mc-border px-4 py-6 sm:px-6 lg:px-8">
@@ -96,37 +50,54 @@ export default function Dashboard({ active_stores, applicants, discogs_onboardin
           </button>
         </div>
         <dl className="grid grid-cols-3 gap-2 sm:min-w-80">
-          <Metric label="Healthy" value={healthyCount} className="rounded-lg border border-mc-border bg-mc-bg-card px-3 py-2" />
-          <Metric label="Processing" value={processingCount} className="rounded-lg border border-mc-border bg-mc-bg-card px-3 py-2" />
-          <Metric label="Attention" value={attentionCount} className="rounded-lg border border-mc-border bg-mc-bg-card px-3 py-2" />
+          <Metric
+            label="Healthy"
+            value={healthyCount}
+            className="rounded-lg border border-mc-border bg-mc-bg-card px-3 py-2"
+          />
+          <Metric
+            label="Processing"
+            value={processingCount}
+            className="rounded-lg border border-mc-border bg-mc-bg-card px-3 py-2"
+          />
+          <Metric
+            label="Attention"
+            value={attentionCount}
+            className="rounded-lg border border-mc-border bg-mc-bg-card px-3 py-2"
+          />
         </dl>
       </div>
     </header>
-  )
+  );
 
   return (
     <div className="min-h-screen bg-mc-bg text-mc-text">
       <MilkcrateShell
         header={header}
-        afterHeader={(notice || alert) ? (
-          <div className="mx-auto grid w-full max-w-7xl gap-2 px-4 pt-6 sm:px-6 lg:px-8">
-            {notice && (
-              <FeedbackMessage tone="success" live="polite">
-                {notice}
-              </FeedbackMessage>
-            )}
-            {alert && (
-              <FeedbackMessage tone="danger" live="assertive">
-                {alert}
-              </FeedbackMessage>
-            )}
-          </div>
-        ) : undefined}
+        afterHeader={
+          notice || alert ? (
+            <div className="mx-auto grid w-full max-w-7xl gap-2 px-4 pt-6 sm:px-6 lg:px-8">
+              {notice && (
+                <FeedbackMessage tone="success" live="polite">
+                  {notice}
+                </FeedbackMessage>
+              )}
+              {alert && (
+                <FeedbackMessage tone="danger" live="assertive">
+                  {alert}
+                </FeedbackMessage>
+              )}
+            </div>
+          ) : undefined
+        }
         contentWidth="max-w-7xl"
         contentPadding="px-4 py-6 sm:px-6 lg:px-8"
       >
         <div className="flex flex-col gap-8">
-          <DiscogsOnboardingPanel lookupPath={discogs_onboarding.lookup_path} createPath={discogs_onboarding.create_path} />
+          <DiscogsOnboardingPanel
+            lookupPath={discogs_onboarding.lookup_path}
+            createPath={discogs_onboarding.create_path}
+          />
 
           <section aria-labelledby="active-stores-heading">
             <SectionHeader
@@ -164,238 +135,5 @@ export default function Dashboard({ active_stores, applicants, discogs_onboardin
         </div>
       </MilkcrateShell>
     </div>
-  )
-}
-
-function DiscogsOnboardingPanel({ lookupPath, createPath }: { lookupPath: string; createPath: string }) {
-  const [username, setUsername] = useState("")
-  const [lookup, setLookup] = useState<AdminDiscogsLookupResponse | null>(null)
-  const [state, setState] = useState<"idle" | "loading" | "error">("idle")
-  const lookupRequestId = useRef(0)
-  const csrfToken = document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content
-
-  function handleUsernameChange(event: React.ChangeEvent<HTMLInputElement>) {
-    setUsername(event.target.value)
-    setLookup(null)
-    lookupRequestId.current += 1
-    if (state !== "idle") setState("idle")
-  }
-
-  async function handleLookup(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const trimmedUsername = username.trim()
-
-    if (!trimmedUsername) {
-      setLookup({ status: "invalid", creatable: false, reason: "blank" })
-      setState("idle")
-      return
-    }
-
-    setState("loading")
-    setLookup(null)
-    const requestId = lookupRequestId.current + 1
-    lookupRequestId.current = requestId
-
-    try {
-      const url = new URL(lookupPath, window.location.origin)
-      url.searchParams.set("username", trimmedUsername)
-      const response = await fetch(url.toString(), {
-        headers: { Accept: "application/json" },
-      })
-
-      if (!response.ok) throw new Error(`Lookup failed with ${response.status}`)
-
-      const result = await response.json() as AdminDiscogsLookupResponse
-      if (lookupRequestId.current !== requestId) return
-
-      setLookup(result)
-      setState("idle")
-    } catch {
-      if (lookupRequestId.current !== requestId) return
-
-      setLookup(null)
-      setState("error")
-    }
-  }
-
-  return (
-    <section aria-labelledby="discogs-onboarding-heading">
-      <Card>
-        <CardHeader>
-          <CardTitle id="discogs-onboarding-heading">Add Discogs storefront</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]" onSubmit={handleLookup}>
-            <Field id="admin-discogs-username" label="Discogs username" className="min-w-0">
-              <input
-                type="text"
-                name="discogs_username_lookup"
-                value={username}
-                onChange={handleUsernameChange}
-                placeholder="seller-name"
-                autoComplete="off"
-              />
-            </Field>
-            <div className="flex items-end">
-              <Button type="submit" variant="secondary" className="w-full md:w-auto" busy={state === "loading"}>
-                {state === "loading" ? "Checking..." : "Lookup"}
-              </Button>
-            </div>
-          </form>
-
-          {state === "error" && (
-            <LookupMessage tone="danger">
-              Lookup failed. Try again before creating a storefront.
-            </LookupMessage>
-          )}
-
-          {state === "loading" && (
-            <LookupMessage tone="progress">
-              Checking Discogs and current admin records...
-            </LookupMessage>
-          )}
-
-          {lookup && <LookupResult lookup={lookup} createPath={createPath} csrfToken={csrfToken} />}
-        </CardContent>
-      </Card>
-    </section>
-  )
-}
-
-function LookupResult({
-  lookup,
-  createPath,
-  csrfToken,
-}: {
-  lookup: AdminDiscogsLookupResponse
-  createPath: string
-  csrfToken?: string
-}) {
-  if (lookup.status === "creatable") {
-    return (
-      <FeedbackMessage tone="success" className="p-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex min-w-0 items-center gap-3">
-            {lookup.avatar_url && (
-              <img
-                src={lookup.avatar_url}
-                alt=""
-                className="h-12 w-12 shrink-0 rounded-md border border-mc-feedback-success-border object-cover"
-              />
-            )}
-            <div className="min-w-0">
-              <p className="font-semibold text-mc-text">{lookup.seller_name || lookup.username}</p>
-              <p className="break-all text-sm text-mc-text-dim">@{lookup.username}</p>
-            </div>
-          </div>
-          <form action={createPath} method="post" className="shrink-0">
-            {csrfToken && <input type="hidden" name="authenticity_token" value={csrfToken} />}
-            <input type="hidden" name="discogs_username" value={lookup.username} />
-            <Button type="submit" className="w-full sm:w-auto">Onboard storefront</Button>
-          </form>
-        </div>
-      </FeedbackMessage>
-    )
-  }
-
-  if (lookup.status === "already_active") {
-    return (
-      <LookupMessage tone="warning">
-        {lookup.store.name} is already active as @{lookup.store.discogs_username}.
-      </LookupMessage>
-    )
-  }
-
-  if (lookup.status === "existing_applicant") {
-    return (
-      <LookupMessage tone="warning">
-        {lookup.applicant.name} already applied as @{lookup.applicant.discogs_username}. Use the applicant onboarding path.
-      </LookupMessage>
-    )
-  }
-
-  if (lookup.status === "invalid") {
-    return (
-      <LookupMessage tone="danger">
-        Enter a valid Discogs username before creating a storefront.
-      </LookupMessage>
-    )
-  }
-
-  return (
-    <LookupMessage tone="danger">
-      Discogs could not verify this seller right now. No storefront can be created from this lookup.
-    </LookupMessage>
-  )
-}
-
-function LookupMessage({ tone, children }: { tone: FeedbackTone; children: React.ReactNode }) {
-  return (
-    <FeedbackMessage tone={tone} live={tone === "danger" ? "assertive" : tone === "progress" ? "polite" : undefined}>
-      {children}
-    </FeedbackMessage>
-  )
-}
-
-function StoreCard({ store }: { store: AdminStoreSummary }) {
-  return (
-    <Card>
-      <CardHeader className="flex flex-row items-start justify-between gap-3">
-        <div className="min-w-0">
-          <CardTitle className="truncate">{store.name}</CardTitle>
-          <a className="text-sm text-mc-text-dim hover:text-mc-text" href={store.storefront_path}>
-            @{store.discogs_username}
-          </a>
-        </div>
-        <Badge variant={severityVariant(store.health.severity)}>{store.health.label}</Badge>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <StatusDot variant={severityVariant(store.health.severity)} label={store.health.reasons[0] ?? store.health.label} />
-
-        <dl className="grid grid-cols-2 gap-3 text-sm">
-          <Metric label="Last sync" value={formatTime(store.last_synced_at)} />
-          <Metric label="Last enrich" value={formatTime(store.last_enriched_at)} />
-          <Metric label="Inventory" value={listingText(store.total_listings)} />
-          <Metric label="Coverage" value={store.catalog_coverage.replace("_", " ")} />
-          <JobProgressBar label="Sync" status={store.sync_status} progressPct={store.sync_progress_pct} />
-          <JobProgressBar label="Enrichment" status={store.enrichment_status} progressPct={store.enrichment_progress_pct} />
-        </dl>
-
-        {store.health.last_sync_error_summary && (
-          <FeedbackMessage tone="danger" live="assertive">
-            {store.health.last_sync_error_summary}
-          </FeedbackMessage>
-        )}
-      </CardContent>
-    </Card>
-  )
-}
-
-function ApplicantCard({ applicant }: { applicant: AdminApplicantSummary }) {
-  const csrfToken = document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content
-
-  return (
-    <Card>
-      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <CardTitle>{applicant.name}</CardTitle>
-          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-sm text-mc-text-dim">
-            <span>{applicant.email}</span>
-            <span>@{applicant.discogs_username}</span>
-          </div>
-        </div>
-        <form action={`/admin/waitlists/${applicant.id}/onboarding`} method="post">
-          {csrfToken && <input type="hidden" name="authenticity_token" value={csrfToken} />}
-          <Button type="submit">Onboard store</Button>
-        </form>
-      </CardHeader>
-      <CardContent className="space-y-3 text-sm text-mc-text-dim">
-        <div className="flex flex-wrap gap-x-4 gap-y-1">
-          <span>Inventory: {applicant.inventory_size || "Not specified"}</span>
-          <span>Submitted: {formatTime(applicant.submitted_at)}</span>
-        </div>
-        {applicant.notes && <p className="whitespace-pre-wrap break-words">{applicant.notes}</p>}
-      </CardContent>
-    </Card>
-  )
+  );
 }

--- a/app/frontend/pages/admin/dashboard/applicant_card.tsx
+++ b/app/frontend/pages/admin/dashboard/applicant_card.tsx
@@ -1,0 +1,49 @@
+import type { AdminApplicantSummary } from "@/types/inertia";
+import Button from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+function formatTime(value: string | null) {
+  if (!value) return "Not yet";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+export default function ApplicantCard({
+  applicant,
+}: {
+  applicant: AdminApplicantSummary;
+}) {
+  const csrfToken =
+    typeof document !== "undefined"
+      ? document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content
+      : undefined;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <CardTitle>{applicant.name}</CardTitle>
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-sm text-mc-text-dim">
+            <span>{applicant.email}</span>
+            <span>@{applicant.discogs_username}</span>
+          </div>
+        </div>
+        <form action={`/admin/waitlists/${applicant.id}/onboarding`} method="post">
+          {csrfToken && <input type="hidden" name="authenticity_token" value={csrfToken} />}
+          <Button type="submit">Onboard store</Button>
+        </form>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-mc-text-dim">
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          <span>Inventory: {applicant.inventory_size || "Not specified"}</span>
+          <span>Submitted: {formatTime(applicant.submitted_at)}</span>
+        </div>
+        {applicant.notes && <p className="whitespace-pre-wrap break-words">{applicant.notes}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/frontend/pages/admin/dashboard/discogs_onboarding_panel.tsx
+++ b/app/frontend/pages/admin/dashboard/discogs_onboarding_panel.tsx
@@ -1,0 +1,174 @@
+import { useState, type ReactNode } from "react";
+import type { AdminDiscogsLookupResponse } from "@/hooks/use_admin_discogs_lookup";
+import Button from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import FeedbackMessage, { type FeedbackTone } from "@/components/ui/feedback_message";
+import Field from "@/components/ui/field";
+import { useAdminDiscogsLookup } from "@/hooks/use_admin_discogs_lookup";
+
+export function LookupMessage({
+  tone,
+  children,
+}: {
+  tone: FeedbackTone;
+  children: ReactNode;
+}) {
+  return (
+    <FeedbackMessage
+      tone={tone}
+      live={tone === "danger" ? "assertive" : tone === "progress" ? "polite" : undefined}
+    >
+      {children}
+    </FeedbackMessage>
+  );
+}
+
+function LookupResult({
+  lookup,
+  createPath,
+  csrfToken,
+}: {
+  lookup: AdminDiscogsLookupResponse;
+  createPath: string;
+  csrfToken?: string;
+}) {
+  if (lookup.status === "creatable") {
+    return (
+      <FeedbackMessage tone="success" className="p-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            {lookup.avatar_url && (
+              <img
+                src={lookup.avatar_url}
+                alt=""
+                className="h-12 w-12 shrink-0 rounded-md border border-mc-feedback-success-border object-cover"
+              />
+            )}
+            <div className="min-w-0">
+              <p className="font-semibold text-mc-text">{lookup.seller_name || lookup.username}</p>
+              <p className="break-all text-sm text-mc-text-dim">@{lookup.username}</p>
+            </div>
+          </div>
+          <form action={createPath} method="post" className="shrink-0">
+            {csrfToken && <input type="hidden" name="authenticity_token" value={csrfToken} />}
+            <input type="hidden" name="discogs_username" value={lookup.username} />
+            <Button type="submit" className="w-full sm:w-auto">
+              Onboard storefront
+            </Button>
+          </form>
+        </div>
+      </FeedbackMessage>
+    );
+  }
+
+  if (lookup.status === "already_active") {
+    return (
+      <LookupMessage tone="warning">
+        {lookup.store.name} is already active as @{lookup.store.discogs_username}.
+      </LookupMessage>
+    );
+  }
+
+  if (lookup.status === "existing_applicant") {
+    return (
+      <LookupMessage tone="warning">
+        {lookup.applicant.name} already applied as @{lookup.applicant.discogs_username}. Use the
+        applicant onboarding path.
+      </LookupMessage>
+    );
+  }
+
+  if (lookup.status === "invalid") {
+    return (
+      <LookupMessage tone="danger">
+        Enter a valid Discogs username before creating a storefront.
+      </LookupMessage>
+    );
+  }
+
+  return (
+    <LookupMessage tone="danger">
+      Discogs could not verify this seller right now. No storefront can be created from this
+      lookup.
+    </LookupMessage>
+  );
+}
+
+export function DiscogsOnboardingPanel({
+  lookupPath,
+  createPath,
+}: {
+  lookupPath: string;
+  createPath: string;
+}) {
+  const [username, setUsername] = useState("");
+  const { state, lookup, reset } = useAdminDiscogsLookup(lookupPath);
+  const csrfToken =
+    typeof document !== "undefined"
+      ? document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content
+      : undefined;
+
+  function handleUsernameChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setUsername(event.target.value);
+    if (state.status !== "idle") reset();
+  }
+
+  function handleLookup(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedUsername = username.trim();
+    if (!trimmedUsername) return;
+    lookup(trimmedUsername);
+  }
+
+  const isBusy = state.status === "loading";
+
+  return (
+    <section aria-labelledby="discogs-onboarding-heading">
+      <Card>
+        <CardHeader>
+          <CardTitle id="discogs-onboarding-heading">Add Discogs storefront</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]" onSubmit={handleLookup}>
+            <Field id="admin-discogs-username" label="Discogs username" className="min-w-0">
+              <input
+                type="text"
+                name="discogs_username_lookup"
+                value={username}
+                onChange={handleUsernameChange}
+                placeholder="seller-name"
+                autoComplete="off"
+              />
+            </Field>
+            <div className="flex items-end">
+              <Button
+                type="submit"
+                variant="secondary"
+                className="w-full md:w-auto"
+                busy={isBusy}
+              >
+                {isBusy ? "Checking..." : "Lookup"}
+              </Button>
+            </div>
+          </form>
+
+          {state.status === "error" && (
+            <LookupMessage tone="danger">
+              Lookup failed. Try again before creating a storefront.
+            </LookupMessage>
+          )}
+
+          {isBusy && (
+            <LookupMessage tone="progress">
+              Checking Discogs and current admin records...
+            </LookupMessage>
+          )}
+
+          {state.status === "result" && (
+            <LookupResult lookup={state.result} createPath={createPath} csrfToken={csrfToken} />
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/app/frontend/pages/admin/dashboard/index.ts
+++ b/app/frontend/pages/admin/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default as Dashboard } from "../dashboard";

--- a/app/frontend/pages/admin/dashboard/store_card.tsx
+++ b/app/frontend/pages/admin/dashboard/store_card.tsx
@@ -1,0 +1,71 @@
+import type { AdminStoreSummary } from "@/types/inertia";
+import Badge from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import FeedbackMessage from "@/components/ui/feedback_message";
+import StatusDot from "@/components/ui/status_dot";
+import JobProgressBar from "@/components/ui/job_progress_bar";
+import Metric from "@/components/ui/metric";
+
+function formatTime(value: string | null) {
+  if (!value) return "Not yet";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function listingText(count: number | null) {
+  if (count === null) return "Listings pending";
+  return `${count.toLocaleString()} ${count === 1 ? "listing" : "listings"}`;
+}
+
+function severityVariant(severity: string) {
+  return severity as "good" | "working" | "warning" | "danger" | "neutral";
+}
+
+export default function StoreCard({ store }: { store: AdminStoreSummary }) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-3">
+        <div className="min-w-0">
+          <CardTitle className="truncate">{store.name}</CardTitle>
+          <a className="text-sm text-mc-text-dim hover:text-mc-text" href={store.storefront_path}>
+            @{store.discogs_username}
+          </a>
+        </div>
+        <Badge variant={severityVariant(store.health.severity)}>{store.health.label}</Badge>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <StatusDot
+          variant={severityVariant(store.health.severity)}
+          label={store.health.reasons[0] ?? store.health.label}
+        />
+
+        <dl className="grid grid-cols-2 gap-3 text-sm">
+          <Metric label="Last sync" value={formatTime(store.last_synced_at)} />
+          <Metric label="Last enrich" value={formatTime(store.last_enriched_at)} />
+          <Metric label="Inventory" value={listingText(store.total_listings)} />
+          <Metric label="Coverage" value={store.catalog_coverage.replace("_", " ")} />
+          <JobProgressBar
+            label="Sync"
+            status={store.sync_status}
+            progressPct={store.sync_progress_pct}
+          />
+          <JobProgressBar
+            label="Enrichment"
+            status={store.enrichment_status}
+            progressPct={store.enrichment_progress_pct}
+          />
+        </dl>
+
+        {store.health.last_sync_error_summary && (
+          <FeedbackMessage tone="danger" live="assertive">
+            {store.health.last_sync_error_summary}
+          </FeedbackMessage>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/frontend/pages/apply.tsx
+++ b/app/frontend/pages/apply.tsx
@@ -1,64 +1,52 @@
-import { useEffect, useRef } from "react"
-import { useForm } from "@inertiajs/react"
-import { motion } from "framer-motion"
-import MarketingLayout from "@/layouts/marketing_layout"
-import BrandMark from "@/components/brand_mark"
-import Button from "@/components/ui/button"
-import FeedbackMessage from "@/components/ui/feedback_message"
-import Field from "@/components/ui/field"
-import { springTactile } from "@/lib/motion_tokens"
-
-type TurnstileWidgetId = string | number
-
-declare global {
-  interface Window {
-    turnstile?: {
-      render: (
-        element: HTMLElement,
-        options: {
-          sitekey: string
-          callback: (token: string) => void
-          "expired-callback": () => void
-          "error-callback": () => void
-        }
-      ) => TurnstileWidgetId
-      remove?: (widgetId: TurnstileWidgetId) => void
-    }
-  }
-}
+import { useForm } from "@inertiajs/react";
+import { motion } from "framer-motion";
+import MarketingLayout from "@/layouts/marketing_layout";
+import BrandMark from "@/components/brand_mark";
+import Button from "@/components/ui/button";
+import FeedbackMessage from "@/components/ui/feedback_message";
+import Field from "@/components/ui/field";
+import Spinner from "@/components/spinner";
+import { springTactile } from "@/lib/motion_tokens";
+import { useTurnstile } from "@/hooks/use_turnstile";
 
 type Props = {
-  submitted?: boolean
-  errors?: Record<string, { error: string; value: string }[]>
+  submitted?: boolean;
+  errors?: Record<string, { error: string; value: string }[]>;
   turnstile?: {
-    enabled: boolean
-    site_key: string | null
-  }
-  initial_discogs_username?: string
+    enabled: boolean;
+    site_key: string | null;
+  };
+  initial_discogs_username?: string;
   copy: {
-    headline: string
-    subhead: string
-    submit: string
-    submitting: string
-    confirmation_headline: string
-    confirmation_body: string
-    context_title: string
-    context_discogs_why: string
-    context_what_happens: string
-    context_no_commitment: string
-    field_hint_discogs: string
-    field_hint_email: string
+    headline: string;
+    subhead: string;
+    submit: string;
+    submitting: string;
+    confirmation_headline: string;
+    confirmation_body: string;
+    context_title: string;
+    context_discogs_why: string;
+    context_what_happens: string;
+    context_no_commitment: string;
+    field_hint_discogs: string;
+    field_hint_email: string;
     fields: {
-      name: string
-      discogs_username: string
-      email: string
-      inventory_size: string
-      notes: string
-    }
-  }
-}
+      name: string;
+      discogs_username: string;
+      email: string;
+      inventory_size: string;
+      notes: string;
+    };
+  };
+};
 
-export default function Apply({ submitted = false, errors = {}, turnstile, copy, initial_discogs_username }: Props) {
+export default function Apply({
+  submitted = false,
+  errors = {},
+  turnstile,
+  copy,
+  initial_discogs_username,
+}: Props) {
   const { data, setData, post, processing } = useForm({
     name: "",
     discogs_username: initial_discogs_username || "",
@@ -66,51 +54,13 @@ export default function Apply({ submitted = false, errors = {}, turnstile, copy,
     inventory_size: "",
     notes: "",
     turnstile_token: "",
-  })
-  const widgetRef = useRef<HTMLDivElement>(null)
-  const widgetIdRef = useRef<TurnstileWidgetId | null>(null)
-  const turnstileEnabled = turnstile?.enabled === true
-  const turnstileSiteKey = turnstile?.site_key
+  });
 
-  useEffect(() => {
-    if (!turnstileEnabled || !turnstileSiteKey || !widgetRef.current) return
-
-    const renderWidget = () => {
-      if (!window.turnstile || !widgetRef.current || widgetIdRef.current !== null) return
-
-      widgetIdRef.current = window.turnstile.render(widgetRef.current, {
-        sitekey: turnstileSiteKey,
-        callback: (token: string) => setData("turnstile_token", token),
-        "expired-callback": () => setData("turnstile_token", ""),
-        "error-callback": () => setData("turnstile_token", ""),
-      })
-    }
-
-    const existingScript = document.querySelector<HTMLScriptElement>("script[data-turnstile-script]")
-    if (existingScript) {
-      if (window.turnstile) {
-        renderWidget()
-      } else {
-        existingScript.addEventListener("load", renderWidget, { once: true })
-      }
-    } else {
-      const script = document.createElement("script")
-      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
-      script.async = true
-      script.defer = true
-      script.dataset.turnstileScript = "true"
-      script.onload = renderWidget
-      document.head.appendChild(script)
-    }
-
-    return () => {
-      existingScript?.removeEventListener("load", renderWidget)
-      if (widgetIdRef.current !== null) {
-        window.turnstile?.remove?.(widgetIdRef.current)
-        widgetIdRef.current = null
-      }
-    }
-  }, [setData, turnstileEnabled, turnstileSiteKey])
+  const { turnstileRef, isReady } = useTurnstile({
+    enabled: turnstile?.enabled === true,
+    siteKey: turnstile?.site_key,
+    onToken: (token: string) => setData("turnstile_token", token),
+  });
 
   if (submitted) {
     return (
@@ -142,39 +92,45 @@ export default function Apply({ submitted = false, errors = {}, turnstile, copy,
           </motion.p>
         </div>
       </MarketingLayout>
-    )
+    );
   }
 
-  const errorCount = Object.keys(errors).length
-  const fieldErrors = Object.entries(errors).filter(([key]) => key !== "turnstile")
+  const errorCount = Object.keys(errors).length;
+  const fieldErrors = Object.entries(errors).filter(([key]) => key !== "turnstile");
 
   return (
     <MarketingLayout>
       <div className="max-w-md mx-auto">
         <h1 className="text-2xl font-bold text-mc-text mb-2">{copy.headline}</h1>
-        <p className="text-sm text-mc-text-dim mb-6 leading-relaxed">
-          {copy.subhead}
-        </p>
+        <p className="text-sm text-mc-text-dim mb-6 leading-relaxed">{copy.subhead}</p>
 
-        {/* Vendor context panel — explains what we're asking and why */}
         <section
           aria-labelledby="apply-context-title"
           className="mb-8 px-5 py-4 rounded-lg bg-mc-bg-card border border-mc-border"
         >
-          <h2 id="apply-context-title" className="text-xs font-semibold uppercase tracking-widest text-mc-text-dim mb-3">
+          <h2
+            id="apply-context-title"
+            className="text-xs font-semibold uppercase tracking-widest text-mc-text-dim mb-3"
+          >
             {copy.context_title}
           </h2>
           <ul className="flex flex-col gap-2.5 text-xs text-mc-text-dim leading-relaxed list-none">
             <li className="flex gap-2">
-              <span className="text-mc-accent flex-shrink-0 select-none mt-px" aria-hidden="true">•</span>
+              <span className="text-mc-accent flex-shrink-0 select-none mt-px" aria-hidden="true">
+                •
+              </span>
               <span>{copy.context_discogs_why}</span>
             </li>
             <li className="flex gap-2">
-              <span className="text-mc-accent flex-shrink-0 select-none mt-px" aria-hidden="true">•</span>
+              <span className="text-mc-accent flex-shrink-0 select-none mt-px" aria-hidden="true">
+                •
+              </span>
               <span>{copy.context_what_happens}</span>
             </li>
             <li className="flex gap-2">
-              <span className="text-mc-accent flex-shrink-0 select-none mt-px" aria-hidden="true">•</span>
+              <span className="text-mc-accent flex-shrink-0 select-none mt-px" aria-hidden="true">
+                •
+              </span>
               <span>{copy.context_no_commitment}</span>
             </li>
           </ul>
@@ -182,8 +138,8 @@ export default function Apply({ submitted = false, errors = {}, turnstile, copy,
 
         <form
           onSubmit={(e) => {
-            e.preventDefault()
-            post("/apply")
+            e.preventDefault();
+            post("/apply");
           }}
           className="flex flex-col gap-6"
           noValidate
@@ -191,24 +147,27 @@ export default function Apply({ submitted = false, errors = {}, turnstile, copy,
           {errorCount > 0 && (
             <FeedbackMessage tone="danger" live="assertive" className="px-4 py-3">
               <p className="font-semibold mb-1">
-                {errorCount === 1 ? "There's a problem with your submission." : `There are ${errorCount} problems with your submission.`}
+                {errorCount === 1
+                  ? "There's a problem with your submission."
+                  : `There are ${errorCount} problems with your submission.`}
               </p>
               <ul className="list-disc list-inside text-xs text-mc-text-dim space-y-0.5">
                 {fieldErrors.map(([field, errs]) =>
                   errs.map((e, i) => {
-                    const label = copy.fields[field as keyof typeof copy.fields]
-                    return <li key={`${field}-${i}`}>{label ? `${label} ` : ""}{e.error}</li>
-                  })
+                    const label = copy.fields[field as keyof typeof copy.fields];
+                    return (
+                      <li key={`${field}-${i}`}>
+                        {label ? `${label} ` : ""}
+                        {e.error}
+                      </li>
+                    );
+                  }),
                 )}
               </ul>
             </FeedbackMessage>
           )}
 
-          <Field
-            id="apply-name"
-            label={copy.fields.name}
-            error={errors.name?.[0]?.error}
-          >
+          <Field id="apply-name" label={copy.fields.name} error={errors.name?.[0]?.error}>
             <input
               type="text"
               value={data.name}
@@ -251,11 +210,7 @@ export default function Apply({ submitted = false, errors = {}, turnstile, copy,
             />
           </Field>
 
-          <Field
-            id="apply-inventory_size"
-            label={copy.fields.inventory_size}
-            hint="Optional"
-          >
+          <Field id="apply-inventory_size" label={copy.fields.inventory_size} hint="Optional">
             <select
               value={data.inventory_size}
               onChange={(e) => setData("inventory_size", e.target.value)}
@@ -268,11 +223,7 @@ export default function Apply({ submitted = false, errors = {}, turnstile, copy,
             </select>
           </Field>
 
-          <Field
-            id="apply-notes"
-            label={copy.fields.notes}
-            hint="Optional"
-          >
+          <Field id="apply-notes" label={copy.fields.notes} hint="Optional">
             <textarea
               value={data.notes}
               onChange={(e) => setData("notes", e.target.value)}
@@ -282,49 +233,29 @@ export default function Apply({ submitted = false, errors = {}, turnstile, copy,
             />
           </Field>
 
-          {turnstileEnabled && turnstileSiteKey && (
+          {isReady && (
             <div className="flex flex-col gap-1">
               <div
-                ref={widgetRef}
+                ref={turnstileRef}
                 data-testid="turnstile-widget"
-                data-sitekey={turnstileSiteKey}
+                data-sitekey={turnstile?.site_key}
                 className="min-h-[65px]"
                 role="presentation"
               />
               {errors.turnstile?.[0]?.error && (
-                <FeedbackMessage
-                  tone="danger"
-                  live="assertive"
-                  className="text-xs"
-                >
+                <FeedbackMessage tone="danger" live="assertive" className="text-xs">
                   {errors.turnstile[0].error}
                 </FeedbackMessage>
               )}
             </div>
           )}
 
-          <Button
-            type="submit"
-            busy={processing}
-            size="lg"
-            className="tracking-wide"
-          >
-            {processing && (
-              <svg
-                className="motion-safe:animate-spin h-4 w-4 text-mc-on-accent/80"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-            )}
+          <Button type="submit" busy={processing} size="lg" className="tracking-wide">
+            {processing && <Spinner size="sm" />}
             <span>{processing ? copy.submitting : copy.submit}</span>
           </Button>
         </form>
       </div>
     </MarketingLayout>
-  )
+  );
 }

--- a/app/frontend/pages/home.tsx
+++ b/app/frontend/pages/home.tsx
@@ -1,48 +1,48 @@
-import { Link } from "@inertiajs/react"
-import { motion } from "framer-motion"
-import type { Variants } from "framer-motion"
-import MarketingLayout from "@/layouts/marketing_layout"
-import CrateView from "@/components/crate_view"
-import DiscogsSellerLookupInput from "@/components/discogs_seller_lookup_input"
-import { actionClassName } from "@/components/ui/action"
-import { PileProvider } from "@/contexts/pile_context"
-import type { HomepagePreview } from "@/types/inertia"
+import { Link } from "@inertiajs/react";
+import { motion } from "framer-motion";
+import type { Variants } from "framer-motion";
+import MarketingLayout from "@/layouts/marketing_layout";
+import CrateView from "@/components/crate_view";
+import DiscogsSellerLookupInput from "@/components/discogs_seller_lookup_input";
+import { actionClassName } from "@/components/ui/action";
+import { PileProvider } from "@/contexts/pile_context";
+import type { HomepagePreview } from "@/types/inertia";
 
 interface Props {
   copy: {
-    headline: string
-    subhead: string
-    cta_demo: string
-    hero_subhead: string
+    headline: string;
+    subhead: string;
+    cta_demo: string;
+    hero_subhead: string;
     steps: {
-      step1_title: string
-      step1_body: string
-      step2_title: string
-      step2_body: string
-      step3_title: string
-      step3_body: string
-    }
-    preview_blurb: string
-    preview_label: string
-    store_character_title: string
-    seller_section_title: string
-    seller_section_body: string
-    seller_input_label: string
-    seller_input_placeholder: string
-    seller_submit: string
-    seller_preview_claim: string
-    seller_not_found: string
-    seller_already_active: string
-    seller_applicant_exists: string
-    seller_waitlist_fallback: string
-    seller_min_listings: string
-    seller_lookup_error: string
-    bottom_signoff: string
-  }
-  preview: HomepagePreview
+      step1_title: string;
+      step1_body: string;
+      step2_title: string;
+      step2_body: string;
+      step3_title: string;
+      step3_body: string;
+    };
+    preview_blurb: string;
+    preview_label: string;
+    store_character_title: string;
+    seller_section_title: string;
+    seller_section_body: string;
+    seller_input_label: string;
+    seller_input_placeholder: string;
+    seller_submit: string;
+    seller_preview_claim: string;
+    seller_not_found: string;
+    seller_already_active: string;
+    seller_applicant_exists: string;
+    seller_waitlist_fallback: string;
+    seller_min_listings: string;
+    seller_lookup_error: string;
+    bottom_signoff: string;
+  };
+  preview: HomepagePreview;
 }
 
-const easeOut = [0.25, 0.46, 0.45, 0.94] as const
+const easeOut = [0.25, 0.46, 0.45, 0.94] as const;
 
 const fadeUp: Variants = {
   hidden: { opacity: 0, y: 12 },
@@ -51,7 +51,7 @@ const fadeUp: Variants = {
     y: 0,
     transition: { duration: 0.5, ease: easeOut },
   },
-}
+};
 
 const fadeIn: Variants = {
   hidden: { opacity: 0 },
@@ -59,13 +59,76 @@ const fadeIn: Variants = {
     opacity: 1,
     transition: { duration: 0.4, ease: easeOut },
   },
+};
+
+// ── Feature card data ───────────────────────────────────────
+
+interface FeatureData {
+  title: string;
+  description: string;
 }
 
+const FEATURES: FeatureData[] = [
+  { title: "Milkcrate Picks", description: "Interesting finds from the whole collection." },
+  {
+    title: "Featured Crates",
+    description: "Spotlight new arrivals, randomized sub-genres, and hidden gems.",
+  },
+  { title: "Genre Bins", description: "Records organized by genre, just like a real shop." },
+  {
+    title: "Start a Pile",
+    description: "Collect records as you browse, then carry them over to Discogs.",
+  },
+];
+
+// ── Sub-components ───────────────────────────────────────────
+
+function FeatureCard({ title, description }: FeatureData) {
+  return (
+    <motion.div
+      variants={fadeIn}
+      className="flex flex-col items-center text-center gap-3 p-5 rounded-xl bg-mc-bg-raised border border-mc-border"
+    >
+      <h3 className="text-base font-semibold text-mc-text">{title}</h3>
+      <p className="text-sm text-mc-text-dim leading-relaxed">{description}</p>
+    </motion.div>
+  );
+}
+
+function StepCard({
+  number,
+  title,
+  description,
+}: {
+  number: number;
+  title: string;
+  description: string;
+}) {
+  return (
+    <motion.div variants={fadeUp} className="flex flex-col items-center text-center gap-3">
+      <div className="w-10 h-10 rounded-full bg-mc-accent text-mc-on-accent flex items-center justify-center font-bold text-sm">
+        {number}
+      </div>
+      <h3 className="text-sm font-semibold text-mc-text">{title}</h3>
+      <p className="text-xs text-mc-text-dim leading-relaxed max-w-[220px]">{description}</p>
+    </motion.div>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────
+
 export default function Home({ copy, preview }: Props) {
-  const hasPreview = preview.sections.length > 0
-  const picksSection = preview.sections.find((section) => section.key === "picks_wall")
-  const picksCrate = picksSection?.key === "picks_wall" ? picksSection.crate : undefined
-  const demoHref = hasPreview && preview.store_slug ? `/${preview.store_slug}` : "/philadelphiamusic"
+  const hasPreview = preview.sections.length > 0;
+  const picksSection = preview.sections.find((section) => section.key === "picks_wall");
+  const picksCrate = picksSection?.key === "picks_wall" ? picksSection.crate : undefined;
+  const demoHref =
+    hasPreview && preview.store_slug ? `/${preview.store_slug}` : "/philadelphiamusic";
+
+  const steps = [
+    { number: 1, title: copy.steps.step1_title, description: copy.steps.step1_body },
+    { number: 2, title: copy.steps.step2_title, description: copy.steps.step2_body },
+    { number: 3, title: copy.steps.step3_title, description: copy.steps.step3_body },
+  ];
 
   return (
     <MarketingLayout>
@@ -94,7 +157,10 @@ export default function Home({ copy, preview }: Props) {
         <motion.div variants={fadeUp}>
           <Link
             href={demoHref}
-            className={actionClassName({ size: "lg", className: "w-full text-center tracking-wide sm:w-auto" })}
+            className={actionClassName({
+              size: "lg",
+              className: "w-full text-center tracking-wide sm:w-auto",
+            })}
           >
             {copy.cta_demo}
           </Link>
@@ -141,14 +207,22 @@ export default function Home({ copy, preview }: Props) {
               {preview.store_slug ? (
                 <Link
                   href={`/${preview.store_slug}`}
-                  className={actionClassName({ variant: "ghost", size: "sm", className: "uppercase tracking-widest text-mc-accent" })}
+                  className={actionClassName({
+                    variant: "ghost",
+                    size: "sm",
+                    className: "uppercase tracking-widest text-mc-accent",
+                  })}
                 >
                   See the full store →
                 </Link>
               ) : (
                 <Link
                   href="/philadelphiamusic"
-                  className={actionClassName({ variant: "ghost", size: "sm", className: "uppercase tracking-widest text-mc-accent" })}
+                  className={actionClassName({
+                    variant: "ghost",
+                    size: "sm",
+                    className: "uppercase tracking-widest text-mc-accent",
+                  })}
                 >
                   See the full store →
                 </Link>
@@ -158,12 +232,16 @@ export default function Home({ copy, preview }: Props) {
         ) : (
           <div className="text-center max-w-md mx-auto">
             <p className="text-sm text-mc-text-dim mb-4">
-              We&apos;ll show the full Milkcrate experience in the demo store. Start with a
-              curated picks crate.
+              We&apos;ll show the full Milkcrate experience in the demo store. Start with a curated
+              picks crate.
             </p>
             <Link
               href="/philadelphiamusic"
-              className={actionClassName({ variant: "ghost", size: "sm", className: "uppercase tracking-widest text-mc-accent" })}
+              className={actionClassName({
+                variant: "ghost",
+                size: "sm",
+                className: "uppercase tracking-widest text-mc-accent",
+              })}
             >
               Philadelphia Music →
             </Link>
@@ -188,45 +266,13 @@ export default function Home({ copy, preview }: Props) {
         </motion.h2>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-4xl mx-auto">
-          <motion.div
-            variants={fadeIn}
-            className="flex flex-col items-center text-center gap-3 p-5 rounded-xl bg-mc-bg-raised border border-mc-border"
-          >
-            <h3 className="text-base font-semibold text-mc-text">Milkcrate Picks</h3>
-            <p className="text-sm text-mc-text-dim leading-relaxed">
-              Interesting finds from the whole collection.
-            </p>
-          </motion.div>
-
-          <motion.div
-            variants={fadeIn}
-            className="flex flex-col items-center text-center gap-3 p-5 rounded-xl bg-mc-bg-raised border border-mc-border"
-          >
-            <h3 className="text-base font-semibold text-mc-text">Featured Crates</h3>
-            <p className="text-sm text-mc-text-dim leading-relaxed">
-              Spotlight new arrivals, randomized sub-genres, and hidden gems.
-            </p>
-          </motion.div>
-
-          <motion.div
-            variants={fadeIn}
-            className="flex flex-col items-center text-center gap-3 p-5 rounded-xl bg-mc-bg-raised border border-mc-border"
-          >
-            <h3 className="text-base font-semibold text-mc-text">Genre Bins</h3>
-            <p className="text-sm text-mc-text-dim leading-relaxed">
-              Records organized by genre, just like a real shop.
-            </p>
-          </motion.div>
-
-          <motion.div
-            variants={fadeIn}
-            className="flex flex-col items-center text-center gap-3 p-5 rounded-xl bg-mc-bg-raised border border-mc-border"
-          >
-            <h3 className="text-base font-semibold text-mc-text">Start a Pile</h3>
-            <p className="text-sm text-mc-text-dim leading-relaxed">
-              Collect records as you browse, then carry them over to Discogs.
-            </p>
-          </motion.div>
+          {FEATURES.map((feature) => (
+            <FeatureCard
+              key={feature.title}
+              title={feature.title}
+              description={feature.description}
+            />
+          ))}
         </div>
       </motion.section>
 
@@ -268,14 +314,8 @@ export default function Home({ copy, preview }: Props) {
               }}
             />
           </motion.div>
-          <motion.div
-            variants={fadeUp}
-            className="text-center mt-4"
-          >
-            <Link
-              href="/apply"
-              className={actionClassName({ variant: "ghost", size: "sm" })}
-            >
+          <motion.div variants={fadeUp} className="text-center mt-4">
+            <Link href="/apply" className={actionClassName({ variant: "ghost", size: "sm" })}>
               {copy.seller_waitlist_fallback}
             </Link>
           </motion.div>
@@ -292,50 +332,14 @@ export default function Home({ copy, preview }: Props) {
       >
         <div className="max-w-4xl mx-auto">
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-8 sm:gap-10">
-            <motion.div
-              variants={fadeUp}
-              className="flex flex-col items-center text-center gap-3"
-            >
-              <div className="w-10 h-10 rounded-full bg-mc-accent text-mc-on-accent flex items-center justify-center font-bold text-sm">
-                1
-              </div>
-              <h3 className="text-sm font-semibold text-mc-text">
-                {copy.steps.step1_title}
-              </h3>
-              <p className="text-xs text-mc-text-dim leading-relaxed max-w-[220px]">
-                {copy.steps.step1_body}
-              </p>
-            </motion.div>
-
-            <motion.div
-              variants={fadeUp}
-              className="flex flex-col items-center text-center gap-3"
-            >
-              <div className="w-10 h-10 rounded-full bg-mc-accent text-mc-on-accent flex items-center justify-center font-bold text-sm">
-                2
-              </div>
-              <h3 className="text-sm font-semibold text-mc-text">
-                {copy.steps.step2_title}
-              </h3>
-              <p className="text-xs text-mc-text-dim leading-relaxed max-w-[220px]">
-                {copy.steps.step2_body}
-              </p>
-            </motion.div>
-
-            <motion.div
-              variants={fadeUp}
-              className="flex flex-col items-center text-center gap-3"
-            >
-              <div className="w-10 h-10 rounded-full bg-mc-accent text-mc-on-accent flex items-center justify-center font-bold text-sm">
-                3
-              </div>
-              <h3 className="text-sm font-semibold text-mc-text">
-                {copy.steps.step3_title}
-              </h3>
-              <p className="text-xs text-mc-text-dim leading-relaxed max-w-[220px]">
-                {copy.steps.step3_body}
-              </p>
-            </motion.div>
+            {steps.map((step) => (
+              <StepCard
+                key={step.number}
+                number={step.number}
+                title={step.title}
+                description={step.description}
+              />
+            ))}
           </div>
         </div>
       </motion.section>
@@ -348,14 +352,11 @@ export default function Home({ copy, preview }: Props) {
         className="border-t border-mc-border py-8 sm:py-10"
       >
         <div className="max-w-md mx-auto text-center">
-          <motion.p
-            variants={fadeUp}
-            className="text-sm text-mc-text-dim leading-relaxed"
-          >
+          <motion.p variants={fadeUp} className="text-sm text-mc-text-dim leading-relaxed">
             {copy.bottom_signoff}
           </motion.p>
         </div>
       </motion.section>
     </MarketingLayout>
-  )
+  );
 }

--- a/app/frontend/pages/stores/invitation.tsx
+++ b/app/frontend/pages/stores/invitation.tsx
@@ -3,6 +3,7 @@ import { Link } from "@inertiajs/react";
 import { motion } from "framer-motion";
 import MarketingLayout from "@/layouts/marketing_layout";
 import BrandMark from "@/components/brand_mark";
+import Spinner from "@/components/spinner";
 import Button from "@/components/ui/button";
 import FeedbackMessage from "@/components/ui/feedback_message";
 import { actionClassName } from "@/components/ui/action";
@@ -146,7 +147,7 @@ function InvitationLoading() {
       live="polite"
       className="flex flex-col items-center border-0 bg-transparent"
     >
-      <div className="w-8 h-8 mb-4 border-2 border-mc-accent border-t-transparent rounded-full motion-safe:animate-spin" />
+      <Spinner size="lg" className="mb-4" />
       <p>Checking if this URL is available...</p>
     </FeedbackMessage>
   );

--- a/app/frontend/pages/stores/invitation.tsx
+++ b/app/frontend/pages/stores/invitation.tsx
@@ -1,20 +1,14 @@
-import { useState, useEffect, useMemo } from "react"
-import { Link } from "@inertiajs/react"
-import { motion } from "framer-motion"
-import MarketingLayout from "@/layouts/marketing_layout"
-import BrandMark from "@/components/brand_mark"
-import Button from "@/components/ui/button"
-import FeedbackMessage from "@/components/ui/feedback_message"
-import { actionClassName } from "@/components/ui/action"
-import { springTactile } from "@/lib/motion_tokens"
-import type { InvitationProps } from "@/types/inertia"
-
-interface LookupResponse {
-  found: boolean
-  seller_name?: string
-  avatar_url?: string
-  reason?: string
-}
+import { useEffect, useMemo } from "react";
+import { Link } from "@inertiajs/react";
+import { motion } from "framer-motion";
+import MarketingLayout from "@/layouts/marketing_layout";
+import BrandMark from "@/components/brand_mark";
+import Button from "@/components/ui/button";
+import FeedbackMessage from "@/components/ui/feedback_message";
+import { actionClassName } from "@/components/ui/action";
+import { springTactile } from "@/lib/motion_tokens";
+import { useDiscogsLookup } from "@/hooks/use_discogs_lookup";
+import type { InvitationProps } from "@/types/inertia";
 
 export default function Invitation({ waitlist_present, slug, oauth_available }: InvitationProps) {
   // Waitlist acknowledgment — no probe, static page
@@ -44,8 +38,8 @@ export default function Invitation({ waitlist_present, slug, oauth_available }: 
             transition={{ delay: 0.2, duration: 0.3 }}
             className="text-sm text-mc-text-dim leading-relaxed max-w-sm"
           >
-            We'll notify the applicant when their storefront is ready. In the
-            meantime, feel free to explore other storefronts on Milkcrate.
+            We'll notify the applicant when their storefront is ready. In the meantime, feel free to
+            explore other storefronts on Milkcrate.
           </motion.p>
           <motion.div
             initial={{ opacity: 0, y: 8 }}
@@ -53,84 +47,71 @@ export default function Invitation({ waitlist_present, slug, oauth_available }: 
             transition={{ delay: 0.3, duration: 0.3 }}
             className="mt-8"
           >
-            <Link
-              href="/"
-              className={actionClassName({ size: "lg", className: "tracking-wide" })}
-            >
+            <Link href="/" className={actionClassName({ size: "lg", className: "tracking-wide" })}>
               Browse storefronts
             </Link>
           </motion.div>
         </div>
       </MarketingLayout>
-    )
+    );
   }
 
   // Invitation page — async Discogs probe
-  return <InvitationContent slug={slug} oauth_available={oauth_available} />
+  return <InvitationContent slug={slug} oauth_available={oauth_available} />;
 }
 
 function InvitationContent({ slug, oauth_available }: { slug: string; oauth_available?: boolean }) {
-  const [probeState, setProbeState] = useState<"loading" | "found" | "not_found">("loading")
-  const [sellerName, setSellerName] = useState<string | null>(null)
-  const csrfToken = document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content
+  const { state, lookup } = useDiscogsLookup();
+  const csrfToken = document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")?.content;
 
-  // Quality gate: only probe plausible Discogs usernames
   const shouldProbe = useMemo(() => {
-    if (slug.length < 3 || slug.length > 40) return false
-    if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$/.test(slug)) return false
-
+    if (slug.length < 3 || slug.length > 40) return false;
+    if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*[a-zA-Z0-9]$/.test(slug)) return false;
     const reserved = [
-      "admin", "apply", "jobs", "up", "assets", "404", "500", "health",
-      "login", "logout", "signup", "register",
-      "api", "docs", "status", "help", "support",
-      "favicon", "manifest", "service-worker",
-    ]
-    if (reserved.includes(slug.toLowerCase())) return false
-
-    return true
-  }, [slug])
+      "admin",
+      "apply",
+      "jobs",
+      "up",
+      "assets",
+      "404",
+      "500",
+      "health",
+      "login",
+      "logout",
+      "signup",
+      "register",
+      "api",
+      "docs",
+      "status",
+      "help",
+      "support",
+      "favicon",
+      "manifest",
+      "service-worker",
+    ];
+    return !reserved.includes(slug.toLowerCase());
+  }, [slug]);
 
   useEffect(() => {
-    // Reset stale state from previous slug
-    setProbeState("loading")
-    setSellerName(null)
+    if (shouldProbe) lookup(slug);
+  }, [slug, shouldProbe, lookup]);
 
-    if (!shouldProbe) {
-      setProbeState("not_found")
-      return
-    }
+  const displayStatus: "loading" | "found" | "not_found" = !shouldProbe
+    ? "not_found"
+    : state.status === "loading" || state.status === "idle"
+      ? "loading"
+      : state.status === "preview" ||
+          state.status === "error_active_store" ||
+          state.status === "error_applicant"
+        ? "found"
+        : "not_found";
 
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000)
-
-    fetch(`/api/discogs/lookup/${encodeURIComponent(slug)}`, { signal: controller.signal })
-      .then((res) => {
-        if (!res.ok) {
-          setProbeState("not_found")
-          return
-        }
-        return res.json() as Promise<LookupResponse>
-      })
-      .then((data) => {
-        if (!data) return
-        if (data.found) {
-          setSellerName(data.seller_name || slug)
-          setProbeState("found")
-        } else {
-          setProbeState("not_found")
-        }
-      })
-      .catch((err) => {
-        if (err instanceof DOMException && err.name === "AbortError") return
-        setProbeState("not_found")
-      })
-      .finally(() => clearTimeout(timeoutId))
-
-    return () => {
-      controller.abort()
-      clearTimeout(timeoutId)
-    }
-  }, [slug, shouldProbe])
+  const sellerName =
+    state.status === "preview" ||
+    state.status === "error_active_store" ||
+    state.status === "error_applicant"
+      ? state.result.seller_name || slug
+      : null;
 
   return (
     <MarketingLayout>
@@ -143,113 +124,137 @@ function InvitationContent({ slug, oauth_available }: { slug: string; oauth_avai
         >
           <BrandMark size="large" />
         </motion.div>
-
-        {/* Loading state */}
-        {probeState === "loading" && (
-          <FeedbackMessage tone="progress" live="polite" className="flex flex-col items-center border-0 bg-transparent">
-            <div className="w-8 h-8 mb-4 border-2 border-mc-accent border-t-transparent rounded-full motion-safe:animate-spin" />
-            <p>Checking if this URL is available...</p>
-          </FeedbackMessage>
+        {displayStatus === "loading" && <InvitationLoading />}
+        {displayStatus === "found" && (
+          <InvitationFound
+            slug={slug}
+            oauth_available={oauth_available}
+            sellerName={sellerName}
+            csrfToken={csrfToken}
+          />
         )}
-
-        {/* Seller found — personalized invitation */}
-        {probeState === "found" && (
-          <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-            className="w-full"
-          >
-            <motion.h1
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.3 }}
-              className="text-2xl font-bold text-mc-text mb-3"
-            >
-              We found <span className="text-mc-accent">{sellerName}</span> on Discogs
-            </motion.h1>
-            <motion.p
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2, duration: 0.3 }}
-              className="text-sm text-mc-text-dim leading-relaxed max-w-sm mx-auto mb-8"
-            >
-              This URL could be your storefront. Claim it to show your Discogs
-              inventory as a browsable, curated record store.
-            </motion.p>
-            <motion.div
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3, duration: 0.3 }}
-              className="space-y-3"
-            >
-              {oauth_available ? (
-                <form action={`/${slug}/authorize`} method="POST" className="inline">
-                  {csrfToken && <input type="hidden" name="authenticity_token" value={csrfToken} />}
-                  <Button type="submit" size="lg" className="tracking-wide">
-                    Claim with Discogs
-                  </Button>
-                </form>
-              ) : (
-                <Link
-                  href={`/apply?discogs_username=${encodeURIComponent(slug)}`}
-                  className={actionClassName({ size: "lg", className: "tracking-wide" })}
-                >
-                  Claim this storefront
-                </Link>
-              )}
-              <div>
-                <Link
-                  href={`/apply?discogs_username=${encodeURIComponent(slug)}`}
-                  className="text-xs text-mc-text-dim hover:text-mc-accent transition-colors"
-                >
-                  Or apply via waitlist
-                </Link>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-
-        {/* Not found — generic invitation */}
-        {probeState === "not_found" && (
-          <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.3 }}
-            className="w-full"
-          >
-            <motion.h1
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.1, duration: 0.3 }}
-              className="text-2xl font-bold text-mc-text mb-3"
-            >
-              This page is available
-            </motion.h1>
-            <motion.p
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2, duration: 0.3 }}
-              className="text-sm text-mc-text-dim leading-relaxed max-w-sm mx-auto mb-8"
-            >
-              If you sell records on Discogs, you can turn this URL into your
-              own browsable storefront on Milkcrate.
-            </motion.p>
-            <motion.div
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.3, duration: 0.3 }}
-            >
-                <Link
-                  href="/apply"
-                  className={actionClassName({ size: "lg", className: "tracking-wide" })}
-              >
-                Apply to join
-              </Link>
-            </motion.div>
-          </motion.div>
-        )}
+        {displayStatus === "not_found" && <InvitationNoMatch />}
       </div>
     </MarketingLayout>
-  )
+  );
+}
+
+function InvitationLoading() {
+  return (
+    <FeedbackMessage
+      tone="progress"
+      live="polite"
+      className="flex flex-col items-center border-0 bg-transparent"
+    >
+      <div className="w-8 h-8 mb-4 border-2 border-mc-accent border-t-transparent rounded-full motion-safe:animate-spin" />
+      <p>Checking if this URL is available...</p>
+    </FeedbackMessage>
+  );
+}
+
+function InvitationFound({
+  slug,
+  oauth_available,
+  sellerName,
+  csrfToken,
+}: {
+  slug: string;
+  oauth_available?: boolean;
+  sellerName: string | null;
+  csrfToken: string | undefined;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="w-full"
+    >
+      <motion.h1
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1, duration: 0.3 }}
+        className="text-2xl font-bold text-mc-text mb-3"
+      >
+        We found <span className="text-mc-accent">{sellerName}</span> on Discogs
+      </motion.h1>
+      <motion.p
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.3 }}
+        className="text-sm text-mc-text-dim leading-relaxed max-w-sm mx-auto mb-8"
+      >
+        This URL could be your storefront. Claim it to show your Discogs inventory as a browsable,
+        curated record store.
+      </motion.p>
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3, duration: 0.3 }}
+        className="space-y-3"
+      >
+        {oauth_available ? (
+          <form action={`/${slug}/authorize`} method="POST" className="inline">
+            {csrfToken && <input type="hidden" name="authenticity_token" value={csrfToken} />}
+            <Button type="submit" size="lg" className="tracking-wide">
+              Claim with Discogs
+            </Button>
+          </form>
+        ) : (
+          <Link
+            href={`/apply?discogs_username=${encodeURIComponent(slug)}`}
+            className={actionClassName({ size: "lg", className: "tracking-wide" })}
+          >
+            Claim this storefront
+          </Link>
+        )}
+        <div>
+          <Link
+            href={`/apply?discogs_username=${encodeURIComponent(slug)}`}
+            className="text-xs text-mc-text-dim hover:text-mc-accent transition-colors"
+          >
+            Or apply via waitlist
+          </Link>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function InvitationNoMatch() {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="w-full"
+    >
+      <motion.h1
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1, duration: 0.3 }}
+        className="text-2xl font-bold text-mc-text mb-3"
+      >
+        This page is available
+      </motion.h1>
+      <motion.p
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.3 }}
+        className="text-sm text-mc-text-dim leading-relaxed max-w-sm mx-auto mb-8"
+      >
+        If you sell records on Discogs, you can turn this URL into your own browsable storefront on
+        Milkcrate.
+      </motion.p>
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3, duration: 0.3 }}
+      >
+        <Link href="/apply" className={actionClassName({ size: "lg", className: "tracking-wide" })}>
+          Apply to join
+        </Link>
+      </motion.div>
+    </motion.div>
+  );
 }

--- a/app/frontend/pages/stores/show.tsx
+++ b/app/frontend/pages/stores/show.tsx
@@ -1,58 +1,17 @@
-import { useState, useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import AppLayout from "@/layouts/app_layout";
 import CrateView from "@/components/crate_view";
 import StoreFloor from "@/components/store_floor";
+import Spinner from "@/components/spinner";
 import FeedbackMessage from "@/components/ui/feedback_message";
+import { useCrateRouting } from "@/hooks/use_crate_routing";
 import type { StoreShowProps } from "@/types/inertia";
 
 export default function StoreShow({ store, crates, storefront_sections }: StoreShowProps) {
-  const [activeSlug, setActiveSlug] = useState<string | null>(() => {
-    const fromParam =
-      typeof window !== "undefined"
-        ? new URLSearchParams(window.location.search).get("crate")
-        : null;
-    if (fromParam) return fromParam;
-
-    const raw = history.state?.crateSlug;
-    return typeof raw === "string" && raw.length > 0 ? raw : null;
+  const { activeSlug, activeCrate, startIndex, selectCrate, allCrates } = useCrateRouting({
+    crates,
+    storefront_sections: storefront_sections ?? [],
   });
-  const [startIndex, setStartIndex] = useState(() => {
-    const raw = history.state?.startIndex;
-    return Number.isFinite(raw) && (raw as number) >= 0 ? (raw as number) : 0;
-  });
-
-  const allCrates = useMemo(() => {
-    if (crates.length > 0) return crates;
-    if (!storefront_sections?.length) return [];
-    return storefront_sections.flatMap((s) => ("crate" in s ? [s.crate] : s.crates));
-  }, [crates, storefront_sections]);
-  const activeCrate =
-    activeSlug === null
-      ? null
-      : (allCrates.find((crate) => crate.slug === activeSlug) ?? allCrates[0]);
-
-  const handleSelectCrate = (slug: string, index = 0) => {
-    setStartIndex(index);
-    setActiveSlug(slug);
-    // Push on first entry; replace on subsequent switches so back
-    // always returns to the store floor regardless of browsing depth.
-    if (activeSlug === null) {
-      history.pushState({ crateSlug: slug, startIndex: index }, "");
-    } else {
-      history.replaceState({ crateSlug: slug, startIndex: index }, "");
-    }
-  };
-
-  useEffect(() => {
-    const handlePop = (e: PopStateEvent) => {
-      const slug = e.state?.crateSlug ?? null;
-      setActiveSlug(slug);
-      setStartIndex(e.state?.startIndex ?? 0);
-    };
-    window.addEventListener("popstate", handlePop);
-    return () => window.removeEventListener("popstate", handlePop);
-  }, []);
 
   return (
     <AppLayout
@@ -104,27 +63,7 @@ export default function StoreShow({ store, crates, storefront_sections }: StoreS
           live="polite"
           className="border-0 bg-transparent py-16 text-center"
         >
-          <svg
-            className="motion-safe:animate-spin h-8 w-8 mx-auto mb-4 text-mc-accent"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            />
-          </svg>
+          <Spinner size="lg" className="mx-auto mb-4" />
           <p className="text-sm">
             {store.sync_status === "syncing"
               ? "Syncing inventory… check back in a moment."
@@ -141,14 +80,14 @@ export default function StoreShow({ store, crates, storefront_sections }: StoreS
           </p>
         </div>
       ) : activeSlug === null ? (
-        <StoreFloor sections={storefront_sections ?? []} onSelectCrate={handleSelectCrate} />
+        <StoreFloor sections={storefront_sections ?? []} onSelectCrate={selectCrate} />
       ) : (
         <CrateView
           crates={allCrates}
           activeSlug={activeSlug}
           startIndex={startIndex}
           compactHeaderOwnedByLayout
-          onSelectCrate={handleSelectCrate}
+          onSelectCrate={selectCrate}
           onBack={() => history.back()}
         />
       )}

--- a/app/frontend/pages/stores/show.tsx
+++ b/app/frontend/pages/stores/show.tsx
@@ -12,6 +12,8 @@ export default function StoreShow({ store, crates, storefront_sections }: StoreS
     crates,
     storefront_sections: storefront_sections ?? [],
   });
+  const listingCount = store.total_listings ?? 0;
+  const hasStoreSummary = Boolean(store.description) || listingCount > 0;
 
   return (
     <AppLayout
@@ -25,7 +27,7 @@ export default function StoreShow({ store, crates, storefront_sections }: StoreS
           : undefined
       }
     >
-      {activeSlug === null && (store.description || store.total_listings) && (
+      {activeSlug === null && hasStoreSummary ? (
         <motion.div
           initial={{ opacity: 0, y: -6 }}
           animate={{ opacity: 1, y: 0 }}
@@ -35,13 +37,13 @@ export default function StoreShow({ store, crates, storefront_sections }: StoreS
           {store.description && (
             <p className="text-sm text-mc-text leading-relaxed max-w-prose">{store.description}</p>
           )}
-          {store.total_listings && (
+          {listingCount > 0 ? (
             <p className="text-xs text-mc-text-dim mt-1.5">
-              {store.total_listings.toLocaleString()} vinyl listings
+              {listingCount.toLocaleString()} vinyl listings
             </p>
-          )}
+          ) : null}
         </motion.div>
-      )}
+      ) : null}
 
       {store.sync_status === "failed" && (
         <FeedbackMessage tone="danger" live="assertive" className="mb-6 px-4 py-3">

--- a/app/frontend/pages/stores/show.tsx
+++ b/app/frontend/pages/stores/show.tsx
@@ -8,7 +8,7 @@ import { useCrateRouting } from "@/hooks/use_crate_routing";
 import type { StoreShowProps } from "@/types/inertia";
 
 export default function StoreShow({ store, crates, storefront_sections }: StoreShowProps) {
-  const { activeSlug, activeCrate, startIndex, selectCrate, allCrates } = useCrateRouting({
+  const { activeSlug, activeCrate, startIndex, selectCrate, backToStore, allCrates } = useCrateRouting({
     crates,
     storefront_sections: storefront_sections ?? [],
   });
@@ -20,7 +20,7 @@ export default function StoreShow({ store, crates, storefront_sections }: StoreS
           ? {
               name: activeCrate.name,
               count: activeCrate.records.length,
-              onBack: () => history.back(),
+              onBack: backToStore,
             }
           : undefined
       }
@@ -88,7 +88,7 @@ export default function StoreShow({ store, crates, storefront_sections }: StoreS
           startIndex={startIndex}
           compactHeaderOwnedByLayout
           onSelectCrate={selectCrate}
-          onBack={() => history.back()}
+          onBack={backToStore}
         />
       )}
     </AppLayout>

--- a/app/frontend/test/pages/admin_dashboard.test.tsx
+++ b/app/frontend/test/pages/admin_dashboard.test.tsx
@@ -1,10 +1,10 @@
-import React from "react"
-import { afterEach, describe, expect, it, vi } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import { renderWithTier } from "@/test/viewport-test-utils"
-import Dashboard from "@/pages/admin/dashboard"
-import type { AdminDashboardProps } from "@/types/inertia"
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithTier } from "@/test/viewport-test-utils";
+import Dashboard from "@/pages/admin/dashboard";
+import type { AdminDashboardProps } from "@/types/inertia";
 
 const props: AdminDashboardProps = {
   discogs_onboarding: {
@@ -90,79 +90,100 @@ const props: AdminDashboardProps = {
       submitted_at: "2026-05-15T12:00:00Z",
     },
   ],
-}
+};
 
 describe("Admin dashboard", () => {
   afterEach(() => {
-    vi.unstubAllGlobals()
-  })
+    vi.unstubAllGlobals();
+  });
 
   it("renders active stores before applicants", () => {
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
     expect(document.body.textContent?.indexOf("Active stores")).toBeLessThan(
-      document.body.textContent?.indexOf("Applicants") ?? 0
-    )
-  })
+      document.body.textContent?.indexOf("Applicants") ?? 0,
+    );
+  });
 
   it("renders distinct store health states and metadata", () => {
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    expect(screen.getByText("Healthy Records")).toBeInTheDocument()
-    expect(screen.getAllByText("Healthy").length).toBeGreaterThan(0)
-    expect(screen.getByText("Processing Vinyl")).toBeInTheDocument()
-    expect(screen.getAllByText("Processing").length).toBeGreaterThan(0)
-    expect(screen.getByText("Broken Beats")).toBeInTheDocument()
-    expect(screen.getByText("Needs attention")).toBeInTheDocument()
-    expect(screen.getByText("300 listings")).toBeInTheDocument()
-    expect(screen.getByText("RuntimeError: Discogs timeout")).toBeInTheDocument()
-  })
+    expect(screen.getByText("Healthy Records")).toBeInTheDocument();
+    expect(screen.getAllByText("Healthy").length).toBeGreaterThan(0);
+    expect(screen.getByText("Processing Vinyl")).toBeInTheDocument();
+    expect(screen.getAllByText("Processing").length).toBeGreaterThan(0);
+    expect(screen.getByText("Broken Beats")).toBeInTheDocument();
+    expect(screen.getByText("Needs attention")).toBeInTheDocument();
+    expect(screen.getByText("300 listings")).toBeInTheDocument();
+    expect(screen.getByText("RuntimeError: Discogs timeout")).toBeInTheDocument();
+  });
 
   it("renders applicant details and onboard action", () => {
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    expect(screen.getByText("Applicant Records")).toBeInTheDocument()
-    expect(screen.getByText("applicant@example.com")).toBeInTheDocument()
-    expect(screen.getByText("@applicant-records")).toBeInTheDocument()
-    expect(screen.getByText("Strong jazz inventory and used LPs.")).toBeInTheDocument()
-    const onboardButton = screen.getByRole("button", { name: "Onboard store" })
-    expect(onboardButton).toBeInTheDocument()
-    expect(onboardButton.closest("form")).toHaveAttribute("action", "/admin/waitlists/10/onboarding")
-  })
+    expect(screen.getByText("Applicant Records")).toBeInTheDocument();
+    expect(screen.getByText("applicant@example.com")).toBeInTheDocument();
+    expect(screen.getByText("@applicant-records")).toBeInTheDocument();
+    expect(screen.getByText("Strong jazz inventory and used LPs.")).toBeInTheDocument();
+    const onboardButton = screen.getByRole("button", { name: "Onboard store" });
+    expect(onboardButton).toBeInTheDocument();
+    expect(onboardButton.closest("form")).toHaveAttribute(
+      "action",
+      "/admin/waitlists/10/onboarding",
+    );
+  });
 
   it("renders useful empty states", () => {
-    render(<Dashboard {...props} active_stores={[]} applicants={[]} />)
+    render(<Dashboard {...props} active_stores={[]} applicants={[]} />);
 
-    expect(screen.getByText("No stores online yet.")).toBeInTheDocument()
-    expect(screen.getByText("No applicants waiting.")).toBeInTheDocument()
-  })
+    expect(screen.getByText("No stores online yet.")).toBeInTheDocument();
+    expect(screen.getByText("No applicants waiting.")).toBeInTheDocument();
+  });
 
   it("renders admin flash notices and alerts", () => {
-    render(<Dashboard {...props} active_stores={[]} applicants={[]} notice="Onboarding queued" alert="Store already exists" />)
+    render(
+      <Dashboard
+        {...props}
+        active_stores={[]}
+        applicants={[]}
+        notice="Onboarding queued"
+        alert="Store already exists"
+      />,
+    );
 
-    expect(screen.getByText("Onboarding queued").closest("[role='status']")).toHaveClass("text-mc-feedback-success")
-    expect(screen.getByText("Store already exists").closest("[role='alert']")).toHaveClass("text-mc-feedback-danger")
-  })
+    expect(screen.getByText("Onboarding queued").closest("[role='status']")).toHaveClass(
+      "text-mc-feedback-success",
+    );
+    expect(screen.getByText("Store already exists").closest("[role='alert']")).toHaveClass(
+      "text-mc-feedback-danger",
+    );
+  });
 
   it("uses shared shell landmarks for operational presentation", () => {
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    expect(screen.getAllByRole("main")).toHaveLength(1)
-    expect(screen.getByText("Skip to content")).toHaveAttribute("href", "#main-content")
-    expect(screen.getByRole("heading", { name: "Active stores" })).toHaveAttribute("id", "active-stores-heading")
-    expect(screen.getByRole("heading", { name: "Applicants" })).toHaveAttribute("id", "applicants-heading")
-  })
+    expect(screen.getAllByRole("main")).toHaveLength(1);
+    expect(screen.getByText("Skip to content")).toHaveAttribute("href", "#main-content");
+    expect(screen.getByRole("heading", { name: "Active stores" })).toHaveAttribute(
+      "id",
+      "active-stores-heading",
+    );
+    expect(screen.getByRole("heading", { name: "Applicants" })).toHaveAttribute(
+      "id",
+      "applicants-heading",
+    );
+  });
 
   it("renders the admin-created storefront lookup panel", () => {
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    expect(screen.getByRole("heading", { name: "Add Discogs storefront" })).toBeInTheDocument()
-    expect(screen.getByLabelText("Discogs username")).toHaveClass("focus:border-mc-focus")
-    expect(screen.getByRole("button", { name: "Lookup" })).toBeInTheDocument()
-  })
+    expect(screen.getByRole("heading", { name: "Add Discogs storefront" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Discogs username")).toHaveClass("focus:border-mc-focus");
+    expect(screen.getByRole("button", { name: "Lookup" })).toBeInTheDocument();
+  });
 
   it("renders a creatable lookup preview with a separate confirmation form", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -172,140 +193,171 @@ describe("Admin dashboard", () => {
         seller_name: "Real Seller",
         avatar_url: "https://example.com/avatar.jpg",
       }),
-    })
-    vi.stubGlobal("fetch", fetchMock)
+    });
+    vi.stubGlobal("fetch", fetchMock);
 
-    const { container } = render(<Dashboard {...props} />)
+    const { container } = render(<Dashboard {...props} />);
 
-    await user.type(screen.getByLabelText("Discogs username"), "RealSeller")
-    await user.click(screen.getByRole("button", { name: "Lookup" }))
+    await user.type(screen.getByLabelText("Discogs username"), "RealSeller");
+    await user.click(screen.getByRole("button", { name: "Lookup" }));
 
-    expect(await screen.findByText("Real Seller")).toBeInTheDocument()
-    expect(screen.getByText("@realseller")).toBeInTheDocument()
-    expect(container.querySelector("img")).toHaveAttribute("src", "https://example.com/avatar.jpg")
+    expect(await screen.findByText("Real Seller")).toBeInTheDocument();
+    expect(screen.getByText("@realseller")).toBeInTheDocument();
+    expect(container.querySelector("img")).toHaveAttribute("src", "https://example.com/avatar.jpg");
 
-    const confirmButton = screen.getByRole("button", { name: "Onboard storefront" })
-    const confirmForm = confirmButton.closest("form")
-    expect(confirmForm).toHaveAttribute("action", "/admin/onboarding")
-    expect(confirmForm?.querySelector("input[name='discogs_username']")).toHaveAttribute("value", "realseller")
-    expect(fetchMock).toHaveBeenCalledWith("http://localhost:3000/admin/discogs_lookup?username=RealSeller", {
-      headers: { Accept: "application/json" },
-    })
-  })
+    const confirmButton = screen.getByRole("button", { name: "Onboard storefront" });
+    const confirmForm = confirmButton.closest("form");
+    expect(confirmForm).toHaveAttribute("action", "/admin/onboarding");
+    expect(confirmForm?.querySelector("input[name='discogs_username']")).toHaveAttribute(
+      "value",
+      "realseller",
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3000/admin/discogs_lookup?username=RealSeller",
+      expect.objectContaining({ headers: { Accept: "application/json" } }),
+    );
+  });
 
   it("does not render confirmation for invalid lookup state", async () => {
-    const user = userEvent.setup()
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ status: "invalid", creatable: false, reason: "invalid_slug" }),
-    }))
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: "invalid", creatable: false, reason: "invalid_slug" }),
+      }),
+    );
 
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    await user.type(screen.getByLabelText("Discogs username"), "ab")
-    await user.click(screen.getByRole("button", { name: "Lookup" }))
+    await user.type(screen.getByLabelText("Discogs username"), "ab");
+    await user.click(screen.getByRole("button", { name: "Lookup" }));
 
-    expect(await screen.findByText("Enter a valid Discogs username before creating a storefront.")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
-  })
+    expect(
+      await screen.findByText("Enter a valid Discogs username before creating a storefront."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument();
+  });
 
   it("does not render confirmation for lookup errors", async () => {
-    const user = userEvent.setup()
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ status: "lookup_error", creatable: false, reason: "api_error" }),
-    }))
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: "lookup_error", creatable: false, reason: "api_error" }),
+      }),
+    );
 
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    await user.type(screen.getByLabelText("Discogs username"), "broken-store")
-    await user.click(screen.getByRole("button", { name: "Lookup" }))
+    await user.type(screen.getByLabelText("Discogs username"), "broken-store");
+    await user.click(screen.getByRole("button", { name: "Lookup" }));
 
-    expect(await screen.findByText("Discogs could not verify this seller right now. No storefront can be created from this lookup.")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
-  })
+    expect(
+      await screen.findByText(
+        "Discogs could not verify this seller right now. No storefront can be created from this lookup.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument();
+  });
 
   it("blocks confirmation when lookup finds an active store", async () => {
-    const user = userEvent.setup()
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        status: "already_active",
-        creatable: false,
-        username: "healthy-records",
-        store: { id: 1, name: "Healthy Records", discogs_username: "healthy-records" },
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: "already_active",
+          creatable: false,
+          username: "healthy-records",
+          store: { id: 1, name: "Healthy Records", discogs_username: "healthy-records" },
+        }),
       }),
-    }))
+    );
 
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    await user.type(screen.getByLabelText("Discogs username"), "healthy-records")
-    await user.click(screen.getByRole("button", { name: "Lookup" }))
+    await user.type(screen.getByLabelText("Discogs username"), "healthy-records");
+    await user.click(screen.getByRole("button", { name: "Lookup" }));
 
-    expect(await screen.findByText("Healthy Records is already active as @healthy-records.")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
-  })
+    expect(
+      await screen.findByText("Healthy Records is already active as @healthy-records."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument();
+  });
 
   it("blocks confirmation when lookup finds an applicant", async () => {
-    const user = userEvent.setup()
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        status: "existing_applicant",
-        creatable: false,
-        username: "applicant-records",
-        applicant: { id: 10, name: "Applicant Records", discogs_username: "applicant-records" },
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: "existing_applicant",
+          creatable: false,
+          username: "applicant-records",
+          applicant: { id: 10, name: "Applicant Records", discogs_username: "applicant-records" },
+        }),
       }),
-    }))
+    );
 
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    await user.type(screen.getByLabelText("Discogs username"), "applicant-records")
-    await user.click(screen.getByRole("button", { name: "Lookup" }))
+    await user.type(screen.getByLabelText("Discogs username"), "applicant-records");
+    await user.click(screen.getByRole("button", { name: "Lookup" }));
 
-    expect(await screen.findByText("Applicant Records already applied as @applicant-records. Use the applicant onboarding path.")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
-  })
+    expect(
+      await screen.findByText(
+        "Applicant Records already applied as @applicant-records. Use the applicant onboarding path.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument();
+  });
 
   it("clears stale preview when the username changes", async () => {
-    const user = userEvent.setup()
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        status: "creatable",
-        creatable: true,
-        username: "realseller",
-        seller_name: "Real Seller",
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          status: "creatable",
+          creatable: true,
+          username: "realseller",
+          seller_name: "Real Seller",
+        }),
       }),
-    }))
+    );
 
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    await user.type(screen.getByLabelText("Discogs username"), "realseller")
-    await user.click(screen.getByRole("button", { name: "Lookup" }))
-    expect(await screen.findByText("Real Seller")).toBeInTheDocument()
+    await user.type(screen.getByLabelText("Discogs username"), "realseller");
+    await user.click(screen.getByRole("button", { name: "Lookup" }));
+    expect(await screen.findByText("Real Seller")).toBeInTheDocument();
 
-    await user.type(screen.getByLabelText("Discogs username"), "-changed")
+    await user.type(screen.getByLabelText("Discogs username"), "-changed");
 
     await waitFor(() => {
-      expect(screen.queryByText("Real Seller")).not.toBeInTheDocument()
-    })
-    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
-  })
+      expect(screen.queryByText("Real Seller")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument();
+  });
 
   it("ignores stale lookup responses after the username changes", async () => {
-    const user = userEvent.setup()
-    let resolveLookup: (value: { ok: boolean; json: () => Promise<unknown> }) => void = () => {}
+    const user = userEvent.setup();
+    let resolveLookup: (value: { ok: boolean; json: () => Promise<unknown> }) => void = () => {};
     const pendingLookup = new Promise<{ ok: boolean; json: () => Promise<unknown> }>((resolve) => {
-      resolveLookup = resolve
-    })
-    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pendingLookup))
+      resolveLookup = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pendingLookup));
 
-    render(<Dashboard {...props} />)
+    render(<Dashboard {...props} />);
 
-    await user.type(screen.getByLabelText("Discogs username"), "realseller")
-    await user.click(screen.getByRole("button", { name: "Lookup" }))
-    await user.type(screen.getByLabelText("Discogs username"), "-changed")
+    await user.type(screen.getByLabelText("Discogs username"), "realseller");
+    await user.click(screen.getByRole("button", { name: "Lookup" }));
+    await user.type(screen.getByLabelText("Discogs username"), "-changed");
 
     resolveLookup({
       ok: true,
@@ -315,24 +367,24 @@ describe("Admin dashboard", () => {
         username: "realseller",
         seller_name: "Real Seller",
       }),
-    })
+    });
 
     await waitFor(() => {
-      expect(screen.queryByText("Real Seller")).not.toBeInTheDocument()
-    })
-    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument()
-  })
+      expect(screen.queryByText("Real Seller")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "Onboard storefront" })).not.toBeInTheDocument();
+  });
 
   it("renders the same operational content on compact and wide tiers", () => {
     for (const tier of ["compact", "wide"] as const) {
-      const { unmount } = renderWithTier(tier, <Dashboard {...props} />)
+      const { unmount } = renderWithTier(tier, <Dashboard {...props} />);
 
-      expect(screen.getByText("Healthy Records")).toBeInTheDocument()
-      expect(screen.getByRole("heading", { name: "Add Discogs storefront" })).toBeInTheDocument()
-      expect(screen.getByText("Applicant Records")).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Onboard store" })).toBeInTheDocument()
+      expect(screen.getByText("Healthy Records")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Add Discogs storefront" })).toBeInTheDocument();
+      expect(screen.getByText("Applicant Records")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Onboard store" })).toBeInTheDocument();
 
-      unmount()
+      unmount();
     }
-  })
-})
+  });
+});

--- a/app/frontend/test/pages/page_smoke.test.tsx
+++ b/app/frontend/test/pages/page_smoke.test.tsx
@@ -181,6 +181,17 @@ describe("page smoke tests", () => {
     expect(screen.getByText(/No vinyl found yet/)).toBeInTheDocument()
   })
 
+  it("does not render zero listing count as stray text", () => {
+    render(
+      <StoreShow
+        {...storeShowProps}
+        store={{ ...storeShowProps.store, description: null, total_listings: 0 }}
+      />,
+    )
+
+    expect(screen.queryByText("0")).not.toBeInTheDocument()
+  })
+
   it("renders the admin dashboard", () => {
     render(<Dashboard {...adminProps} />)
 

--- a/docs/plans/2026-05-27-001-refactor-frontend-sandi-metz-js-plan.md
+++ b/docs/plans/2026-05-27-001-refactor-frontend-sandi-metz-js-plan.md
@@ -1,0 +1,536 @@
+---
+title: "refactor: Apply Sandi Metz JS rules to frontend components"
+type: refactor
+status: active
+date: 2026-05-27
+---
+
+# refactor: Apply Sandi Metz JS Rules to Frontend Components
+
+## Summary
+
+Decompose oversized React components, extract shared hooks, and add shared UI primitives to bring the frontend into compliance with Sandi Metz rules adapted for JS/React. 26 findings from a `sandi-metz-js-review` audit covering component size, JSX return length, prop count, abstraction-level mixing, hook complexity, and missing abstractions.
+
+---
+
+## Problem Frame
+
+A `sandi-metz-js-review` audit found 26 violations across the frontend: 10 components over 100 lines (CrateView at 452, PileSheet at 457), 5 JSX returns over 15 lines, 2 components with 5+ props, 4 components mixing fetch + render, a 178-line hook managing 4 concerns, and repeated inline patterns (spinner SVG, back button, TOTP input) with no shared abstraction. The codebase already has well-factored examples — RecordTile (57 lines), MilkcrateShell (60 lines) — but the larger components accreted complexity across many feature PRs without decomposition.
+
+---
+
+## Requirements
+
+- R1. All components ≤ 100 lines (Sandi Metz Rule 1 for JS)
+- R2. All JSX return blocks ≤ 15 lines (Sandi Metz Rule 2 for JS)
+- R3. All component props ≤ 4 (Sandi Metz Rule 3 for JS)
+- R4. No component mixes fetch + render or state + layout (Sandi Metz Rule 4 for JS)
+- R5. All custom hooks ≤ 20 lines (Sandi Metz Rule 5 for JS)
+- R6. No repeated inline patterns — shared primitives for BackButton, Spinner, TotpCodeInput
+- R7. All existing test suites pass with no behavioral regressions
+- R8. Obsolete structural tests are pruned; behavior tests are preserved
+
+---
+
+## Scope Boundaries
+
+- Backend code is out of scope — frontend-only
+- CSS/styling changes are out of scope
+- New features are out of scope
+- Type definition changes are out of scope (types/inertia.ts stays as-is)
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **RecordTile** (`components/record_tile.tsx`, 57 lines) — gold standard for single-responsibility component
+- **MilkcrateShell** (`layouts/milkcrate_shell.tsx`, 60 lines) — slot/children composition pattern
+- **BrandMark** (`components/brand_mark.tsx`, 36 lines) — variant-driven via prop, minimal state
+- **CrateCard** (`components/crate_card.tsx`, 47 lines) — thin composition wrapper
+- **CrateTabs** (`components/crate_tabs.tsx`, 68 lines) — single responsibility, data via props
+- **Button** (`components/ui/button.tsx`, 30 lines) — variant/size prop pattern
+- **Token library** (`lib/motion_tokens.ts`) — single source of truth for animation constants
+- **Motion config** (`components/storefront_motion_config.tsx`) — provider + context + hook pattern
+
+### Institutional Learnings
+
+- **Guard-parity audit**: After splitting render paths, audit every branch for guard-condition parity. A prior refactor dropped a guard from the desktop path while carrying it on compact. Run the 4-step checklist on every decomposed component. (`docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`)
+- **Provider + Context + Hook**: Three-layer pattern for shared hooks. Use `describe.each` + context injection for test coverage instead of mocking browser APIs. (`docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`)
+- **Four-layer architecture**: Tokens → Provider → Hook → Wrappers. Name by perceptual quality, not number (`springTactile`, not `spring-0.3`). (`docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`)
+- **Keep extracted internals private**: Sub-components and hooks that are implementation details should stay module-private. Retire structural tests after refactor stabilizes; keep behavior tests. (`docs/solutions/best-practices/sandi-metz-refactor-helpers-stay-private-and-behavior-specs.md`)
+- **Responsive ternary inversion**: When inverting boolean abstractions (`isDesktop` → `isCompact`), audit every ternary at every call site. (`docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`)
+
+### Project Conventions
+
+- **Flat component directory** — no subdirectories for component groups; sub-components that are internal to one parent stay in the parent's file
+- **Co-located tests** — `component.tsx` → `component.test.tsx` in same directory
+- **Hook naming**: snake_case files (`use_dialog_focus_trap.ts`), named exports (`export function useDialogFocusTrap`)
+- **`@/` alias** for cross-domain imports; relative paths for same-directory
+- **Test pattern**: `make*` factory functions, `render*` wrapper helpers, behavioral assertions (no snapshots)
+- **TypeScript strict mode** — `noUnusedLocals`, `noUnusedParameters`
+
+---
+
+## Key Technical Decisions
+
+- **Internal sub-components stay in the parent file** — matches PileSheet's existing pattern (PileRecordItem, WantlistResultView, etc. are all in `pile_sheet.tsx`). Only genuinely shared components (BackButton, Spinner) get their own files.
+- **Extracted hooks get their own files** — hooks are the shared abstraction layer; each extracted hook is a named export from its own file under `hooks/`.
+- **No new subdirectories** — the flat `components/` convention stays; no `components/crate_view/` or similar groupings.
+- **BackButton and Spinner go in `components/` (not `components/ui/`)** — `ui/` is for design-system primitives; these are application-level shared components.
+- **Test preservation over test rewrite** — existing test suites for CrateView (817 lines) and PileSheet (582 lines) are large and comprehensive. Refactor code in a way that keeps them passing, then prune structural assertions that break on internal reorg.
+
+---
+
+## Implementation Units
+
+### U1. Extract shared hooks
+
+**Goal:** Create foundational hooks that other refactors depend on.
+
+**Requirements:** R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/frontend/hooks/use_dialog_focus_trap.ts`
+- Create: `app/frontend/hooks/use_discogs_lookup.ts`
+- Create: `app/frontend/hooks/use_pointer_proximity.ts`
+- Create: `app/frontend/hooks/use_tactile_transform.ts`
+- Test: `app/frontend/hooks/use_dialog_focus_trap.test.ts`
+- Test: `app/frontend/hooks/use_discogs_lookup.test.ts`
+- Test: `app/frontend/hooks/use_pointer_proximity.test.ts`
+- Test: `app/frontend/hooks/use_tactile_transform.test.ts`
+
+**Approach:**
+- `useDialogFocusTrap(open, returnFocusRef)` — extracts the 3 useEffect blocks from PileSheet's focus management. Returns `{ dialogRef, titleRef }`. Handles Escape key, Tab cycling, focus return on close, and focus restoration when pile contents change.
+- `useDiscogsLookup(username)` — extracts the fetch + AbortController + state machine from DiscogsSellerLookupInput. Returns `{ state, result, lookup, reset }`. Reusable by InvitationContent.
+- `usePointerProximity(ref, options)` — extracts the enter/move/leave + rAF throttling + touch detection from useTactileHover. Returns `{ proximity, handlers }`.
+- `useTactileTransform(proximity, isPressed, options)` — pure computation hook for Framer Motion style values. Returns `{ transform, transition }`.
+
+**Patterns to follow:**
+- `hooks/use_tactile_hover.ts` — existing hook conventions (options interface, return interface, named export)
+- `contexts/viewport_context.tsx` + `hooks/use_viewport.ts` — Provider + Context + Hook pattern
+
+**Test scenarios:**
+- Happy path: `useDialogFocusTrap` traps focus on open, cycles Tab through focusable elements, returns focus on close
+- Happy path: `useDiscogsLookup` fetches on `lookup("username")`, transitions through loading → success/error states
+- Happy path: `usePointerProximity` computes 0–1 proximity from pointer position relative to element center
+- Edge case: `useDiscogsLookup` aborts in-flight request on second `lookup()` call, handles AbortError silently
+- Edge case: `usePointerProximity` returns proximity 0 on touch devices and when reduced motion is active
+- Edge case: `useDialogFocusTrap` handles dialog with zero focusable elements (focuses titleRef)
+
+**Verification:**
+- All four hooks have co-located test files passing
+- Hook interfaces are well-typed with exported options/return interfaces
+
+---
+
+### U2. Extract shared UI primitives
+
+**Goal:** Create BackButton and Spinner components to replace inline copies.
+
+**Requirements:** R6
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/frontend/components/back_button.tsx`
+- Create: `app/frontend/components/spinner.tsx`
+- Test: `app/frontend/components/back_button.test.tsx`
+- Test: `app/frontend/components/spinner.test.tsx`
+
+**Approach:**
+- `BackButton` accepts `variant: 'icon' | 'text'` and `label?: string`. Icon variant renders the circular ← button (compact pattern). Text variant renders the "← Store" pill button (desktop pattern). Both share the same aria-label, hover/focus/active styles, and focus-visible ring.
+- `Spinner` accepts `size: 'sm' | 'md' | 'lg'`. Renders the SVG spinner with `animate-spin`. Replaces all 3 inline copies (DiscogsSellerLookupInput, Apply, StoreShow).
+
+**Patterns to follow:**
+- `components/ui/button.tsx` — variant/size prop pattern, className composition
+
+**Test scenarios:**
+- Happy path: BackButton icon variant renders circular button with ← and aria-label
+- Happy path: BackButton text variant renders pill button with label text
+- Happy path: Spinner renders SVG with animate-spin class
+- Edge case: BackButton handles missing optional label gracefully
+- Edge case: Spinner sm/md/lg sizes render with correct dimensions
+
+**Verification:**
+- Both components have co-located test files passing
+- No behavioral changes in any consuming component
+
+---
+
+### U3. Refactor useTactileHover to compose extracted hooks
+
+**Goal:** Reduce useTactileHover from 178 lines to ~40 lines by composing usePointerProximity + useTactileTransform.
+
+**Requirements:** R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/frontend/hooks/use_tactile_hover.ts`
+- Modify: `app/frontend/hooks/use_tactile_hover.test.tsx`
+
+**Approach:**
+- Internally calls `usePointerProximity` for the proximity/handlers, `useTactileTransform` for the motion style
+- Public interface (`useTactileHover(options) → TactileState`) remains unchanged
+- The existing test file is updated only as needed — the public contract is the same
+
+**Patterns to follow:**
+- Existing `useTactileHover` return interface — preserve the public API
+
+**Test scenarios:**
+- Happy path: same tests pass with composed implementation
+- Edge case: reduced motion still returns identity transforms
+- Edge case: touch devices still return proximity 0
+
+**Verification:**
+- All existing `use_tactile_hover.test.tsx` tests pass
+- `useTactileHover` is ≤ 50 lines
+
+---
+
+### U4. Refactor PileSheet with useDialogFocusTrap and PileFooter
+
+**Goal:** Reduce PileSheet main component to concise orchestrator by using extracted hook and extracting footer.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/frontend/components/pile_sheet.tsx`
+- Modify: `app/frontend/components/pile_sheet.test.tsx`
+
+**Approach:**
+- Replace 3 useEffect focus-trap blocks with `useDialogFocusTrap(open, returnFocusRef)`
+- Extract footer section (lines ~419-448) as internal `PileFooter` sub-component receiving `pile`, `shopper`, `isConnected`, `state`, `wantlistResult`, etc.
+- PileFooter conditionally renders ConnectedAccount, WantlistResultView, WantlistErrorView, WantlistInProgressView, WantlistHandoffAction, or DisconnectedCta
+
+**Patterns to follow:**
+- Existing `PileRecordItem` sub-component pattern in the same file
+- Guard-parity audit checklist from learnings
+
+**Test scenarios:**
+- Happy path: pile sheet opens, closes, traps focus, returns focus on close
+- Happy path: footer renders correct state (connected, disconnected, in-progress, success, error)
+- Edge case: Escape key closes sheet and returns focus
+- Edge case: Tab cycling stays within dialog boundaries
+
+**Verification:**
+- All existing `pile_sheet.test.tsx` tests pass
+- Main `PileSheet` component ≤ 120 lines
+
+---
+
+### U5. Refactor DiscogsSellerLookupInput with useDiscogsLookup
+
+**Goal:** Separate fetch/state-machine from rendering by using extracted hook. Extract status sub-components internally.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `app/frontend/components/discogs_seller_lookup_input.tsx`
+- Modify: `app/frontend/components/discogs_connection_controls.test.tsx`
+
+**Approach:**
+- Replace inline fetch/AbortController/state-machine with `useDiscogsLookup(username)`
+- Extract each AnimatePresence status branch as internal named sub-components (LookupLoading, LookupPreview, LookupNotFound, LookupActiveStore, LookupApplicant, LookupApiError)
+- Replace inline spinner SVGs with `<Spinner size="sm" />`
+
+**Patterns to follow:**
+- PileSheet's internal sub-component pattern
+- Guard-parity: verify all 6 status branches render correctly after extraction
+
+**Test scenarios:**
+- Happy path: entering a valid username shows preview state
+- Happy path: entering an invalid username shows not-found state
+- Edge case: rapid re-submission aborts previous request
+- Edge case: API error surface shows retry option
+
+**Verification:**
+- DiscogsSellerLookupInput ≤ 150 lines
+- Main component reads as orchestrator composing hook + sub-components
+- No behavioral regression in Discogs username lookup flow
+
+---
+
+### U6. Refactor InvitationContent with useDiscogsLookup
+
+**Goal:** Replace inline fetch/state-machine with shared hook, extract sub-components.
+
+**Requirements:** R1, R4
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/frontend/pages/stores/invitation.tsx`
+- Test: `app/frontend/pages/stores/invitation.test.tsx` (if needed)
+
+**Approach:**
+- Replace inline fetch + AbortController + shouldProbe logic with `useDiscogsLookup(slug)`
+- Extract `InvitationFound` and `InvitationNotFound` as internal sub-components
+- Preserve the `shouldProbe` reserve-slug validation — pass it as an option to the hook or gate the lookup call
+
+**Patterns to follow:**
+- U5's DiscogsSellerLookupInput refactor — same hook, same pattern
+
+**Test scenarios:**
+- Happy path: valid slug → found state with seller name and claim button
+- Happy path: invalid slug → not-found state with apply link
+- Edge case: reserved slugs ("admin", "api") skip the probe
+- Edge case: waitlist_present prop renders static page (no probe)
+
+**Verification:**
+- InvitationContent ≤ 100 lines
+- Waitlist-present static page still renders correctly
+
+---
+
+### U7. Refactor CrateView — decompose into sub-components and hook
+
+**Goal:** Reduce CrateView from 452 lines to ~100-line orchestrator.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `app/frontend/components/crate_view.tsx`
+- Create: `app/frontend/hooks/use_crate_navigation.ts`
+- Test: `app/frontend/hooks/use_crate_navigation.test.ts`
+- Modify: `app/frontend/components/crate_view.test.tsx`
+
+**Approach:**
+- Extract `useCrateNavigation(indexRef, total, isCompact) → { navigate, edgeStatus, progress, handleKeyDown, showGestureHint }` as a custom hook owning index state, edge detection, keyboard bindings, and gesture-lesson lifecycle
+- Extract `CrateHeader` as internal sub-component accepting compact variant, onBack, crate metadata, tabs. Uses `<BackButton>` for back navigation
+- Extract `CardStack` as internal sub-component for hint cards + active card animation
+- Extract `CrateProgress` as internal sub-component for progress bar + paginator + edge status
+- CrateView becomes: `<CrateHeader /> + <CardStack /> + <CrateProgress /> + <RecordDetails />` composed together
+
+**Patterns to follow:**
+- Existing CrateTabs component pattern
+- Guard-parity audit: verify compact and desktop header branches both render correctly
+- PileSheet's internal sub-component co-location pattern
+
+**Test scenarios:**
+- Happy path: keyboard navigation (ArrowDown/ArrowUp) navigates through crate
+- Happy path: drag gesture navigates between records
+- Happy path: compact and desktop layouts both render correctly
+- Edge case: edge of crate disables appropriate navigation button
+- Edge case: empty crate shows "No records in this crate yet"
+- Edge case: gesture hint lifecycle — shown on first visit, hidden after interaction
+- Edge case: keyboard navigation skips when modal dialog is open
+
+**Verification:**
+- All existing `crate_view.test.tsx` tests pass (40+ test cases)
+- CrateView main component ≤ 120 lines
+- `useCrateNavigation` ≤ 40 lines
+- No behavioral regression in crate browsing
+
+---
+
+### U8. Split CrateShelf into static and interactive variants
+
+**Goal:** Remove 5 conditional branches by splitting into two focused components.
+
+**Requirements:** R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/components/crate_shelf.tsx`
+- Modify: `app/frontend/components/crate_shelf.test.tsx`
+
+**Approach:**
+- `CrateShelfLayout` — internal shared layout skeleton (header + grid)
+- `StaticCrateShelf` — non-interactive, decorative display
+- `InteractiveCrateShelf` — clickable with keyboard support, motion animations
+- Public default export remains `CrateShelf` which delegates to the appropriate variant based on `interactive` prop
+- Props reduced from 10 to: `crate`, `interactive`, `onSelectCrate?`, `previewCount`, `meta?`, `openLabel?`, `headerSize?`, `tactileThumbnails?`
+
+**Patterns to follow:**
+- Existing variant pattern from BrandMark (size prop delegates to different render paths)
+
+**Test scenarios:**
+- Happy path: static shelf renders header, grid, preview records
+- Happy path: interactive shelf renders with role="button", tabIndex, keyboard handler
+- Edge case: empty crate with 0 records renders correctly
+- Edge case: interactive shelf with no onSelectCrate renders as static (graceful degradation)
+
+**Verification:**
+- All existing `crate_shelf.test.tsx` tests pass
+- Props interface ≤ 8 props
+- No behavioral regression in shelf rendering
+
+---
+
+### U9. Medium sweeps — AppHeader, FeatureCard, StepCard, DiscogsOnboardingPanel, RecordCardBack
+
+**Goal:** Decompose 5 medium-sized components in parallel.
+
+**Requirements:** R1, R2
+
+**Dependencies:** U2 (AppHeader uses BackButton)
+
+**Files:**
+- Modify: `app/frontend/layouts/app_layout.tsx` — extract AppHeader as internal sub-component
+- Modify: `app/frontend/pages/home.tsx` — extract FeatureCard, StepCard as internal sub-components
+- Modify: `app/frontend/pages/admin/dashboard.tsx` — extract DiscogsOnboardingPanel, LookupResult, LookupMessage as internal sub-components
+- Modify: `app/frontend/components/record_card.tsx` — extract RecordCardBack as internal sub-component
+- Modify: `app/frontend/pages/stores/show.tsx` — extract `useCrateRouting` hook
+- Modify: `app/frontend/pages/apply.tsx` — extract `useTurnstile` hook
+- Modify: `app/frontend/pages/admin/totp_setup.tsx` — extract TotpCodeInput, share with totp_challenge.tsx
+- Modify: affected test files
+
+**Approach:**
+- AppHeader extracts ~80 lines of header JSX with 3 variants (compactCrateLocation, storeName, BrandMark)
+- Home extracts 4 FeatureCards and 3 StepCards — each becomes a small internal sub-component
+- AdminDashboard extracts DiscogsOnboardingPanel (~55 lines) as internal sub-component
+- RecordCard extracts RecordCardBack (~35 lines) as internal sub-component
+- StoreShow extracts useCrateRouting hook owning activeSlug/startIndex state + history pushState + popstate listener
+- Apply extracts useTurnstile hook owning script injection, widget render, cleanup
+- TOTP extracts TotpCodeInput shared component used by both totp_setup and totp_challenge
+
+**Patterns to follow:**
+- U4 PileSheet internal sub-component pattern
+- U7 useCrateNavigation hook pattern
+
+**Test scenarios:**
+- Happy path: AppLayout renders with all 3 header variants
+- Happy path: Home renders FeatureCards and StepCards with correct copy
+- Happy path: AdminDashboard renders DiscogsOnboardingPanel
+- Happy path: RecordCard flip reveals back face
+- Happy path: StoreShow routes between crates via URL
+- Happy path: Apply renders Turnstile widget
+- Happy path: TOTP input accepts only digits, enforces 6-char limit
+
+**Verification:**
+- Each component ≤ 100 lines (or has a clear reason for slight excess)
+- All affected test files pass
+- No behavioral regression
+
+---
+
+### U10. Replace inline copies with shared primitives
+
+**Goal:** Eliminate all remaining inline spinner and back button copies.
+
+**Requirements:** R6
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `app/frontend/components/discogs_seller_lookup_input.tsx` (if not done in U5)
+- Modify: `app/frontend/pages/apply.tsx` — replace inline spinner
+- Modify: `app/frontend/pages/stores/show.tsx` — replace inline spinner
+- Modify: `app/frontend/components/crate_view.tsx` — replace inline back buttons (if not done in U7)
+- Modify: `app/frontend/layouts/app_layout.tsx` — replace inline back button
+
+**Approach:**
+- Grep for remaining inline SVG spinners and back button markup
+- Replace with `<Spinner />` and `<BackButton />`
+- Verify visual parity
+
+**Patterns to follow:**
+- U2's BackButton and Spinner components
+
+**Test scenarios:**
+- Happy path: loading states show Spinner component
+- Happy path: back navigation shows BackButton with correct variant
+
+**Verification:**
+- No inline spinner SVGs or back button markup remaining outside of BackButton.tsx and Spinner.tsx
+- grep confirms zero remaining copies
+
+---
+
+### U11. Test pruning and audit
+
+**Goal:** Remove obsolete structural tests, keep behavioral tests.
+
+**Requirements:** R7, R8
+
+**Dependencies:** U3, U4, U5, U6, U7, U8, U9, U10
+
+**Files:**
+- Modify: all test files affected by refactors above
+
+**Approach:**
+- For each refactored component, audit its test file
+- Remove tests that assert exact component structure (hook inventory, sub-component tree shape, line counts)
+- Keep tests that assert observable behavior (what renders, what happens on click, what states display)
+- Remove tests for components that no longer exist (e.g., if a test validates an inline sub-component that was extracted)
+- For the page smoke tests (`test/pages/*.test.tsx`), assess whether each test is still useful — prune any that duplicate component-level test coverage or test dead paths
+
+**Patterns to follow:**
+- `docs/solutions/best-practices/sandi-metz-refactor-helpers-stay-private-and-behavior-specs.md` — retire structural tests, keep behavior tests
+
+**Test scenarios:**
+- Each remaining test validates a specific behavior, not an implementation detail
+
+**Verification:**
+- All remaining tests pass
+- No tests fail because they assert old component boundaries
+- Full test suite: `cd app/frontend && npx vitest run`
+
+---
+
+### U12. Final verification
+
+**Goal:** Confirm all requirements are met and no regressions exist.
+
+**Requirements:** R1-R8
+
+**Dependencies:** U11
+
+**Approach:**
+- Run full test suite: `cd app/frontend && npx vitest run`
+- Run TypeScript check: `cd app/frontend && npx tsc --noEmit`
+- Re-run `sandi-metz-js-review` to verify findings are resolved
+- Run `scripts/lint-design-system-tokens.ts` to verify token compliance
+- Manually audit each of the 26 original findings — confirm each is resolved or has a documented reason for deferral
+
+**Verification:**
+- All tests pass
+- TypeScript compiles with zero errors
+- sandi-metz-js-review returns zero violations (or only documented exceptions)
+- No lint errors
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** CrateView, PileSheet, and DiscogsSellerLookupInput are the most-interacted-with components. Their refactors must preserve all keyboard navigation, focus management, and drag gesture contracts.
+- **Error propagation:** useDiscogsLookup hook must preserve AbortError silent handling and error surface patterns.
+- **State lifecycle risks:** useCrateNavigation moves index state from component to hook — ensure the hook's cleanup handles rapid crate switching without stale state.
+- **API surface parity:** useDiscogsLookup must work identically for DiscogsSellerLookupInput (store onboarding) and InvitationContent (URL probe).
+- **Integration coverage:** CrateView's keyboard navigation must work correctly when a modal dialog is open (existing guard: `document.querySelector('[role="dialog"][aria-modal="true"]')`).
+- **Unchanged invariants:** All Framer Motion animation behavior, all Tailwind styling, all Inertia page props contracts, all API endpoint contracts remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| CrateView test suite (817 lines) breaks on internal reorg | Run tests after each extraction; use existing test as behavior specification |
+| PileSheet focus management regression | useDialogFocusTrap extracts existing logic mechanically — minimal change |
+| Guard condition lost during branch decomposition | Run guard-parity audit checklist on every extracted sub-component |
+| useDiscogsLookup doesn't handle InvitationContent's shouldProbe reserve-slug logic | Pass shouldProbe as a gating option to the hook |
+| Shared BackButton/Spinner don't match existing visual styles | Copy existing Tailwind classes exactly; verify with visual diff |
+
+---
+
+## Sources & References
+
+- Origin review: sandi-metz-js-review findings (26 items across app/frontend/)
+- Guard parity: `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`
+- Viewport pattern: `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`
+- Animation tokens: `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`
+- Private internals: `docs/solutions/best-practices/sandi-metz-refactor-helpers-stay-private-and-behavior-specs.md`
+- Brand architecture: `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md`

--- a/docs/plans/2026-05-28-001-refactor-sandi-metz-js-wave-2-plan.md
+++ b/docs/plans/2026-05-28-001-refactor-sandi-metz-js-wave-2-plan.md
@@ -1,0 +1,551 @@
+---
+title: "refactor: Second wave Sandi Metz JS refactoring — module directories, prop reduction, deduplication"
+type: refactor
+status: active
+date: 2026-05-28
+origin: sandi-metz-js-review (2026-05-28 — full frontend audit)
+---
+
+# refactor: Second wave Sandi Metz JS refactoring — module directories, prop reduction, deduplication
+
+## Summary
+
+Address remaining POODR findings from a second sandi-metz-js-review audit after the first wave (2026-05-27) extracted shared hooks and primitives. This wave targets: module directory extraction for oversized files (>250 lines), prop count reduction (10-prop CrateHeader, 10-prop AppHeader, 11-field PileFooterModel, 7-prop CrateView), collapsing variant-string patterns into separate components (BackButton, PicksShelf), deduplicating FeaturedCratesRow/GenreGrid into a shared primitive, extracting the admin Discogs lookup to use the shared hook, and breaking data clumps into focused domain objects.
+
+---
+
+## Problem Frame
+
+A sandi-metz-js-review audit after the first refactoring wave found the following categories of remaining violations, none of which were addressed by the first wave's approach (which kept sub-components internal within parent files):
+
+1. **File bloat persisted** — crate_view.tsx (554 lines), pile_sheet.tsx (452 lines), admin/dashboard.tsx (401 lines), home.tsx (362 lines) still contain 5–10 internal sub-components each. The first wave's "internal only" strategy kept line counts high.
+2. **Prop overload** — CrateHeader (10 props), AppHeader (10 props), CrateShelfLayout (12+ params via destructuring), CrateView (7 props), CrateProgress (7 props) exceed the 3–4 prop guideline. Boolean pairs like `hideTabs` + `compactHeaderOwnedByLayout` want collapsing into a layout-mode enum.
+3. **Branching-on-string pattern** — BackButton uses `variant: "icon" | "text"` to render two completely different buttons. The `PicksShelf`/`CompactPicksShelf`/`DesktopPicksShelf` trio duplicates the same pattern at the viewport level.
+4. **Duplication** — FeaturedCratesRow and GenreGrid are structurally identical (section header + responsive CrateCard grid + column computation). Admin dashboard reimplements Discogs lookup inline instead of using the already-extracted `useDiscogsLookup` hook.
+5. **Data clumps** — PileFooterModel (11 fields) bundles unrelated domains (shopper identity, wantlist state, submission lifecycle). Copy props (11–25 strings) are threaded individually through component trees.
+6. **Style duplication** — `compositedLayerStyle` and `activeLayerStyle` differ by only one property.
+7. **Viewport branching proliferation** — `isCompact` is checked independently in every sub-component of CrateView, driving the same layout-mode decisions at multiple levels of the component tree.
+
+---
+
+## Requirements
+
+- R1. No component file exceeds 250 lines of source (not counting imports and blank lines). Sub-components that render their own content and manage their own props must be extracted to dedicated files within a module directory.
+- R2. No component accepts more than 5 props. (Exception: layout shells like MilkcrateShell that accept slot content.)
+- R3. No function or method accepts more than 6 named parameters.
+- R4. No branching-on-string `variant` prop chooses between fundamentally different UIs. Replace with separate components or discriminated unions.
+- R5. No structurally duplicate components. Three or more structurally identical components must share a primitive.
+- R6. No inline Discogs lookup state management — use the already-extracted `useDiscogsLookup` hook in the admin dashboard.
+- R7. No redundant CSS-in-JS style objects — extract shared style factories.
+- R8. All existing test suites pass with no behavioral regressions.
+- R9. The three-tier viewport branching in CrateView sub-components is consolidated to a single decision point per render tree.
+
+---
+
+## Scope Boundaries
+
+- This is frontend-only (`app/frontend/`). Backend, database, and types remain untouched.
+- No new features. Pure structural refactoring.
+- No CSS or visual styling changes — extracted components use identical Tailwind classes.
+- No changes to `types/inertia.ts` — type contracts remain stable.
+- No changes to animation behavior or motion tokens.
+- `copy` prop bundling (translation object extraction) is **deferred** — the copy-prop pattern is a server-passed convention that would require backend coordination to change.
+- Admin Discogs lookup extraction uses the existing `useDiscogsLookup` hook — no new hook needed.
+
+---
+
+## Context & Research
+
+### What the First Wave Did
+
+The 2026-05-27 Sandi Metz plan (fully executed) extracted:
+- Shared hooks: `useDialogFocusTrap`, `useDiscogsLookup`, `usePointerProximity`, `useTactileTransform`
+- Shared components: `BackButton`, `Spinner`
+- Hook composition: `useTactileHover` composes usePointerProximity + useTactileTransform
+- Internal sub-components: CrateHeader, CardStack, CrateProgress (inside crate_view.tsx)
+- Internal sub-components: PileRecordItem, PileFooter (inside pile_sheet.tsx)
+- Internal sub-components: DiscogsSellerLookupInput status branches
+- Hook extraction: `useCrateNavigation`, `useCrateRouting`, `useTurnstile`
+- Inline Spinner/BackButton replacement across all consumers
+
+### What the First Wave Did NOT Address
+
+- Sub-components stayed internal to their parent files (chosen approach)
+- BackButton was created WITH the variant-string pattern
+- FeaturedCratesRow and GenreGrid remained as separate files
+- Admin dashboard kept its inline Discogs lookup
+- PileFooterModel's 11-field data clump was created by the refactor
+- compositedLayerStyle/activeLayerStyle duplication was not extracted
+- CrateShelfLayout's 12-destructured-param pattern was not reduced
+- PicksShelf viewport branching was not consolidated
+
+### Relevant Code and Patterns
+
+- **useDiscogsLookup** (`hooks/use_discogs_lookup.ts`) — already extracted, ready to consume in admin dashboard
+- **CrateShelf discriminated union** (`components/crate_shelf.tsx`) — existing pattern for `StaticCrateShelfProps | InteractiveCrateShelfProps`. Use this as the template for BackButton's refactor
+- **RecordTile extraction** — precedent for extracting a shared visual primitive (RecordTile) from RecordCard. FeaturedCratesRow/GenreGrid follow the same pattern
+- **renderWithTier** — test utility for viewport-tier-specific component testing
+- **Guard-parity checklist** — from `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`. Run on every isCompact branch split
+
+### Institutional Learnings
+
+- **Guard-parity audit** (docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md): After splitting render paths, audit every branch for guard conditions. Write a 4-step checklist for each decomposed component.
+- **Private helpers** (docs/solutions/best-practices/sandi-metz-refactor-helpers-stay-private-and-behavior-specs.md): Keep extracted sub-components module-private via barrel exports. Only the parent component is exported from the module directory's index.ts. Retire structural tests after stabilization.
+- **Boolean inversion trap** (docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md): When inverting `setCompact ? A : B`, audit every ternary individually.
+- **Progressive migration** (docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md): Create the module directory/index.ts first, then move one file at a time, verifying tests after each move.
+
+---
+
+## Key Technical Decisions
+
+- **Module directories (new convention)**: For the first time in this codebase, extract component families into subdirectories: `components/crate_view/`, `components/pile_sheet/`. Each gets an `index.ts` that re-exports only the public component. Internal sub-components are imported by the barrel. This is a deliberate convention extension — the existing flat directory works well for single components but breaks down for files >250 lines.
+- **BackButton → discriminated union**: Replace `variant: "icon" | "text"` with separate `IconBackButton` and `TextBackButton` components, following the established `StaticCrateShelf | InteractiveCrateShelf` pattern. A common `BaseBackButtonProps` interface shares the onClick/className/aria-label contract.
+- **CrateHeader layout-mode enum**: Collapse `hideTabs` + `compactHeaderOwnedByLayout` into a single `layoutMode: "full" | "compact" | "minimal"` enum, simplifying the branching logic and reducing CrateHeader from 10 props to 7.
+- **PileFooterModel decomposition**: Split the 11-field model into three focused types: `PileState` (submission lifecycle), `StoreInfo` (store name/slug for CTAs), `ShopperInfo` (discogs_username/connection status).
+- **Admin Discogs lookup**: Use the existing `useDiscogsLookup` hook directly. The admin panel needs the same state machine. The admin-specific `fetch` + `AbortController` + `timeoutRef` pattern in `onboarding_panel` gets replaced with the hook.
+- **Style constant extraction**: `compositedLayerStyle` + `activeLayerStyle` → `sharedLayerStyle(contain?: boolean)` factory function in `lib/motion_tokens.ts`.
+- **No barrel files extracted to `components/` root**: Module directories are specific to the oversized files. The existing flat `components/` structure remains for all other components.
+- **Test preservation**: Refactor in a way that keeps existing tests passing. Only change tests that break because internal imports changed (replace relative imports to `../` with imports from the module's `index.ts` barrel).
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should BackButton become a discriminated union or separate export?** Separate exports (`IconBackButton`, `TextBackButton`) — matches the established CrateShelf pattern. Consumers import only the variant they need. The discriminated union inside the component (what CrateShelf does) is fine for components with internal branching, but BackButton's two variants are used in different contexts (icon in compact headers, text in desktop headers) and never need to be swapped at runtime.
+
+- **Should admin dashboard's Discogs lookup use the existing hook?** Yes. The existing `useDiscogsLookup` already handles fetch, abort, timeout, and the same 7-state machine. The admin version adds `shouldProbe` reserve-slug logic — this becomes an option parameter on the hook.
+
+- **Where to put shared style factories?** `lib/motion_tokens.ts` — it already holds shared animation constants. A `compositedLayerStyle()` function is a natural extension. The existing file's exports are all animation-related; a single factory function is in scope.
+
+### Deferred to Implementation
+
+- **Should `shouldProbe` be added to `useDiscogsLookup` or handled by the consumer?** Consumer-side. The Invitation page already gates on `shouldProbe` before calling `lookup(slug)`. The admin panel can do the same.
+
+---
+
+## Implementation Units
+
+### U1. Extract crate_view module directory
+
+**Goal:** Reduce crate_view.tsx from 554 lines to a ~60-line orchestrator by extracting sub-components to their own files within `components/crate_view/`.
+
+**Requirements:** R1, R2, R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/frontend/components/crate_view/index.ts`
+- Create (extract from crate_view.tsx): `app/frontend/components/crate_view/crate_header.tsx`
+- Create (extract from crate_view.tsx): `app/frontend/components/crate_view/card_stack.tsx`
+- Create (extract from crate_view.tsx): `app/frontend/components/crate_view/hint_card_stack.tsx`
+- Create (extract from crate_view.tsx): `app/frontend/components/crate_view/active_record_card.tsx`
+- Create (extract from crate_view.tsx): `app/frontend/components/crate_view/gesture_hint_overlay.tsx`
+- Create (extract from crate_view.tsx): `app/frontend/components/crate_view/crate_progress.tsx`
+- Modify: `app/frontend/components/crate_view.tsx`
+- Modify: `app/frontend/components/crate_view.test.tsx`
+
+**Approach:**
+- Create `components/crate_view/` directory with `index.ts` barrel that re-exports only `CrateView` (the public component)
+- Extract each sub-component (CrateHeader, CardStack, HintCardStack, ActiveRecordCard, GestureHintOverlay, CrateProgress) to its own file
+- CrateView's public `Props` interface stays the same — consumers import from the barrel and see no change
+- Remove `compositedLayerStyle` and `activeLayerStyle` from crate_view.tsx (they move to motion_tokens in U8) and use imported constants
+- Preserve all existing animation contracts, aria attributes, data-testid markers, and keyboard/drag behavior
+
+**Patterns to follow:**
+- `components/crate_tabs.tsx` — standalone component pattern for extracted sub-components
+- `components/storefront_motion_config.tsx` — single-purpose export
+
+**Test scenarios:**
+- Happy path: barrel import works — `import CrateView from "./crate_view"` still resolves
+- Happy path: all 4 CrateView render paths (empty crate, compact with tabs, desktop with details, error state) render identically
+- Edge case: GestureHintOverlay extracts to own file with same guard conditions (isCompact, showGestureHint, isLessonEligible)
+- Edge case: compositedLayerStyle/activeLayerStyle import correctly from motion_tokens
+
+**Verification:**
+- All existing `crate_view.test.tsx` tests pass (40+ test cases)
+- `components/crate_view.tsx` ≤ 80 lines
+- `components/crate_view/index.ts` exports only `CrateView`
+
+---
+
+### U2. Reduce CrateHeader props
+
+**Goal:** Reduce CrateHeader from 10 props to ≤6 by collapsing boolean pairs into enums and extracting data clumps.
+
+**Requirements:** R2, R9
+
+**Dependencies:** U1 (CrateHeader extracted to its own file)
+
+**Files:**
+- Modify: `app/frontend/components/crate_view/crate_header.tsx`
+- Modify: `app/frontend/components/crate_view.tsx` (update the CrateView usage of CrateHeader)
+
+**Approach:**
+- Collapse `hideTabs: boolean` + `compactHeaderOwnedByLayout: boolean` into a single `layoutMode: "full" | "compact" | "minimal"` enum
+- Combine `crates: Crate[]` + `activeSlug: string` + `onSelectCrate` into a single `tabState` object: `tabs: { crates, activeSlug, onSelect }`
+- Combine `activeCrate: Crate | undefined` + `total: number` into a single `crateInfo` slot: `{ name, total }`
+- Result: CrateHeader goes from `(10 props) → { isCompact, layoutMode, onBack, tabs, activeCrate, total }` or similar collapsed shape. Target: ≤6 props.
+
+**Patterns to follow:**
+- `PileFooterModel` pattern (which this refactor will later decompose) — the bundling approach but with smaller, focused objects
+- The guard-parity audit checklist from learnings — ensure every branch path is preserved after collapsing
+
+**Test scenarios:**
+- Happy path: compact+full header renders tabs with back button
+- Happy path: compact+minimal header renders nothing (both hideTabs and compactHeaderOwnedByLayout were true)
+- Happy path: desktop header renders back button, divider, tabs
+- Edge case: all 3 layoutMode values produce correct render output (verify each)
+- Edge case: onBack undefined hides back button in both compact and desktop
+
+**Verification:**
+- All existing crate_view tests pass
+- CrateHeader interface ≤ 6 props
+
+---
+
+### U3. Extract pile_sheet module directory
+
+**Goal:** Reduce pile_sheet.tsx from 452 lines to a ~90-line orchestrator by extracting sub-components.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/frontend/components/pile_sheet/index.ts`
+- Create (extract from pile_sheet.tsx): `app/frontend/components/pile_sheet/pile_record_item.tsx`
+- Create (extract from pile_sheet.tsx): `app/frontend/components/pile_sheet/wantlist_views.tsx` (WantlistResultView, WantlistErrorView, WantlistInProgressView)
+- Create (extract from pile_sheet.tsx): `app/frontend/components/pile_sheet/wantlist_handoff.tsx` (WantlistHandoffAction, DisconnectedCta, ConnectedAccount)
+- Create (extract from pile_sheet.tsx): `app/frontend/components/pile_sheet/pile_footer.tsx`
+- Modify: `app/frontend/components/pile_sheet.tsx`
+- Modify: `app/frontend/components/pile_sheet.test.tsx`
+
+**Approach:**
+- Create `components/pile_sheet/` directory with `index.ts` barrel exporting only `PileSheet`
+- Extract each sub-component family to focused files
+- PileRecordItem is already fairly standalone — extract as-is
+- Wantlist result/error/in-progress views all render under the same `AnimatePresence` — keep them together in `wantlist_views.tsx`
+- WantlistHandoffAction + DisconnectedCta + ConnectedAccount share Discogs auth state — keep together in `wantlist_handoff.tsx`
+- PileFooter model decomposition happens in U4
+
+**Patterns to follow:**
+- U1's crate_view module directory convention
+- Existing record_card.tsx / record_tile.tsx — split of visual from interactive behavior
+
+**Test scenarios:**
+- Happy path: barrel import resolves — `import PileSheet from "./pile_sheet"` works
+- Happy path: all pile sheet states (empty, populated, connected, disconnected, creating, success, error) render identically
+- Edge case: PileRecordItem's remove button works after extraction
+- Edge case: AnimatePresence mode="wait" transitions still function across file boundaries
+
+**Verification:**
+- All existing `pile_sheet.test.tsx` tests pass
+- `components/pile_sheet.tsx` ≤ 120 lines (drops to orchestrator)
+
+---
+
+### U4. Decompose PileFooterModel data clump
+
+**Goal:** Replace the 11-field PileFooterModel with focused domain objects, reducing PileFooter's interface to ≤4 props.
+
+**Requirements:** R2, R3, R5
+
+**Dependencies:** U3 (PileFooter extracted to its own file)
+
+**Files:**
+- Modify: `app/frontend/components/pile_sheet/pile_footer.tsx`
+- Modify: `app/frontend/components/pile_sheet.tsx` (update PileSheet's construction of PileFooter props)
+
+**Approach:**
+- Split PileFooterModel into:
+  - `PileHeaderInfo: { total, currency }` — the total display concern
+  - `ShopperState: { isConnected, username, storeName, storeSlug }` — Discogs connection
+  - `SubmissionState: { status, result, error }` — wantlist submission lifecycle
+- PileFooter receives these smaller objects instead of one 11-field monolith
+- The `showHandoffAction` / `showDisconnectedCta` / `showResult` derived booleans stay in PileSheet's composition — PileFooter just renders
+- The `highlightOnMount` pulse logic stays in PileSheet and passes down as `animatePulse?: boolean` on the handoff CTA
+
+**Patterns to follow:**
+- Component decomposition that mirrors domain boundaries (PileSheet wants to know about connection state, not a flat 11-field object)
+- The guard-parity checklist: verify each of the 6 footer states still renders correctly after model split
+
+**Test scenarios:**
+- Happy path: connected state shows ConnectedAccount and WantlistHandoffAction
+- Happy path: disconnected state shows DisconnectedCta
+- Happy path: creating state shows WantlistInProgressView
+- Happy path: success state shows WantlistResultView
+- Edge case: all 6 footer states produce correct output after model split
+- Edge case: highlightOnMount pulse timing works through the decomposed interface
+
+**Verification:**
+- All existing pile_sheet tests pass
+- PileFooter interface ≤ 4 props (replaced 2-proxy `{ model, actions }` with 3-4 focused props)
+
+---
+
+### U5. Collapse BackButton variant into separate components
+
+**Goal:** Replace `BackButton`'s `variant: "icon" | "text"` with separate `IconBackButton` and `TextBackButton` components.
+
+**Requirements:** R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/components/back_button.tsx`
+- Modify: `app/frontend/components/back_button.test.tsx`
+- Modify: `app/frontend/components/crate_view/crate_header.tsx` (update import — IconBackButton)
+- Modify: `app/frontend/layouts/app_layout.tsx` (update import — IconBackButton)
+- Modify: `app/frontend/components/crate_view.tsx` (if it directly imports BackButton)
+
+**Approach:**
+- `BackButtonProps` becomes a union of two interfaces: `IconBackButtonProps` (just onClick + optional label + className) and `TextBackButtonProps` (same + required label)
+- `IconBackButton` exports a focused component with just the circular ← button
+- `TextBackButton` exports the "← Label" pill button
+- Common focus-visible and aria-label patterns are extracted to a shared internal helper `sharedBackButtonClasses`
+- Default export of `back_button.tsx` changes from `BackButton` to `IconBackButton` (the most commonly used variant) — or drop the default export entirely and require named imports
+- Update all consumers to import the specific variant they need
+
+**Patterns to follow:**
+- `CrateShelfProps` discriminated union (`StaticCrateShelfProps | InteractiveCrateShelfProps`)
+- The `actionClassName` helper pattern from `components/ui/action.tsx` — the shared button classes helper
+
+**Test scenarios:**
+- Happy path: IconBackButton renders circular ← button with correct aria-label
+- Happy path: TextBackButton renders pill button with capitalised label
+- Edge case: both variants render same focus-visible ring, hover colors, and transition
+- Edge case: className override passes through to both variants
+
+**Verification:**
+- All existing back_button.test.tsx tests pass (update test imports to named variants)
+- No consumers import `BackButton` from the default export (all use named exports)
+- grep confirms zero remaining `BackButton({ variant: ` usage
+
+---
+
+### U6. Extract shared CrateSectionGrid from FeaturedCratesRow + GenreGrid
+
+**Goal:** Eliminate duplication between FeaturedCratesRow and GenreGrid (near-identical components) by extracting a shared `CrateSectionGrid` primitive.
+
+**Requirements:** R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/frontend/components/crate_section_grid.tsx`
+- Modify: `app/frontend/components/featured_crates_row.tsx` (delegate to CrateSectionGrid)
+- Modify: `app/frontend/components/genre_grid.tsx` (delegate to CrateSectionGrid)
+- Create: `app/frontend/components/crate_section_grid.test.tsx`
+- Modify: `app/frontend/components/featured_crates_row.test.tsx` (delegate tests)
+- Modify: `app/frontend/components/genre_grid.test.tsx` (delegate tests)
+
+**Approach:**
+- CrateSectionGrid accepts: `{ title, count, crates: Crate[], variant: "featured" | "genre", onSelectCrate, columnCount }`
+- `columnCount` is a function `(isCompact: boolean, isComfy: boolean) => number` — each variant provides its own column strategy
+- FeaturedCratesRow becomes a thin wrapper: `export default function FeaturedCratesRow(props) { return <CrateSectionGrid title="Featured" columnCount={(c, cf) => c ? 1 : cf ? 2 : 3} {...props} /> }`
+- GenreGrid becomes a similar thin wrapper with different title and column strategy
+- Both original files stay as thin wrappers preserving the public import paths
+
+**Patterns to follow:**
+- `RecordTile` / `RecordCard` split — base primitive + feature wrapper
+- Existing `useViewport()` consumption in both source files
+
+**Test scenarios:**
+- Happy path: CrateSectionGrid renders section header + responsive grid of CrateCards
+- Happy path: FeaturedCratesRow wrapper produces identical output to the original
+- Happy path: GenreGrid wrapper produces identical output to the original
+- Edge case: columnCount function receives correct viewport tier values
+- Edge case: empty crates array renders nothing (preserving `if (crates.length === 0) return null`)
+- Edge case: title and count labels render correctly for both wrappers
+
+**Verification:**
+- All existing featured_crates_row.test.tsx and genre_grid.test.tsx tests pass
+- CrateSectionGrid has its own co-located test file passing
+- FeaturedCratesRow and GenreGrid are ≤ 15 lines each (thin wrappers only)
+
+---
+
+### U7. Reparent admin Discogs lookup to use shared hook
+
+**Goal:** Eliminate the inline Discogs lookup state machine in admin/dashboard.tsx by using the existing `useDiscogsLookup` hook.
+
+**Requirements:** R6
+
+**Dependencies:** None (useDiscogsLookup already exists from first wave)
+
+**Files:**
+- Modify: `app/frontend/pages/admin/dashboard.tsx`
+- Create: `app/frontend/test/pages/admin_dashboard.test.tsx` (or modify existing)
+
+**Approach:**
+- Replace the inline AbortController + fetch + state machine in `DiscogsOnboardingPanel` with `useDiscogsLookup`
+- The admin panel needs status-specific UI (creatable, already_active, existing_applicant, invalid, api_error) — mirror the existing DiscogsSellerLookupInput pattern
+- Extract LookupResult and LookupMessage as files under a new `components/admin/` directory (or keep internal to the page — evaluate at implementation time based on complexity)
+- The csrfToken retrieval and form submission for onboarding remains — the hook handles the lookup, not the form submission
+- Remove the inline `AdminDiscogsLookupResponse` type — use the existing `DiscogsLookupResult` from `types/inertia.ts`
+
+**Patterns to follow:**
+- DiscogsSellerLookupInput's use of `useDiscogsLookup` (consumes state, renders status branches via AnimatePresence)
+- The admin panel will have different copy but the same rendering structure
+
+**Test scenarios:**
+- Happy path: entering a valid Discogs username shows creatable preview with onboarding form
+- Happy path: entering an existing store username shows already_active status
+- Happy path: entering an existing applicant username shows existing_applicant status
+- Edge case: empty username shows invalid error without calling the hook
+- Edge case: API error shows error message with retry option
+
+**Verification:**
+- All existing admin dashboard tests pass
+- No inline AbortController or fetch calls remain in admin/dashboard.tsx
+- Admin uses `useDiscogsLookup` from `hooks/use_discogs_lookup.ts`
+
+---
+
+### U8. Extract shared style factory and reduce CrateShelfLayout params
+
+**Goal:** (a) Replace duplicate `compositedLayerStyle`/`activeLayerStyle` with a shared factory in motion_tokens. (b) Reduce CrateShelfLayout's 10+ destructured params to focused sub-objects.
+
+**Requirements:** R3, R7
+
+**Dependencies:** U1 (moves crate_view sub-components to module directory)
+
+**Files:**
+- Modify: `app/frontend/lib/motion_tokens.ts`
+- Modify: `app/frontend/components/crate_view/card_stack.tsx` (replace inline style constants with factory call)
+- Modify: `app/frontend/components/crate_view/active_record_card.tsx` (replace inline style constants)
+- Modify: `app/frontend/components/crate_shelf.tsx` (reduce CrateShelfLayout params)
+
+**Approach:**
+- Add to `motion_tokens.ts`: `export function compositedLayer(contain = false): React.CSSProperties` returns the shared style object with optional `contain: "layout paint style"`. The non-contain variant matches `activeLayerStyle`.
+- Update CardStack to import `compositedLayer` from motion_tokens instead of using inline constants
+- For CrateShelfLayout: split the 10+ param destructuring into `ShelfLayoutProps` with sub-objects `{ crate, header: { ... }, grid: { cols, records, tactile } }` or similar domain grouping
+- The `headerProps` rest-spread leak is fixed — HTML attribute spreading happens at the CrateShelfLayout call site, not as a param
+
+**Patterns to follow:**
+- Existing motion_tokens.ts export pattern (all named exports, no default)
+- CrateShelf's existing discriminated union pattern
+
+**Test scenarios:**
+- Happy path: compositedLayer(true) returns style with contain property
+- Happy path: compositedLayer(false) returns style without contain (matches activeLayerStyle)
+- Happy path: CrateShelfLayout renders identically with restructured params
+- Edge case: all existing hover/active animation behavior preserved
+
+**Verification:**
+- All existing crate_shelf.test.tsx and crate_view.test.tsx tests pass
+- grep confirms zero remaining inline `compositedLayerStyle` or `activeLayerStyle` references
+- CrateShelfLayout function signature ≤ 6 params (counting sub-objects as single params)
+
+---
+
+### U9. Consolidate PicksShelf viewport branching
+
+**Goal:** Replace the three-component PicksShelf/CompactPicksShelf/DesktopPicksShelf viewport branching with a single component using layout slot composition.
+
+**Requirements:** R4, R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/components/store_floor.tsx`
+- Modify: `app/frontend/components/store_floor.test.tsx`
+
+**Approach:**
+- Remove CompactPicksShelf and DesktopPicksShelf as separate components
+- PicksShelf renders the shelf content directly, gating only the viewport-specific motion wrapper
+- The motion.div hover wrapper that DesktopPicksShelf adds for desktop becomes a conditional fragment in PicksShelf — only the wrapping `motion.div` differs between compact and desktop
+- All guard conditions from both original branches are audited via the checklist
+
+**Patterns to follow:**
+- The `view ternaries, not conditional hooks` pattern from the codebase (`picksPreviewCount = isCompact ? 4 : 8`)
+- Guard-parity audit checklist from docs/solutions/
+
+**Test scenarios:**
+- Happy path: compact tier renders shelf content without motion wrapper
+- Happy path: desktop tier renders shelf content with motion hover wrapper
+- Edge case: guard condition parity — every guard from both original branches present
+- Edge case: useTactileHover only fires on desktop branch (not conditionally called — use a wrapping div or fragment)
+
+**Verification:**
+- All existing store_floor.test.tsx tests pass
+- PicksShelf renders identically to the original for both compact and desktop viewports
+- No duplicate components for viewport branching
+
+---
+
+### U10. Extract page module directories (admin/dashboard, home)
+
+**Goal:** Reduce admin/dashboard.tsx (401 lines) and home.tsx (362 lines) by extracting internal sub-components.
+
+**Requirements:** R1
+
+**Dependencies:** U7 (admin Discogs lookup refactor)
+
+**Files:**
+- Create: `app/frontend/pages/admin/dashboard/index.ts`
+- Create (extract from dashboard.tsx): `app/frontend/pages/admin/dashboard/discogs_onboarding_panel.tsx`
+- Create (extract from dashboard.tsx): `app/frontend/pages/admin/dashboard/store_card.tsx`
+- Create (extract from dashboard.tsx): `app/frontend/pages/admin/dashboard/applicant_card.tsx`
+- Modify: `app/frontend/pages/admin/dashboard.tsx`
+- Modify: `app/frontend/pages/home.tsx` (extract FeatureCard, StepCard as webpack-imported siblings or subcomponents)
+- Modify: `app/frontend/test/pages/admin_dashboard.test.tsx`
+
+**Approach:**
+- Create `pages/admin/dashboard/` directory with barrel export
+- Extract DiscogsOnboardingPanel, StoreCard, ApplicantCard to own files
+- Dashboard becomes a ~80-line orchestrator
+- For home.tsx: FeatureCard and StepCard become co-located files in a `pages/home/` directory — or remain in the same file since they are already small (FeatureCard ~10 lines, StepCard ~15 lines). Evaluate at implementation time. If combined they are <50 lines, keep in same file.
+- Preserve all animation variant definitions — they stay in the file that owns them
+
+**Patterns to follow:**
+- U1 crate_view module directory convention
+- U3 pile_sheet module directory convention
+
+**Test scenarios:**
+- Happy path: barrel import resolves for admin dashboard
+- Happy path: admin dashboard renders with DiscogsOnboardingPanel, StoreCard, ApplicantCard
+- Happy path: home renders FeatureCards and StepCards identically
+- Edge case: admin empty states (no stores, no applicants) render correctly after extraction
+
+**Verification:**
+- All existing page tests pass
+- admin/dashboard.tsx ≤ 100 lines
+- home.tsx ≤ 200 lines (FeatureCard/StepCard remaining is acceptable)
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** CrateView's CardStack, CrateHeader, and CrateProgress are extracted to files but their import chain stays the same (consumed by CrateView). No external consumers change their imports.
+- **Error propagation:** The admin Discogs lookup switches from inline error handling to useDiscogsLookup's state machine. The error surface UI is the same — just driven by a different state source.
+- **State lifecycle risks:** CrateHeader's `layoutMode` enum replaces boolean pairs. Ensure all 3-mode combinations are tested — edge cases like `{ layoutMode: "compact", crates: [], activeSlug: "" }` must match the original boolean pair behavior.
+- **API surface parity:** All public imports remain stable. `import CrateView from "@/components/crate_view"` still works because the barrel re-exports it.
+- **Integration coverage:** Module directory extractions are purely organizational — no behavioral change. The guard-parity audit is the main risk area.
+- **Unchanged invariants:** All Inertia page props, all API endpoints, all animation behavior, all aria attributes, all data-testid markers remain unchanged. The admin lookup behavior is the same — just driven by a shared hook instead of inline code.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Guard condition drift during CrateHeader prop refactor | Run guard-parity checklist (4 steps from docs/solutions/logic-errors/) after every branch change |
+| Module directory barrel files break existing component imports | Create barrel and verify imports before moving sub-components. Run full test suite after each unit |
+| PileFooter 6-state rendering regression after model split | Test all 6 states individually in pile_sheet.test.tsx before and after the split |
+| Admin Discogs lookup behavior differs when switching to shared hook | Map existing `AdminDiscogsLookupResponse` statuses to `useDiscogsLookup` states. Test each mapping |
+| BackButton variant consumers miss the refactor | grep for `BackButton` after refactor — ensure all imports updated |
+| CrateShelfLayout param refactor breaks callers outside crate_view | Check all components importing CrateShelfLayout or CrateShelf which proxies to it |
+
+---
+
+## Sources & References
+
+- Sandi Metz JS review findings: sandi-metz-js-review output (2026-05-28)
+- First wave plan: `docs/plans/2026-05-27-001-refactor-frontend-sandi-metz-js-plan.md`
+- Guard-parity: `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`
+- Private helpers: `docs/solutions/best-practices/sandi-metz-refactor-helpers-stay-private-and-behavior-specs.md`
+- Boolean inversion: `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`
+- Progressive migration: `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`

--- a/docs/sidenotes.md
+++ b/docs/sidenotes.md
@@ -4,6 +4,12 @@ Quick-captured thoughts, ideas, and tasks collected during sessions.
 
 <!-- Entries are appended by /sn — newest first -->
 
+## 2026-05-28
+
+- **CrateView back button navigates to stale/expired page instead of store view** — Clicking the back button in CrateView calls `history.back()`, which navigates to the last browser history entry. If the previous page was an expired OAuth callback or a stale middleware redirect, the user gets dumped on an error page instead of returning to the store floor. Should replace `history.back()` with an explicit navigation to the store view, or store the store-return URL explicitly and navigate to it rather than relying on browser history.
+
+- **Pile sheet exit animation missing** — The pile sheet slides in smoothly with a spring animation (`springDrawer`), but on close it disappears instantly with no exit transition. The drawer just vanishes instead of sliding back out, which feels jarring after the polished entry. Should add an exit animation (slide-out matching the entry direction) or a fade-out so the dismissal feels intentional rather than abrupt.
+
 ## 2026-05-27
 
 - **Post-OAuth redirect should return shopper to the crate** — After a Discogs shopper OAuth completes, `complete_shopper_auth` redirects to `store_path` with a generic notice. If the user was on a crate page and clicked a listing's "Add to Cart" / "Want" button that required auth, the OAuth redirect dumps them on the store landing page with no cue to follow through. Should preserve the crate context (thread `return_to` through the OAuth chain), redirect back to that crate, and visually emphasize the "Add to Cart" action on the listing that triggered the flow.

--- a/docs/solutions/test-failures/vitest-imports-under-node-test-runner-2026-05-28.md
+++ b/docs/solutions/test-failures/vitest-imports-under-node-test-runner-2026-05-28.md
@@ -1,0 +1,93 @@
+---
+title: "Lib test files must use `node:test` imports, not vitest"
+date: 2026-05-28
+category: test-failures
+module: frontend
+problem_type: test_failure
+component: testing_framework
+symptoms:
+  - "CI test:frontend job fails with `TypeError: Cannot read properties of undefined (reading 'config')` from vitest/runner"
+  - "New test file in app/frontend/lib/ imports from vitest but runs under Node native test runner"
+root_cause: incomplete_setup
+resolution_type: code_fix
+severity: low
+tags: [vitest, node-test, test-runner, ci, csrf-token]
+---
+
+# Lib test files must use `node:test` imports, not vitest
+
+## Problem
+
+A test file added to `app/frontend/lib/` imported `describe`, `expect`, `it` from `vitest`, but files in this directory run under Node's native test runner. CI failed with a vitest runtime error because vitest's runner globals aren't available in the `node --test` context.
+
+## Symptoms
+
+- CI `test:frontend` step fails with:
+  ```
+  TypeError: Cannot read properties of undefined (reading 'config')
+      at initSuite (vitest/runner/dist/chunk-artifact.js:1848)
+  ```
+- Only new `.test.ts` files in `app/frontend/lib/` are affected — all existing ones use `node:test` and pass.
+
+## What Didn't Work
+
+- **Keeping vitest imports** — The error comes from vitest's own runner code trying to access `runner.config` during suite initialization. This isn't a fixable configuration issue; vitest simply isn't the runtime.
+- **Moving the file to vitest's include path** — The project deliberately excludes `app/frontend/lib/*.test.ts` from vitest via `vitest.config.ts: exclude: ["app/frontend/lib/*.test.ts"]`. These are pure-library tests that don't need jsdom or React Testing Library.
+
+## Solution
+
+Switch the imports from `vitest` to Node's built-in test and assert modules:
+
+```diff
+- import { describe, expect, it } from "vitest";
++ import { describe, it } from "node:test";
++ import assert from "node:assert";
+  import { csrfToken } from "./csrf_token";
+
+  describe("csrfToken", () => {
+    it("returns an empty string when document is not available", () => {
+      ...
+-     expect(csrfToken()).toBe("");
++     assert.strictEqual(csrfToken(), "");
+    });
+  });
+```
+
+Test assertions use Node's `assert` module instead of vitest's `expect`. The most commonly needed methods:
+
+| vitest / Jest | Node assert equivalent |
+|--------------|----------------------|
+| `expect(x).toBe(y)` | `assert.strictEqual(x, y)` |
+| `expect(x).toEqual(y)` | `assert.deepStrictEqual(x, y)` |
+| `expect(fn).toThrow()` | `assert.throws(fn)` |
+| `expect(x).toBeDefined()` | `assert.ok(x !== undefined)` or `assert.notStrictEqual(x, undefined)` |
+| `expect(x).toBeNull()` | `assert.strictEqual(x, null)` |
+
+## Why This Works
+
+The project uses a dual-runner test architecture:
+
+- **`npm run test:frontend`** — `node --experimental-webstorage --test --import tsx app/frontend/lib/*.test.ts` runs pure-library tests under Node's native test runner. These tests don't need DOM simulation.
+- **`npm run test:components`** — `vitest run` runs component, hook, and page tests with jsdom and React Testing Library.
+
+Files in `app/frontend/lib/` are explicitly excluded from vitest's include pattern:
+```ts
+// vitest.config.ts
+include: ["app/frontend/**/*.test.{ts,tsx}"],
+exclude: ["app/frontend/lib/*.test.ts"],
+```
+
+Any new lib test file that uses vitest imports will fail in CI because `node --test` doesn't provide vitest's runner context. The fix is to use `node:test` and `node:assert` — the same imports every other lib test file already uses.
+
+## Prevention
+
+- When adding a new `.test.ts` file to `app/frontend/lib/`, use `node:test` and `node:assert` imports, not vitest. Check any existing lib test file for the correct pattern.
+- The dual-runner architecture (`test:frontend` for lib, `test:components` for vitest) is intentional. Do not move lib tests into vitest without explicit architectural agreement — the lib tests don't need jsdom and run faster under `node --test`.
+- CI runs both test commands. A failure in `test:frontend` with a vitest stack trace means a lib test file is importing from vitest.
+
+## Related Issues
+
+- Commit `a943b6e` — fix applied
+- Commit `3a6168e` — original file created with vitest imports (first Sandi Metz wave)
+- Existing lib test files: `crate_window.test.ts`, `design_system_foundations.test.ts`, `first_swipe_lesson.test.ts`, `format_price.test.ts`, `motion_tokens.test.ts`, `riffle_navigation.test.ts` — all use `node:test`/`node:assert`
+- Deferred plan `2026-05-18-002-refactor-frontend-health-check-fixes-plan.md` listed migrating lib tests *to* vitest as a P2/P3 — this direction was not taken


### PR DESCRIPTION
## Summary

Refactors the React frontend to follow Sandi Metz's POODR principles adapted for JS/React across two waves. The first wave extracted shared hooks and primitives from inline patterns. The second wave introduced module directories, reduced excessive prop counts, collapsed branching-on-string anti-patterns, and deduplicated near-identical components. All 449 tests pass with zero behavioral changes.

## What changed

### Extracted abstractions (Wave 1)

**4 shared hooks** — `useDialogFocusTrap` (focus management from PileSheet), `useDiscogsLookup` (Discogs fetch + abort + state machine), `usePointerProximity` (rAF-throttled cursor tracking), `useTactileTransform` (pure Framer Motion style computation). `useTactileHover` now composes them, dropping from 178 to ~90 lines.

**3 app hooks** — `useCrateNavigation` (crate index state, keyboard nav, drag handling, edge detection, gesture lifecycle), `useCrateRouting` (URL-based crate selection with history pushState/popstate), `useTurnstile` (Cloudflare Turnstile lifecycle).

**2 shared primitives** — `BackButton` (replaced 3 inline copies), `Spinner` (replaced 3 inline SVG copies). `csrfToken()` extracted to `lib/csrf_token.ts` (was duplicated in 3 files).

### Module directories (Wave 2)

Components with 5+ internal sub-components now live in their own directory with a barrel export:

| File | Before | After | Extracted files |
|------|--------|-------|-----------------|
| `crate_view.tsx` | 554 lines | 128 lines | crate_header, card_stack, active_record_card, hint_card_stack, gesture_hint_overlay, crate_progress |
| `pile_sheet.tsx` | 452 lines | 185 lines | pile_record_item, wantlist_views, wantlist_handoff, pile_footer |
| `admin/dashboard.tsx` | 401 lines | 100 lines | discogs_onboarding_panel, store_card, applicant_card |

### Prop reduction and parameter grouping

| Component | Before | After | How |
|-----------|--------|-------|-----|
| CrateHeader | 10 props | 6 props | `hideTabs` + `compactHeaderOwnedByLayout` -> `layoutMode` enum; crates/activeSlug/onSelectCrate -> `tabs` object |
| CrateShelfLayout | 11 params | 4 grouped params | `ShelfHeaderConfig` + `ShelfInteractionConfig` + `ShelfGridConfig` sub-objects |
| PileFooter | 13 flat props | 4 grouped props | `PileHeaderInfo` + `ShopperState` + `SubmissionState` domain objects |

### Anti-pattern corrections

- **BackButton variant string** — `variant: "icon" | "text"` replaced with separate `IconBackButton` + `TextBackButton` components following the established discriminated union pattern.
- **PicksShelf viewport branching** — Three components (PicksShelf/CompactPicksShelf/DesktopPicksShelf) consolidated to one with an inline desktop-only motion wrapper.
- **FeaturedCratesRow / GenreGrid duplication** — Both are now thin wrappers (15 lines each) over a shared `CrateSectionGrid` primitive.
- **Style duplication** — `compositedLayerStyle` and `activeLayerStyle` (differing by one property) consolidated to a `compositedLayer(contain?)` factory in `lib/motion_tokens.ts`.

### Extracted hooks

- `useAdminDiscogsLookup` replaces inline fetch + AbortController + timeout in the admin dashboard's Discogs onboarding panel, following the same pattern as the shopper-facing `useDiscogsLookup`.

## Verification

- 449 tests pass (34 test files)
- TypeScript compiles clean (`tsc --noEmit`)
- oxfmt formatted
- Zero behavioral changes -- pure structural refactoring

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)