### PR TITLE
test: add Discogs inventory export fixture matching real export format

### DIFF
--- a/docs/.sidenotes-active.md
+++ b/docs/.sidenotes-active.md
@@ -1,4 +1,0 @@
-# Active Sidenote
-- **Date:** 2026-05-27
-- **Entry:** Inventory export fixtures for OAuth sync testing
-- **Started:** 2026-05-30

--- a/docs/.sidenotes-active.md
+++ b/docs/.sidenotes-active.md
@@ -1,0 +1,4 @@
+# Active Sidenote
+- **Date:** 2026-05-27
+- **Entry:** Inventory export fixtures for OAuth sync testing
+- **Started:** 2026-05-30

--- a/docs/sidenotes.md
+++ b/docs/sidenotes.md
@@ -12,5 +12,5 @@ Quick-captured thoughts, ideas, and tasks collected during sessions.
 ## 2026-05-27
 
 - **Freshness scoring shouldn't hard-code 3 points** — The current freshness value gives exactly 3 points. This should be a fine-tuned, emergent behavior instead. The model should learn to weigh recency appropriately based on data patterns, not a fixed multiplier. Needs experimentation to find the right approach (decay function, ML feature, etc.).
-- **Inventory export fixtures for OAuth sync testing** — Need to add a couple of fixture inventory exports that we can use to test the OAuth sync pipeline end-to-end. Options: create a dummy export from my single-listing store and pad it with synthetic data, or get a real export from an actual Discogs store. The fixture should cover edge cases (multiple conditions, sold items, images, etc.) so we can validate the full import pipeline without hitting the real Discogs API every time.
+
 

--- a/spec/fixtures/discogs_inventory_export.csv
+++ b/spec/fixtures/discogs_inventory_export.csv
@@ -1,0 +1,23 @@
+listing_id,artist,title,label,catno,format,release_id,status,price,listed,comments,media_condition,sleeve_condition,accept_offer,external_id,weight,format_quantity,location,quantity
+4173116577,Phillip White Hawk,The Returning Of The Medicine Horse,Sunhawk,28526,LP,11644978,For Sale,10.0,2026-05-22 18:50:41,"Great shape, slightly worn edges",Very Good Plus (VG+),Very Good Plus (VG+),N,,230,1,,1
+1001,Miles Davis,Kind of Blue,Columbia,CL 1355,Vinyl,2001,For Sale,25.0,2026-01-15 10:00:00,,Very Good Plus (VG+),Very Good Plus (VG+),N,,230,1,,1
+1002,John Coltrane,A Love Supreme,Impulse!,AS-77,Vinyl,2002,For Sale,40.0,2026-01-20 14:30:00,"Original pressing — stereo",Mint (M),Mint (M),N,,250,1,,1
+1003,Thelonious Monk,Brilliant Corners,Riverside,RLP-226,Vinyl,2003,For Sale,15.0,2026-02-01 09:00:00,,Very Good (VG),Very Good (VG),N,,230,1,,1
+1004,Bill Evans,Sunday at the Village Vanguard,Riverside,RLP-9376,Vinyl,2004,For Sale,30.0,2026-03-10 16:00:00,"Includes original insert",Very Good Plus (VG+),Very Good (VG),N,,240,1,,1
+1005,Alice Coltrane,Journey in Satchidananda,Impulse!,AS-9203,Vinyl,2005,For Sale,35.0,2026-03-15 11:00:00,,Very Good Plus (VG+),Very Good Plus (VG+),N,,230,1,,1
+1006,Nina Simone,I Put a Spell on You,Philips,PHS 600-172,Vinyl,2006,For Sale,12.0,2026-04-01 08:00:00,"Light crackle on side A",Good Plus (G+),Good Plus (G+),N,,230,1,,1
+1007,Can,Tago Mago,"United Artists",UAS-29211,"Vinyl, LP, Reissue",2007,For Sale,22.0,2026-04-10 14:00:00,,Very Good (VG),Good Plus (G+),N,,240,1,,1
+1008,King Tubby,"King Tubby Meets Rockers Uptown",Clocktower,CT-001,"Vinyl, LP",2008,For Sale,18.0,2026-04-12 12:00:00,"Minimal surface noise",Very Good Plus (VG+),Very Good (VG),N,,230,1,,1
+1009,Ornette Coleman,The Shape of Jazz to Come,Atlantic,SD 1317,Vinyl,2009,For Sale,28.0,2026-04-20 15:00:00,,Very Good Plus (VG+),Very Good Plus (VG+),N,,230,1,,1
+1010,Fela Kuti,Expensive Shit,Soundworkshop,SW-001,Vinyl,2010,For Sale,45.0,2026-05-01 10:00:00,"Nigerian pressing — rare",Mint (M),Mint (M),N,,250,1,,1
+2001,Erykah Badu,Baduizm,Kedar,KD-9007,CD,3001,For Sale,8.0,2026-01-18 12:00:00,,Very Good Plus (VG+),Very Good (VG),N,,110,1,,1
+2002,Daft Punk,Discovery,Virgin,724381,CD,3002,For Sale,12.0,2026-02-20 13:00:00,,Mint (M),Mint (M),N,,110,1,,1
+2003,The Beatles,The White Album,Apple,PCS 7067,"Box Set, LP",3003,For Sale,60.0,2026-03-05 11:00:00,"Includes poster",Very Good (VG),Very Good (VG),N,,540,1,,1
+3001,Led Zeppelin,Led Zeppelin IV,Atlantic,SD 7208,Vinyl,4001,Sold,35.0,2025-12-01 10:00:00,,Very Good Plus (VG+),Very Good Plus (VG+),N,,230,1,,1
+3002,Pink Floyd,Dark Side of the Moon,Harvest,SHVL 804,Vinyl,4002,Sold,20.0,2025-11-15 09:00:00,"Original UK press",Very Good (VG),Very Good (VG),N,,230,1,,1
+3003,David Bowie,Hunky Dory,RCA,RCA-4623,Vinyl,4003,Draft,25.0,2025-10-20 14:00:00,,Very Good Plus (VG+),Very Good (VG),N,,230,1,,1
+3004,"The Velvet Underground","The Velvet Underground & Nico",Verve,V6-5008,Vinyl,4004,Expired,50.0,2025-09-10 12:00:00,"Tattersall cover — no banana sticker",Good (G),Fair (F),N,,230,1,,1
+4001,Radiohead,OK Computer,Parlophone,CDP 7243,CD,5001,Draft,10.0,2026-01-25 10:00:00,,Very Good Plus (VG+),Very Good Plus (VG+),N,,110,1,,1
+4002,Madonna,Like a Virgin,Sire,W1-25157,Cassette,5002,For Sale,4.0,2026-03-30 16:00:00,,Very Good (VG),Very Good (VG),N,,90,1,,1
+4003,U2,The Joshua Tree,Island,CID-112,VHS,5003,For Sale,3.0,2026-04-05 14:00:00,,Good (G),Good (G),N,,90,1,,1
+5001,John Zohr,Untitled Noise Project,Self-Released,,7 Inch Vinyl,6001,For Sale,8.0,2026-05-15 12:00:00,"Hand-numbered edition of 50",Mint (M),Mint (M),N,,120,1,,1

--- a/spec/support/inventory_export_fixtures.rb
+++ b/spec/support/inventory_export_fixtures.rb
@@ -1,0 +1,9 @@
+module InventoryExportFixtures
+  def discogs_inventory_export_csv
+    file_fixture("discogs_inventory_export.csv").read
+  end
+end
+
+RSpec.configure do |config|
+  config.include InventoryExportFixtures
+end


### PR DESCRIPTION
## Summary

OAuth sync tests now have a reusable Discogs inventory export fixture in the real 19-column format, seeded with the actual lil_blizzard store record. The 22-row CSV covers edge cases — sold/draft/expired statuses, CD/cassette/VHS formats, multiple media conditions, and fields with commas — so the full sync pipeline (CsvParser → RecordFilter → InventoryUpdater) can be tested without hitting the Discogs API.

A helper (`InventoryExportFixtures#discogs_inventory_export_csv`) is available in any spec via `file_fixture` or the included module.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_3.7_Sonnet_%28200K%29-D97757?logo=claude&logoColor=white)
