### PR TITLE
fix: animate pile sheet close and make pile button visibly clickable

### DIFF
--- a/app/frontend/components/pile_sheet.tsx
+++ b/app/frontend/components/pile_sheet.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { usePage } from "@inertiajs/react";
 import { usePileContext } from "../contexts/pile_context";
 import { useViewport } from "@/hooks/use_viewport";
@@ -65,124 +65,129 @@ export default function PileSheet({ open, onClose, returnFocusRef, highlightOnMo
     await addToWantlist(items, storeSlug);
   }, [isConnected, storeSlug, pile, addToWantlist]);
 
-  if (!open) return null;
-
   return (
-    <>
-      <motion.div
-        className="fixed inset-0 bg-black/50 z-40"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        onClick={handleClose}
-        aria-hidden="true"
-      />
+    <AnimatePresence>
+      {open && (
+        <>
+          <motion.div
+            className="fixed inset-0 bg-black/50 z-40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            onClick={handleClose}
+            aria-hidden="true"
+          />
 
-      <motion.div
-        ref={dialogRef}
-        id="pile-sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="pile-sheet-title"
-        className={
-          isCompact
-            ? "fixed inset-0 z-50 h-dvh bg-mc-bg flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
-            : "fixed top-0 right-0 bottom-0 z-50 bg-mc-bg border-l border-mc-border w-96 flex flex-col"
-        }
-        initial={isCompact ? { y: "100%" } : { x: "100%" }}
-        animate={isCompact ? { y: 0 } : { x: 0 }}
-        transition={springDrawer}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-mc-border flex-shrink-0">
-          <div className="flex items-center gap-3">
-            <span
-              ref={titleRef}
-              id="pile-sheet-title"
-              tabIndex={-1}
-              className="text-sm font-semibold outline-none"
-            >
-              Your pile{" "}
-              {pile.length > 0 && (
-                <span className="text-mc-text-dim font-normal">· {pile.length} records</span>
-              )}
-            </span>
-            {pile.length > 0 &&
-              (confirmClear ? (
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-mc-text-dim">Sure?</span>
-                  <button
-                    onClick={() => {
-                      clearPile();
-                      setConfirmClear(false);
-                    }}
-                    className={`${actionClassName({ variant: "danger", size: "sm" })} min-w-11 justify-center`}
-                  >
-                    Yes
-                  </button>
-                  <button
-                    onClick={() => setConfirmClear(false)}
-                    className={`${actionClassName({ variant: "ghost", size: "sm" })} min-w-11 justify-center`}
-                  >
-                    No
-                  </button>
+          <motion.div
+            ref={dialogRef}
+            id="pile-sheet"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="pile-sheet-title"
+            className={
+              isCompact
+                ? "fixed inset-0 z-50 h-dvh bg-mc-bg flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
+                : "fixed top-0 right-0 bottom-0 z-50 bg-mc-bg border-l border-mc-border w-96 flex flex-col"
+            }
+            initial={isCompact ? { y: "100%" } : { x: "100%" }}
+            animate={isCompact ? { y: 0 } : { x: 0 }}
+            exit={isCompact ? { y: "100%" } : { x: "100%" }}
+            transition={springDrawer}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-mc-border flex-shrink-0">
+              <div className="flex items-center gap-3">
+                <span
+                  ref={titleRef}
+                  id="pile-sheet-title"
+                  tabIndex={-1}
+                  className="text-sm font-semibold outline-none"
+                >
+                  Your pile{" "}
+                  {pile.length > 0 && (
+                    <span className="text-mc-text-dim font-normal">· {pile.length} records</span>
+                  )}
+                </span>
+                {pile.length > 0 &&
+                  (confirmClear ? (
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-mc-text-dim">Sure?</span>
+                      <button
+                        onClick={() => {
+                          clearPile();
+                          setConfirmClear(false);
+                        }}
+                        className={`${actionClassName({ variant: "danger", size: "sm" })} min-w-11 justify-center`}
+                      >
+                        Yes
+                      </button>
+                      <button
+                        onClick={() => setConfirmClear(false)}
+                        className={`${actionClassName({ variant: "ghost", size: "sm" })} min-w-11 justify-center`}
+                      >
+                        No
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setConfirmClear(true)}
+                      className={`${actionClassName({ variant: "ghost", size: "sm" })} min-w-11 justify-center`}
+                      aria-label={`Clear ${pile.length} records from pile`}
+                    >
+                      Clear
+                    </button>
+                  ))}
+              </div>
+              <button
+                onClick={handleClose}
+                className="inline-flex h-11 w-11 items-center justify-center rounded text-lg leading-none text-mc-text-dim transition-colors hover:bg-mc-bg-raised hover:text-mc-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus"
+                aria-label="Close pile"
+              >
+                ×
+              </button>
+            </div>
+
+            {/* Records list */}
+            <div className="flex-1 overflow-y-auto">
+              {pile.length === 0 ? (
+                <div className="py-16 text-center text-sm text-mc-text-dim">
+                  No records in your pile yet.
                 </div>
               ) : (
-                <button
-                  onClick={() => setConfirmClear(true)}
-                  className={`${actionClassName({ variant: "ghost", size: "sm" })} min-w-11 justify-center`}
-                  aria-label={`Clear ${pile.length} records from pile`}
-                >
-                  Clear
-                </button>
-              ))}
-          </div>
-          <button
-            onClick={handleClose}
-            className="inline-flex h-11 w-11 items-center justify-center rounded text-lg leading-none text-mc-text-dim transition-colors hover:bg-mc-bg-raised hover:text-mc-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus"
-            aria-label="Close pile"
-          >
-            ×
-          </button>
-        </div>
-
-        {/* Records list */}
-        <div className="flex-1 overflow-y-auto">
-          {pile.length === 0 ? (
-            <div className="py-16 text-center text-sm text-mc-text-dim">
-              No records in your pile yet.
+                <ul>
+                  {pile.map((listing) => (
+                    <PileRecordItem key={listing.id} listing={listing} onRemove={removeFromPile} />
+                  ))}
+                </ul>
+              )}
             </div>
-          ) : (
-            <ul>
-              {pile.map((listing) => (
-                <PileRecordItem key={listing.id} listing={listing} onRemove={removeFromPile} />
-              ))}
-            </ul>
-          )}
-        </div>
 
-        {/* Footer */}
-        {pile.length > 0 && (
-          <PileFooter
-            pileSize={pile.length}
-            header={{ total, currency: pile[0]?.currency }}
-            shopper={{
-              isConnected,
-              username: shopper?.discogs_username ?? null,
-              storeName: store?.name ?? null,
-              storeSlug: storeSlug ?? null,
-            }}
-            submission={{
-              status: state,
-              wantlistResult,
-              errorMessage,
-            }}
-            handoffAvailable={handoffAvailable}
-            highlightOnMount={highlightOnMount}
-            onSendToWantlist={handleSendToWantlist}
-            onReset={resetResult}
-          />
-        )}
-      </motion.div>
-    </>
+            {/* Footer */}
+            {pile.length > 0 && (
+              <PileFooter
+                pileSize={pile.length}
+                header={{ total, currency: pile[0]?.currency }}
+                shopper={{
+                  isConnected,
+                  username: shopper?.discogs_username ?? null,
+                  storeName: store?.name ?? null,
+                  storeSlug: storeSlug ?? null,
+                }}
+                submission={{
+                  status: state,
+                  wantlistResult,
+                  errorMessage,
+                }}
+                handoffAvailable={handoffAvailable}
+                highlightOnMount={highlightOnMount}
+                onSendToWantlist={handleSendToWantlist}
+                onReset={resetResult}
+              />
+            )}
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
   );
 }

--- a/app/frontend/layouts/app_layout.test.tsx
+++ b/app/frontend/layouts/app_layout.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import AppLayout from "./app_layout";
 import type { Listing } from "@/types/inertia";
@@ -163,7 +163,9 @@ describe("AppLayout storefront chrome", () => {
     await user.click(trigger);
     await user.click(screen.getByRole("button", { name: "Close pile" }));
 
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
     expect(screen.getByTestId("storefront-background")).not.toHaveAttribute("inert");
     expect(trigger).toHaveFocus();
   });

--- a/app/frontend/layouts/app_layout.tsx
+++ b/app/frontend/layouts/app_layout.tsx
@@ -106,7 +106,7 @@ function AppHeader({
           <button
             type="button"
             onClick={() => setPileOpen(true)}
-            className="inline-flex min-h-10 items-center gap-2 rounded-md px-3 text-xs font-semibold text-mc-accent hover:bg-mc-accent/10 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
+            className="inline-flex min-h-10 items-center gap-2 rounded-md border border-mc-border bg-mc-bg-card px-3 text-xs font-semibold text-mc-accent hover:bg-mc-accent/10 hover:border-mc-accent/30 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-2 focus-visible:ring-offset-mc-bg"
             aria-label={`Pile (${pile.length})`}
             aria-expanded={pileOpen}
             aria-controls="pile-sheet"

--- a/docs/sidenotes.md
+++ b/docs/sidenotes.md
@@ -6,7 +6,8 @@ Quick-captured thoughts, ideas, and tasks collected during sessions.
 
 ## 2026-05-28
 
-- **Pile sheet exit animation missing** — The pile sheet slides in smoothly with a spring animation (`springDrawer`), but on close it disappears instantly with no exit transition. The drawer just vanishes instead of sliding back out, which feels jarring after the polished entry. Should add an exit animation (slide-out matching the entry direction) or a fade-out so the dismissal feels intentional rather than abrupt.
+- ~~**Pile sheet exit animation missing** — The pile sheet slides in smoothly with a spring animation (`springDrawer`), but on close it disappears instantly with no exit transition. The drawer just vanishes instead of sliding back out, which feels jarring after the polished entry. Should add an exit animation (slide-out matching the entry direction) or a fade-out so the dismissal feels intentional rather than abrupt.~~
+  ✅ *Resolved — Wrapped in `AnimatePresence` with `exit` animation reversing entry direction (backdrop fades out, drawer slides back down/right).*
 
 ## 2026-05-27
 
@@ -16,7 +17,8 @@ Quick-captured thoughts, ideas, and tasks collected during sessions.
 
 ## 2026-05-24
 
-- **Pile scope — global vs per-store** — The pile is currently global (same pile across all stores). When you browse a different store, the pile carries over. This is either a bug or a feature. It could be confusing ("why are there records from Philadelphia Music on the betternowrecords page?") or it could be a useful cross-store collection feature ("I'm browsing everywhere and building one unified pile"). Need to decide: scope pile to the specific store, or lean into cross-store as a feature with appropriate UI to clarify what's in the pile and where it came from.
+- ~~**Pile scope — global vs per-store** — The pile is currently global (same pile across all stores). When you browse a different store, the pile carries over. This is either a bug or a feature. It could be confusing ("why are there records from Philadelphia Music on the betternowrecords page?") or it could be a useful cross-store collection feature ("I'm browsing everywhere and building one unified pile"). Need to decide: scope pile to the specific store, or lean into cross-store as a feature with appropriate UI to clarify what's in the pile and where it came from.~~
+  ✅ *Resolved — Decided: per-store pile with localStorage scoped to current store.*
 
 ## 2026-05-23
 


### PR DESCRIPTION
Two pile UX improvements:

- **Exit animation.** Pile sheet now slides back out on close (matching
  the entry direction) instead of vanishing instantly. Backdrop fades.
- **Button clarity.** The pile header button gained a border and card
  background so it clearly reads as a clickable button, not static text.

Test: existing pile sheet and layout tests pass (452 passing).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
