### PR TITLE
docs: codify storefront experience model

### DIFF
--- a/docs/brainstorms/2026-05-31-storefront-experience-language-requirements.md
+++ b/docs/brainstorms/2026-05-31-storefront-experience-language-requirements.md
@@ -1,0 +1,113 @@
+---
+date: 2026-05-31
+topic: storefront-experience-language
+reconstructed: true
+---
+
+# Storefront Experience Language Requirements
+
+## Summary
+
+Milkcrate needs one product model for the shopper-facing storefront: store,
+wall, crate, record, pile, and Discogs handoff are connected moments in the
+same browsing session. This language should guide product copy, design
+hierarchy, accessibility labels, and future UI issues without forcing backend,
+service, or Discogs integration renames.
+
+This document was reconstructed from the preserved issue bodies for #215,
+#216, and #217 after the original untracked brainstorm artifact was removed.
+
+---
+
+## Problem Frame
+
+The product already has strong backend and integration confidence around seller
+inventory, shopper piles, OAuth, Wantlist handoff, and listing links. The
+current confidence gap is frontend cohesion: shoppers should feel as if they
+entered one record store session, not a set of separate page tools.
+
+The language model should make that session legible. Store, wall, crate,
+record, pile, and handoff are the nouns that clarify the loop. "Register" is
+not a primary shopper-facing noun because Milkcrate does not provide checkout.
+
+---
+
+## Core Vocabulary
+
+- **Store:** The owned storefront context. It orients the shopper to the
+  seller, tone, current browsing surfaces, and available handoff.
+- **Wall:** The curated Milkcrate Picks surface. It behaves like a store wall:
+  a quick read on taste and a distinct entry into browsing.
+- **Crate:** The immersive browsing mode. It is the center of the product loop
+  and should not collapse into a generic menu or filter set.
+- **Record:** The inspection unit. It carries cover, artist, title, price,
+  notes, and the decision to keep browsing or add to the pile.
+- **Pile:** The persistent shopper-intent layer. It collects records without
+  claiming reservation, cart behavior, or checkout.
+- **Handoff:** The moment Milkcrate sends intent to Discogs. Product copy can
+  call this a handoff, while integration code should keep precise Discogs names
+  such as OAuth, Wantlist, listing, release, and seller.
+
+---
+
+## Requirements
+
+- R1. Shopper-facing copy uses store, wall, crate, record, pile, and handoff
+  where those nouns clarify the browsing loop.
+- R2. The app does not use "register" as a primary shopper-facing noun because
+  Milkcrate does not provide checkout.
+- R3. Store floor, crate browsing, record inspection, pile review, and Discogs
+  handoff feel like connected moments in one storefront session.
+- R4. Transitions preserve context and shopper intent when entering a crate,
+  inspecting a record, adding to the pile, opening the pile, returning to
+  browse, or leaving for Discogs.
+- R5. Mobile-first means the compact sequence defines the product hierarchy,
+  not that mobile is the only designed environment.
+- R6. Desktop and larger layouts adapt outward by revealing context, previews,
+  and parallel inspection while preserving the same loop, vocabulary, and
+  state model.
+- R7. Frontend confidence is evaluated at the system level across hierarchy,
+  copy, motion, affordance, responsive adaptation, and accessibility before
+  isolated component polish drives the roadmap.
+- R8. Presentation code may use tactile product language, but Discogs
+  integration code keeps precise external-system names.
+- R9. Changes prefer targeted hierarchy docs, copy, aria-label, and test
+  updates before broader component or data-model renames.
+- R10. Each follow-up issue is independently shippable and testable.
+
+---
+
+## Acceptance Examples
+
+- AE1. Canonical product and design docs explain store, wall, crate, record,
+  pile, handoff, and the decision not to use register as a primary shopper
+  noun.
+- AE2. A frontend audit can evaluate the whole store loop at compact and larger
+  breakpoints without reopening stable backend OAuth, Wantlist, seller filter,
+  or listing-link behavior.
+- AE3. A hierarchy spec can explain how StoreFloor, CrateView, RecordCard,
+  PileSheet, and AppLayout fit together on mobile, then adapt outward on larger
+  layouts without changing the product loop.
+- AE4. Follow-up UI work is prioritized by storefront continuity rather than by
+  easiest component edits.
+
+---
+
+## Scope Boundaries
+
+- No backend, service object, OAuth, Wantlist, seller filter, or Discogs API
+  rename is implied.
+- No immediate visual redesign is required by this vocabulary work.
+- No checkout, cart, reservation, or purchase-completion claim is introduced.
+- No desktop-only or mobile-only hierarchy is introduced; compact hierarchy is
+  the source sequence and larger screens adapt from it.
+
+---
+
+## Issue Decomposition
+
+- #215 documents the unified storefront experience model in canonical
+  product/design docs.
+- #216 audits the shopper-facing frontend as one unified storefront system.
+- #217 defines the mobile-first adaptive store page hierarchy and surface
+  relationships.

--- a/docs/design-system/patterns.md
+++ b/docs/design-system/patterns.md
@@ -61,6 +61,23 @@ record, crate, score, connection, and pile behavior. Dialog lifecycle, shopper
 connection, browsing, Wantlist handoff, and tactile interaction remain owned by
 their existing domain-facing components.
 
+The storefront product model is a single session: store orientation, wall,
+crate, record, pile, and Discogs handoff. Storefront presentation may use this
+tactile language in headings, controls, and aria labels when it clarifies
+shopper intent. Integration-facing code keeps precise Discogs names such as
+OAuth, Wantlist, listing, release, and seller.
+
+"Register" is not a primary shopper-facing noun. The pile is an intent layer,
+not a cart, reservation, register, or checkout. Handoff language should make
+clear that Milkcrate preserves browsing context and sends the shopper to
+Discogs for the external action.
+
+Compact hierarchy is the source sequence. Larger tiers reveal context,
+previews, and parallel inspection from the same state model rather than
+inventing a separate desktop product. Review storefront changes as a system
+across hierarchy, copy, motion, affordance, responsive adaptation, and
+accessibility before treating local component polish as the main risk.
+
 Implemented composition:
 
 - `AppLayout` and the store route render flash and sync lifecycle states with

--- a/docs/design.md
+++ b/docs/design.md
@@ -114,6 +114,37 @@ This system explicitly rejects: Discogs-style data density, SaaS-generic blue-an
 - Spring-based motion, reduced-motion first
 - Every interaction lands with weight
 
+## 1.1 Unified Storefront Experience
+
+The storefront is designed as one connected browsing session. The shopper
+enters a store, reads the wall for taste, enters a crate, inspects a record,
+adds intent to the pile, reviews that pile, and leaves through a Discogs
+handoff. These are not separate tools competing for attention; they are
+moments in the same loop.
+
+Use the core nouns where they clarify the experience:
+
+- **Store:** The seller's owned environment and orientation layer.
+- **Wall:** The Milkcrate Picks surface, a quick read on the store's taste.
+- **Crate:** The immersive browsing surface.
+- **Record:** The inspection object.
+- **Pile:** The persistent shopper-intent layer.
+- **Handoff:** The transition from Milkcrate browsing to Discogs action.
+
+"Register" is not a primary shopper-facing noun because Milkcrate does not
+provide checkout. Presentation code and copy may use tactile store language,
+but Discogs integration boundaries should keep exact external-system names:
+OAuth, Wantlist, listing, release, seller, and related API terms.
+
+Mobile-first means the compact sequence is the source hierarchy, not the only
+designed environment. Comfy, wide, and larger layouts adapt outward from that
+sequence by revealing more context, previews, and parallel inspection while
+preserving the same vocabulary and state model.
+
+Before polishing isolated components, evaluate storefront confidence across
+hierarchy, copy, motion, affordance, responsive adaptation, and accessibility.
+The current product risk is whether the shopper loop feels cohesive.
+
 ## 2. Colors
 
 The palette splits across two themes. Dark mode (default) uses deep charcoals and oxblood red. Light mode uses warm kraft-paper tones and amber. Both share the same neutral family — warm browns — tinted away from pure black or white.

--- a/docs/plans/2026-06-01-001-feat-storefront-experience-language-issues-plan.md
+++ b/docs/plans/2026-06-01-001-feat-storefront-experience-language-issues-plan.md
@@ -1,0 +1,209 @@
+---
+title: "feat: Codify unified storefront experience language"
+type: feat
+status: active
+date: 2026-06-01
+origin: docs/brainstorms/2026-05-31-storefront-experience-language-requirements.md
+reconstructed: true
+---
+
+# feat: Codify Unified Storefront Experience Language
+
+## Summary
+
+Split the storefront experience language work into independently shippable
+issues. The product model treats store, wall, crate, record, pile, and Discogs
+handoff as one connected browsing session, while keeping precise Discogs names
+at integration boundaries.
+
+This plan was reconstructed from the preserved issue bodies for #215, #216,
+and #217 after the original untracked plan artifact was removed.
+
+---
+
+## Problem Frame
+
+Milkcrate's current backend and integration work is substantially clearer than
+the frontend product model that connects the shopper journey. Future work needs
+a canonical source for the storefront vocabulary and a deliberate sequence for
+turning that vocabulary into audit and hierarchy work.
+
+---
+
+## Scope Boundaries
+
+- Do not rename backend models, services, controllers, or Discogs integration
+  concepts as part of this language work.
+- Do not introduce checkout, cart, reservation, or purchase-completion claims.
+- Do not treat mobile-first as mobile-only.
+- Do not start with isolated component polish before the storefront loop is
+  evaluated as a system.
+
+---
+
+## Implementation Units
+
+### U1: Document the unified storefront experience model
+
+**Issue:** #215
+
+**Goal:** Make the experience model discoverable outside the brainstorm
+artifact so future work treats store, wall, crate, record, pile, and handoff as
+one connected session.
+
+**Requirements:**
+
+- Shopper-facing copy uses the core nouns store, wall, crate, record, pile, and
+  handoff where they clarify the browsing loop.
+- The app does not use "register" as a primary shopper-facing noun because
+  Milkcrate does not provide checkout.
+- Store floor, crate browsing, record inspection, pile review, and Discogs
+  handoff feel like connected moments in one storefront session.
+- Transitions preserve context and shopper intent when entering a crate,
+  inspecting a record, adding to the pile, opening the pile, returning to
+  browse, or leaving for Discogs.
+- Mobile-first means the compact sequence defines the product hierarchy, not
+  that mobile is the only designed environment.
+- Desktop and larger layouts adapt outward by revealing context, previews, and
+  parallel inspection while preserving the same loop, vocabulary, and state
+  model.
+- Frontend confidence is evaluated at the system level across hierarchy, copy,
+  motion, affordance, responsive adaptation, and accessibility before isolated
+  component polish drives the roadmap.
+- Presentation code may use tactile product language, but Discogs integration
+  code keeps precise external-system names.
+- Changes prefer targeted hierarchy docs, copy, aria-label, and test updates
+  before broader component or data-model renames.
+
+**Files:**
+
+- Modify: `docs/product.md`
+- Modify: `docs/design.md`
+- Modify: `docs/design-system/patterns.md`
+- Reference: `docs/brainstorms/2026-05-31-storefront-experience-language-requirements.md`
+
+**Approach:**
+
+- Add a concise "Unified storefront experience" section to product/design
+  documentation.
+- Define store, wall, crate, record, pile, and handoff in product terms.
+- Define the flow principle: the storefront should feel like one browsing
+  session, not separate page tools.
+- Capture the responsive principle: mobile defines the sequence; larger
+  screens adapt that same sequence outward.
+- Capture the frontend confidence principle: hierarchy, copy, motion,
+  affordance, responsive adaptation, and accessibility should be reviewed
+  together.
+- Record the boundary rule: physical language in presentation, precise Discogs
+  language at integration boundaries.
+- Explicitly reject "register" as a shopper-facing primary noun.
+
+**Test Scenarios:**
+
+- Documentation scan: canonical docs mention the six core nouns and the
+  handoff/register decision.
+- Documentation scan: canonical docs describe the one-session flow and
+  mobile-first adaptive model.
+- Documentation scan: canonical docs identify frontend cohesion, not backend
+  comprehensiveness, as the current confidence gap.
+- Documentation scan: no absolute file paths are introduced.
+
+**Acceptance Criteria:**
+
+- A future implementer can find the storefront experience model without
+  reading the brainstorm transcript.
+- The docs make clear that mobile-first means source sequence, not mobile-only
+  design.
+- The docs make clear that this language does not require backend/service
+  renames.
+
+### U2: Audit the shopper-facing frontend as one storefront system
+
+**Issue:** #216
+
+**Goal:** Identify where the current frontend breaks the feeling of one
+continuous record-store experience before changing isolated components.
+
+**Dependencies:** Should follow U1 so the canonical vocabulary is available.
+
+**Files:**
+
+- Create: a frontend cohesion audit under `docs/brainstorms/` or
+  `docs/reviews/`
+- Reference: `docs/product.md`
+- Reference: `docs/design.md`
+- Reference: `docs/brainstorms/2026-05-31-storefront-experience-language-requirements.md`
+- Reference: `app/frontend/pages/stores/show.tsx`
+- Reference: `app/frontend/components/store_floor.tsx`
+- Reference: `app/frontend/components/crate_view.tsx`
+- Reference: `app/frontend/components/record_card.tsx`
+- Reference: `app/frontend/components/record_details.tsx`
+- Reference: `app/frontend/components/pile_sheet.tsx`
+- Reference: `app/frontend/layouts/app_layout.tsx`
+
+**Approach:**
+
+- Audit the mobile shopper journey from store landing through Wall, crate,
+  record, pile, and Discogs handoff.
+- Score each transition for hierarchy, continuity, tactile affordance, copy,
+  responsive adaptation, accessibility, and conversion clarity.
+- Separate backend/integration confidence from frontend experience confidence
+  so the audit does not reopen sound backend work.
+- Identify the smallest frontend issues that would most improve the feeling of
+  one unified storefront.
+- Use the audit to validate whether downstream issues are still in the right
+  order.
+
+**Acceptance Criteria:**
+
+- The team can name the top frontend cohesion gaps with evidence.
+- The audit explains why Wall, crate, record, pile, and handoff do or do not
+  feel like one experience today.
+- Follow-up UI issues are prioritized by storefront continuity, not by easiest
+  component edits.
+
+### U3: Define the mobile-first adaptive store hierarchy
+
+**Issue:** #217
+
+**Goal:** Make the compact storefront IA explicit as the source sequence, then
+define how that same sequence adapts outward on larger screens.
+
+**Dependencies:** Should follow U2 so the hierarchy work is grounded in the
+frontend cohesion audit.
+
+**Files:**
+
+- Create or modify: a storefront mobile hierarchy requirements doc under
+  `docs/brainstorms/`
+- Modify if needed: `docs/brainstorms/2026-05-31-storefront-experience-language-requirements.md`
+- Reference: `app/frontend/pages/stores/show.tsx`
+- Reference: `app/frontend/components/store_floor.tsx`
+- Reference: `app/frontend/components/crate_view.tsx`
+- Reference: `app/frontend/layouts/app_layout.tsx`
+- Reference: `app/frontend/components/pile_sheet.tsx`
+
+**Approach:**
+
+- Define the compact storefront as a set of modes: store orientation,
+  Wall/Milkcrate Picks entry, crate entry, active crate browsing, record
+  inspection, pile review, and Discogs handoff.
+- Specify each mode's job, primary content, persistent controls, and transition
+  into the next mode.
+- Identify which current components own each mode today and where the current
+  hierarchy is unclear or duplicated.
+- Produce a low-fidelity content order for compact screens, without committing
+  to a visual redesign.
+- Define how desktop and larger environments adapt the same sequence outward
+  through context, previews, and parallel inspection.
+- Keep desktop expansion as a secondary adaptation of the same hierarchy, not
+  a separate product model.
+
+**Acceptance Criteria:**
+
+- A future implementer can explain how StoreFloor, CrateView, RecordCard,
+  PileSheet, and AppLayout fit together on mobile.
+- A future implementer can explain how the same pieces adapt on desktop or
+  larger layouts without changing the product loop.
+- The hierarchy spec does not require immediate visual redesign or backend
+  changes.

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,8 +1,32 @@
 # Product
 
-## Register
+## Unified Storefront Experience
 
-product
+Milkcrate is one connected storefront session, not a set of separate page
+tools. The shopper moves through a store, reads the wall for taste, enters a
+crate, inspects a record, adds intent to the pile, and leaves through a
+Discogs handoff when they are ready to act.
+
+Core shopper-facing nouns:
+
+- **Store:** The seller's owned space and browsing context.
+- **Wall:** The curated Milkcrate Picks surface that previews the store's
+  taste.
+- **Crate:** The immersive browsing mode and primary interaction.
+- **Record:** The unit of inspection and decision.
+- **Pile:** The shopper's persistent intent layer, not a cart and not a
+  checkout claim.
+- **Handoff:** The transition from Milkcrate intent to Discogs action.
+
+Do not use "register" as a primary shopper-facing noun. Milkcrate does not
+provide checkout. Shopper copy can use tactile store language, while Discogs
+integration code keeps precise external-system names such as OAuth, Wantlist,
+listing, release, and seller.
+
+Mobile-first means the compact sequence defines the product hierarchy. Desktop
+and larger layouts adapt that sequence outward by revealing context, previews,
+and parallel inspection while preserving the same loop, vocabulary, and state
+model.
 
 ## Users
 
@@ -34,6 +58,17 @@ Three words: warm, curious, tactile.
 3. **Record store warmth.** Physical, textured, tangible. Dark warm tones, serif type, the feeling of being in a shop at golden hour.
 4. **Digger's delight.** Reward exploration. Every interaction should surface something surprising. No dead ends.
 5. **Owner's character.** Each storefront feels like the store's own space. Premium tier unlocks customization that lets a store's personality come through. Never a white-label template.
+6. **One storefront loop.** Store floor, wall, crate, record, pile, and Discogs handoff should preserve context and shopper intent as one continuous browsing session.
+
+## Frontend Confidence
+
+Evaluate shopper-facing frontend confidence at the system level before
+prioritizing isolated component polish. The current gap is cohesion across
+hierarchy, copy, motion, affordance, responsive adaptation, and accessibility,
+not backend comprehensiveness.
+
+Targeted hierarchy docs, copy, aria-label, and test updates are preferred
+before broader component or data-model renames.
 
 ## Accessibility & Inclusion
 


### PR DESCRIPTION
## Summary

Future storefront work can now find the unified shopper experience model in canonical product and design docs instead of reconstructing it from planning artifacts. The docs define store, wall, crate, record, pile, and Discogs handoff as one connected browsing loop, reject "register" as a primary shopper-facing noun, and clarify that mobile-first means source sequence rather than mobile-only design.

This also keeps the reconstructed brainstorm and implementation plan on the branch so the issue source stays discoverable.

Closes body-clock/milkcrate#215.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `rg -n '/Users|/private|/home|C:\\' docs/product.md docs/design.md docs/design-system/patterns.md docs/brainstorms/2026-05-31-storefront-experience-language-requirements.md docs/plans/2026-06-01-001-feat-storefront-experience-language-issues-plan.md`
- `rg -n '^## Register|Register$' docs/product.md docs/design.md docs/design-system/patterns.md`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)