### PR TITLE
feat(storefront): close mobile hierarchy gaps G1-G6

### DIFF
--- a/app/frontend/components/crate_card.test.tsx
+++ b/app/frontend/components/crate_card.test.tsx
@@ -1,12 +1,12 @@
-import React from "react"
-import { describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import CrateCard from "./crate_card"
-import StorefrontMotionConfig from "./storefront_motion_config"
-import { PileProvider } from "../contexts/pile_context"
-import { ViewportProvider } from "../contexts/viewport_context"
-import type { Crate, Listing } from "../types/inertia"
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CrateCard from "./crate_card";
+import StorefrontMotionConfig from "./storefront_motion_config";
+import { PileProvider } from "../contexts/pile_context";
+import { ViewportProvider } from "../contexts/viewport_context";
+import type { Crate, Listing } from "../types/inertia";
 
 const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
   id: 1,
@@ -26,7 +26,7 @@ const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
   notes: null,
   discogs_url: "https://www.discogs.com/sell/item/1",
   ...overrides,
-})
+});
 
 const makeCrate = (overrides: Partial<Crate> = {}): Crate => ({
   slug: "test-crate",
@@ -39,197 +39,207 @@ const makeCrate = (overrides: Partial<Crate> = {}): Crate => ({
     makeListing({ id: 4, title: "Record 4" }),
   ],
   ...overrides,
-})
+});
 
 const renderCard = (ui: React.ReactElement) =>
   render(
     <StorefrontMotionConfig>
       <ViewportProvider>
-        <PileProvider>
-          {ui}
-        </PileProvider>
+        <PileProvider>{ui}</PileProvider>
       </ViewportProvider>
     </StorefrontMotionConfig>,
-  )
+  );
 
 describe("CrateCard", () => {
   describe("rendering", () => {
     it("renders crate name", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
-      expect(screen.getByText("Test Crate")).toBeInTheDocument()
-    })
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
+      expect(screen.getByText("Test Crate")).toBeInTheDocument();
+    });
 
     it("renders record count", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
       // Count is 4, shown in CrateShelf
-      expect(screen.getByText("4")).toBeInTheDocument()
-    })
+      expect(screen.getByText("4")).toBeInTheDocument();
+    });
 
     it("renders open label 'DIG →'", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
-      expect(screen.getByText("DIG →")).toBeInTheDocument()
-    })
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
+      expect(screen.getByText("DIG →")).toBeInTheDocument();
+    });
 
     it("renders featured variant with larger header text", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="featured" onSelectCrate={vi.fn()} />)
-      const nameEl = screen.getByText("Test Crate")
-      expect(nameEl.className).toContain("text-base")
-      expect(nameEl.className).toContain("font-semibold")
-    })
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="featured" onSelectCrate={vi.fn()} />);
+      const nameEl = screen.getByText("Test Crate");
+      expect(nameEl.className).toContain("text-base");
+      expect(nameEl.className).toContain("font-semibold");
+    });
 
     it("renders genre variant with smaller header text", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
-      const nameEl = screen.getByText("Test Crate")
-      expect(nameEl.className).toContain("text-sm")
-      expect(nameEl.className).toContain("font-semibold")
-    })
-  })
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
+      const nameEl = screen.getByText("Test Crate");
+      expect(nameEl.className).toContain("text-sm");
+      expect(nameEl.className).toContain("font-semibold");
+    });
+  });
 
   describe("empty state", () => {
     it("shows 'No records yet' when crate has no records", () => {
-      const crate = makeCrate({ count: 0, records: [] })
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
-      expect(screen.getByText("No records yet")).toBeInTheDocument()
-    })
+      const crate = makeCrate({ count: 0, records: [] });
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
+      expect(screen.getByText("No records yet")).toBeInTheDocument();
+    });
 
     it("does not render record tiles for empty crate", () => {
-      const crate = makeCrate({ count: 0, records: [] })
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      const crate = makeCrate({ count: 0, records: [] });
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
       // Only the header button should exist (no thumbnail buttons)
-      expect(screen.queryAllByRole("button", { name: /Open.*at Record/ })).toHaveLength(0)
-    })
-  })
+      expect(screen.queryAllByRole("button", { name: /Open.*at Record/ })).toHaveLength(0);
+    });
+  });
 
   describe("keyboard interaction", () => {
     it("fires onSelectCrate with slug on header Enter key", async () => {
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />);
 
-      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" })
-      headerBtn.focus()
-      await userEvent.keyboard("{Enter}")
+      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" });
+      headerBtn.focus();
+      await userEvent.keyboard("{Enter}");
 
-      expect(onSelectCrate).toHaveBeenCalledWith("test-crate")
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate");
+    });
 
     it("fires onSelectCrate with slug on header Space key", async () => {
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />);
 
-      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" })
-      headerBtn.focus()
-      await userEvent.keyboard(" ")
+      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" });
+      headerBtn.focus();
+      await userEvent.keyboard(" ");
 
-      expect(onSelectCrate).toHaveBeenCalledWith("test-crate")
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate");
+    });
 
     it("does not fire when keyboard target is a nested button", async () => {
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />);
 
       // Focus a thumbnail button (which is a nested <button> inside the shelf)
-      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 1" })
-      thumbBtn.focus()
-      await userEvent.keyboard("{Enter}")
+      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 1" });
+      thumbBtn.focus();
+      await userEvent.keyboard("{Enter}");
 
       // The thumbnail button's click handler fires, not the header's keyboard
-      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 0)
-    })
-  })
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 0);
+    });
+  });
 
   describe("thumbnail interaction", () => {
     it("fires onSelectCrate with slug and index on thumbnail click", async () => {
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />);
 
-      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 1" })
-      await userEvent.click(thumbBtn)
+      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 1" });
+      await userEvent.click(thumbBtn);
 
-      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 0)
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 0);
+    });
 
     it("fires onSelectCrate with correct index for 2nd record", async () => {
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />);
 
-      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 2" })
-      await userEvent.click(thumbBtn)
+      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 2" });
+      await userEvent.click(thumbBtn);
 
-      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 1)
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 1);
+    });
 
     it("fires onSelectCrate with correct index for 4th record", async () => {
-      const onSelectCrate = vi.fn()
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />)
+      const onSelectCrate = vi.fn();
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={onSelectCrate} />);
 
-      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 4" })
-      await userEvent.click(thumbBtn)
+      const thumbBtn = screen.getByRole("button", { name: "Open Test Crate at Record 4" });
+      await userEvent.click(thumbBtn);
 
-      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 3)
-    })
+      expect(onSelectCrate).toHaveBeenCalledWith("test-crate", 3);
+    });
 
     it("renders 4 thumbnail buttons for crate with 4+ records", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
 
       // 4 thumbnail buttons + 1 header button
-      const buttons = screen.getAllByRole("button")
-      expect(buttons.length).toBe(5)
-    })
-  })
+      const buttons = screen.getAllByRole("button");
+      expect(buttons.length).toBe(5);
+    });
+  });
 
   describe("accessibility", () => {
     it("has accessible header button", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
 
-      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" })
-      expect(headerBtn).toHaveAttribute("tabindex", "0")
-    })
+      const headerBtn = screen.getByRole("button", { name: "Open Test Crate" });
+      // Native <button> is focusable by default — no tabIndex attribute needed
+      expect(headerBtn.tagName).toBe("BUTTON");
+      expect(headerBtn).not.toHaveAttribute("role", "button");
+    });
 
     it("thumbnail buttons have accessible names", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
 
-      expect(screen.getByRole("button", { name: "Open Test Crate at Record 1" })).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Open Test Crate at Record 2" })).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Open Test Crate at Record 3" })).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Open Test Crate at Record 4" })).toBeInTheDocument()
-    })
+      expect(
+        screen.getByRole("button", { name: "Open Test Crate at Record 1" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Open Test Crate at Record 2" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Open Test Crate at Record 3" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Open Test Crate at Record 4" }),
+      ).toBeInTheDocument();
+    });
 
     it("does not nest button elements inside button elements", () => {
-      const crate = makeCrate()
-      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      const crate = makeCrate();
+      renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />);
 
-      const buttons = document.querySelectorAll("button")
+      const buttons = document.querySelectorAll("button");
       buttons.forEach((btn) => {
-        expect(btn.querySelectorAll("button").length).toBe(0)
-      })
-    })
-  })
+        expect(btn.querySelectorAll("button").length).toBe(0);
+      });
+    });
+  });
 
   describe("tactile hover wrapper", () => {
     it("wraps CrateShelf in a div with pointer event handlers", () => {
-      const crate = makeCrate()
-      const { container } = renderCard(<CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />)
+      const crate = makeCrate();
+      const { container } = renderCard(
+        <CrateCard crate={crate} variant="genre" onSelectCrate={vi.fn()} />,
+      );
 
       // CrateCard wraps CrateShelf inside a div. The CrateShelf's own
       // root div has a rounded/border class, so we can verify the structure.
-      const shelfRoots = container.querySelectorAll('.rounded-lg.bg-mc-bg-card')
-      expect(shelfRoots.length).toBe(1)
+      const shelfRoots = container.querySelectorAll(".rounded-lg.bg-mc-bg-card");
+      expect(shelfRoots.length).toBe(1);
       // The CrateShelf header button should be inside this wrapper
-      expect(screen.getByRole("button", { name: "Open Test Crate" })).toBeInTheDocument()
-    })
-  })
-})
+      expect(screen.getByRole("button", { name: "Open Test Crate" })).toBeInTheDocument();
+    });
+  });
+});

--- a/app/frontend/components/crate_section_grid.tsx
+++ b/app/frontend/components/crate_section_grid.tsx
@@ -17,6 +17,8 @@ interface CrateSectionGridProps {
   onSelectCrate: (slug: string, startIndex?: number) => void;
   /** Optional gap size between grid items (Tailwind classes). Default: "gap-4". */
   gap?: string;
+  /** Optional short description of this section's job rendered below the title. */
+  description?: string;
 }
 
 /**
@@ -31,25 +33,30 @@ export default function CrateSectionGrid({
   columnCount,
   onSelectCrate,
   gap = "gap-4",
+  description,
 }: CrateSectionGridProps) {
   const { isCompact, isComfy } = useViewport();
 
   if (crates.length === 0) return null;
 
   const cols = columnCount(isCompact, isComfy);
+  const regionLabel = description ? `${title} — ${description}` : title;
 
   return (
-    <div>
+    <div role="region" aria-label={regionLabel}>
       <div className="flex items-center justify-between gap-2 border-b border-mc-border pb-2 mb-4">
         <span className="mc-section-name text-base font-semibold">{title}</span>
         <span className="mc-section-count">{count}</span>
       </div>
-      <div
-        className={`grid ${gap}`}
-        style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}
-      >
+      {description && <p className="text-xs text-mc-text-dim mb-3 -mt-2">{description}</p>}
+      <div className={`grid ${gap}`} style={{ gridTemplateColumns: `repeat(${cols}, 1fr)` }}>
         {crates.map((crate) => (
-          <CrateCard key={crate.slug} crate={crate} variant={variant} onSelectCrate={onSelectCrate} />
+          <CrateCard
+            key={crate.slug}
+            crate={crate}
+            variant={variant}
+            onSelectCrate={onSelectCrate}
+          />
         ))}
       </div>
     </div>

--- a/app/frontend/components/crate_shelf.test.tsx
+++ b/app/frontend/components/crate_shelf.test.tsx
@@ -184,7 +184,6 @@ describe("CrateShelf", () => {
 
       expect(onSelectCrate).toHaveBeenCalledWith("jazz-crate");
     });
-
   });
 
   describe("product-browsing variant", () => {
@@ -330,7 +329,6 @@ describe("CrateShelf", () => {
 
       expect(screen.getByRole("button", { name: "Open Jazz" })).toBeInTheDocument();
     });
-
   });
 
   describe("type contract", () => {
@@ -348,14 +346,16 @@ describe("CrateShelf", () => {
   });
 
   describe("accessibility", () => {
-    it("interactive header has tabIndex 0", () => {
+    it("interactive header is a native button and focusable by default", () => {
       const crate = makeCrate();
       const onSelectCrate = vi.fn();
 
       renderShelf(<CrateShelf crate={crate} interactive onSelectCrate={onSelectCrate} />);
 
       const button = screen.getByRole("button", { name: "Open Jazz" });
-      expect(button).toHaveAttribute("tabindex", "0");
+      // Native <button> is focusable by default — no tabIndex attribute needed
+      expect(button.tagName).toBe("BUTTON");
+      expect(button).not.toHaveAttribute("role", "button");
     });
 
     it("non-interactive mode has no interactive elements", () => {

--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -62,13 +62,13 @@ function CrateShelfLayout({
   header,
   interaction,
   grid,
-  headerProps: { className: headerClassName, ...headerProps },
+  headerProps: { className: headerClassName, as: HeaderTag = "div", ...headerProps },
 }: {
   crate: Crate;
   header: ShelfHeaderConfig;
   interaction: ShelfInteractionConfig;
   grid: ShelfGridConfig;
-  headerProps: React.HTMLAttributes<HTMLDivElement>;
+  headerProps: React.HTMLAttributes<HTMLElement> & { as?: "div" | "button" };
 }) {
   const { headerSize = "genre", meta, openLabel, previewCount } = header;
   const { interactive, onSelectCrate, isHovered, tactileThumbnails } = interaction;
@@ -102,9 +102,12 @@ function CrateShelfLayout({
   return (
     <>
       {/* Header */}
-      <div className={`px-3 pt-3 pb-1.5 ${headerClassName ?? ""}`} {...headerProps}>
+      <HeaderTag
+        className={`px-3 pt-3 pb-1.5 ${headerClassName ?? ""}`}
+        {...(headerProps as React.HTMLAttributes<HTMLElement>)}
+      >
         {headerContent}
-      </div>
+      </HeaderTag>
 
       {/* Record grid */}
       {crate.records.length > 0 ? (
@@ -223,14 +226,6 @@ function InteractiveCrateShelf(params: InteractiveCrateShelfProps) {
     onSelectCrate?.(crate.slug);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if ((e.target as HTMLElement).closest("button, a")) return;
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleSelectCrate();
-    }
-  };
-
   return (
     <motion.div
       className={containerClassName}
@@ -246,10 +241,8 @@ function InteractiveCrateShelf(params: InteractiveCrateShelfProps) {
         interaction={{ interactive: true, onSelectCrate, isHovered, tactileThumbnails }}
         grid={{ gridCols }}
         headerProps={{
-          role: "button",
-          tabIndex: 0,
+          as: "button",
           onClick: handleSelectCrate,
-          onKeyDown: handleKeyDown,
           className:
             "cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mc-focus focus-visible:ring-offset-1 focus-visible:ring-offset-mc-bg-card",
           "aria-label": `Open ${crate.name}`,

--- a/app/frontend/components/crate_view.test.tsx
+++ b/app/frontend/components/crate_view.test.tsx
@@ -508,11 +508,11 @@ describe("CrateView", () => {
     const stack = screen.getByTestId("crate-stack");
     expect(stack).toBeInTheDocument();
 
-    // Verify hint cards are positioned at the expected offsets inside the stack
-    const stackContainer = stack.firstElementChild;
-    expect(stackContainer).not.toBeNull();
+    // Hint cards live inside the relative positioned container within the flex wrapper
+    const relativeContainer = stack.firstElementChild!.firstElementChild;
+    expect(relativeContainer).not.toBeNull();
     // Should have multiple child elements for hint cards
-    expect(stackContainer!.children.length).toBeGreaterThan(1);
+    expect(relativeContainer!.children.length).toBeGreaterThan(1);
   });
 
   it("renders active card with thumbnail backdrop when thumbnail_url is present", () => {

--- a/app/frontend/components/crate_view.test.tsx
+++ b/app/frontend/components/crate_view.test.tsx
@@ -1,13 +1,13 @@
-import { describe, expect, it, vi } from "vitest"
-import { screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import CrateView from "./crate_view"
-import { GHOST_FINGER_CUE_TEST_ID } from "./ghost_finger_cue"
-import StorefrontMotionConfig from "./storefront_motion_config"
-import { RIFFLE_LANGUAGE } from "@/lib/riffle_navigation"
-import { PileProvider } from "@/contexts/pile_context"
-import { renderWithTier } from "@/test/viewport-test-utils"
-import type { Crate, Listing } from "../types/inertia"
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CrateView from "./crate_view";
+import { GHOST_FINGER_CUE_TEST_ID } from "./ghost_finger_cue";
+import StorefrontMotionConfig from "./storefront_motion_config";
+import { RIFFLE_LANGUAGE } from "@/lib/riffle_navigation";
+import { PileProvider } from "@/contexts/pile_context";
+import { renderWithTier } from "@/test/viewport-test-utils";
+import type { Crate, Listing } from "../types/inertia";
 
 const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
   id: 1,
@@ -27,7 +27,7 @@ const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
   notes: null,
   discogs_url: "https://www.discogs.com/sell/item/1",
   ...overrides,
-})
+});
 
 const makeCrates = (): Crate[] => [
   {
@@ -44,210 +44,241 @@ const makeCrates = (): Crate[] => [
     slug: "rock",
     name: "Rock",
     count: 1,
-    records: [
-      makeListing({ id: 4, title: "Rock Record", artist: "Four" }),
-    ],
+    records: [makeListing({ id: 4, title: "Rock Record", artist: "Four" })],
   },
-]
+];
 
-function renderCrateView(tier: "compact" | "comfy" | "wide", props: Partial<React.ComponentProps<typeof CrateView>> = {}) {
+function renderCrateView(
+  tier: "compact" | "comfy" | "wide",
+  props: Partial<React.ComponentProps<typeof CrateView>> = {},
+) {
   const defaultProps: React.ComponentProps<typeof CrateView> = {
     crates: makeCrates(),
     activeSlug: "jazz",
     onSelectCrate: vi.fn(),
     onBack: vi.fn(),
     ...props,
-  }
+  };
 
   return {
-    ...renderWithTier(tier, (
+    ...renderWithTier(
+      tier,
       <StorefrontMotionConfig>
         <PileProvider>
           <CrateView {...defaultProps} />
         </PileProvider>
-      </StorefrontMotionConfig>
-    )),
+      </StorefrontMotionConfig>,
+    ),
     props: defaultProps,
-  }
+  };
 }
 
 describe("CrateView", () => {
   beforeEach(() => {
-    sessionStorage.clear()
-  })
+    sessionStorage.clear();
+  });
 
   it("renders a compact mobile header with active crate context", () => {
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument()
-    expect(screen.getByText("3 records")).toBeInTheDocument()
-    expect(screen.queryByText("Independent record store in South Philly.")).not.toBeInTheDocument()
-  })
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument();
+    expect(screen.getByText("3 records")).toBeInTheDocument();
+    expect(screen.queryByText("Independent record store in South Philly.")).not.toBeInTheDocument();
+  });
 
   it("leaves compact tabs and browsing controls in content when the storefront header owns crate identity", () => {
-    renderCrateView("compact", { compactHeaderOwnedByLayout: true })
+    renderCrateView("compact", { compactHeaderOwnedByLayout: true });
 
-    expect(screen.queryByRole("button", { name: "Back to store" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("heading", { name: "Jazz" })).not.toBeInTheDocument()
-    expect(screen.getByRole("tablist", { name: "Crates" })).toBeInTheDocument()
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    expect(screen.queryByRole("button", { name: "Back to store" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Jazz" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tablist", { name: "Crates" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   it("keeps desktop details visible on wide viewports", () => {
-    renderCrateView("wide")
+    renderCrateView("wide");
 
-    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
-    expect(screen.getAllByText("One").length).toBeGreaterThan(1)
-    const discogsLinks = screen.getAllByRole("link", { name: /Discogs/ })
-    expect(discogsLinks.length).toBeGreaterThan(1)
-    discogsLinks.forEach((link) => expect(link).toHaveClass("focus-visible:ring-mc-focus"))
-  })
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument();
+    expect(screen.getAllByText("One").length).toBeGreaterThan(1);
+    // On wide, flip is disabled on the card, so only RecordDetails exposes the Discogs link
+    const discogsLink = screen.getByRole("link", { name: /Discogs/ });
+    expect(discogsLink).toHaveClass("focus-visible:ring-mc-focus");
+  });
 
   it("renders score direction using semantic success and danger roles", () => {
-    const crates = makeCrates()
+    const crates = makeCrates();
     crates[0].records[0] = makeListing({
       id: 1,
       score_breakdown: { freshness: 2, noise: -1 },
-    })
+    });
 
-    renderCrateView("wide", { crates })
+    renderCrateView("wide", { crates });
 
-    expect(screen.getByText("+2.0")).toHaveClass("text-mc-feedback-success")
-    expect(screen.getByText("-1.0")).toHaveClass("text-mc-feedback-danger")
-    expect(screen.getByText(/^\+?1\.0$/)).toHaveClass("text-mc-feedback-success")
-  })
+    expect(screen.getByText("+2.0")).toHaveClass("text-mc-feedback-success");
+    expect(screen.getByText("-1.0")).toHaveClass("text-mc-feedback-danger");
+    expect(screen.getByText(/^\+?1\.0$/)).toHaveClass("text-mc-feedback-success");
+  });
 
   it("calls onBack from the compact back control", async () => {
-    const user = userEvent.setup()
-    const onBack = vi.fn()
+    const user = userEvent.setup();
+    const onBack = vi.fn();
 
-    renderCrateView("compact", { onBack })
+    renderCrateView("compact", { onBack });
 
-    await user.click(screen.getByRole("button", { name: "Back to store" }))
+    await user.click(screen.getByRole("button", { name: "Back to store" }));
 
-    expect(onBack).toHaveBeenCalledOnce()
-  })
+    expect(onBack).toHaveBeenCalledOnce();
+  });
 
   it("keeps crate tab selection working in compact presentation", async () => {
-    const user = userEvent.setup()
-    const onSelectCrate = vi.fn()
+    const user = userEvent.setup();
+    const onSelectCrate = vi.fn();
 
-    renderCrateView("compact", { onSelectCrate })
+    renderCrateView("compact", { onSelectCrate });
 
-    await user.click(screen.getByRole("tab", { name: "Rock" }))
+    await user.click(screen.getByRole("tab", { name: "Rock" }));
 
-    expect(onSelectCrate).toHaveBeenCalledWith("rock")
-  })
+    expect(onSelectCrate).toHaveBeenCalledWith("rock");
+  });
 
   it("preserves compact header context when tabs are hidden", () => {
-    renderCrateView("compact", { hideTabs: true })
+    renderCrateView("compact", { hideTabs: true });
 
-    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument()
-    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
-  })
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument();
+  });
 
   it("uses compact stack sizing without dropping the progress indicator", () => {
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    expect(screen.getByTestId("crate-stack")).toHaveAttribute("data-viewport", "compact")
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("crate-stack")).toHaveAttribute("data-viewport", "compact");
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   it("reserves compact bottom clearance between the record pile and progress", () => {
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    expect(screen.getByTestId("crate-stack")).toHaveClass("pb-8")
-  })
+    expect(screen.getByTestId("crate-stack")).toHaveClass("pb-8");
+  });
 
   it("keeps compact browse controls thumb-sized and visually separated", () => {
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).toHaveClass("h-12")
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).toHaveClass("h-12")
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }).parentElement).toHaveClass("mt-1")
-  })
+    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).toHaveClass(
+      "h-12",
+    );
+    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).toHaveClass(
+      "h-12",
+    );
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }).parentElement,
+    ).toHaveClass("mt-1");
+  });
 
   it("keeps wide stack sizing and desktop detail panel", () => {
-    renderCrateView("wide")
+    renderCrateView("wide");
 
-    expect(screen.getByTestId("crate-stack")).toHaveAttribute("data-viewport", "wide")
-    expect(screen.getAllByText("One").length).toBeGreaterThan(1)
-  })
+    expect(screen.getByTestId("crate-stack")).toHaveAttribute("data-viewport", "wide");
+    expect(screen.getAllByText("One").length).toBeGreaterThan(1);
+  });
 
-  it.each(["compact", "comfy", "wide"] as const)("renders riffle controls and progress on %s tier", (tier) => {
-    renderCrateView(tier)
+  it.each(["compact", "comfy", "wide"] as const)(
+    "renders riffle controls and progress on %s tier",
+    (tier) => {
+      renderCrateView(tier);
 
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).toBeInTheDocument()
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-    expect(screen.getByText(RIFFLE_LANGUAGE.progressStart)).toBeInTheDocument()
-    expect(screen.getByText(RIFFLE_LANGUAGE.progressEnd)).toBeInTheDocument()
-  })
+      expect(
+        screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText(RIFFLE_LANGUAGE.progressStart)).toBeInTheDocument();
+      expect(screen.getByText(RIFFLE_LANGUAGE.progressEnd)).toBeInTheDocument();
+    },
+  );
 
   it("clicking the deeper control advances one record and dismisses the gesture hint", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
     // First-swipe lesson is eligible for compact populated unlearned users
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
 
-    expect(screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" }),
+    ).toBeInTheDocument();
     // showGestureHint is set false after navigation, hiding the cue
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+  });
 
   it("clicking the front control from record two returns to record one", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front }))
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front }));
 
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   it("does not dismiss the compact hint when front navigation is blocked", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    await user.keyboard("{ArrowUp}")
+    await user.keyboard("{ArrowUp}");
 
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
     // showGestureHint stays true because navigation was blocked
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
-    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.front)).toBeInTheDocument()
-  })
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.front)).toBeInTheDocument();
+  });
 
   it("keeps front and deeper controls labeled while disabled at crate edges", () => {
-    const { unmount } = renderCrateView("compact")
+    const { unmount } = renderCrateView("compact");
 
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).toBeDisabled()
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).not.toBeDisabled()
+    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }),
+    ).not.toBeDisabled();
 
-    unmount()
-    renderCrateView("compact", { startIndex: 2 })
+    unmount();
+    renderCrateView("compact", { startIndex: 2 });
 
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).not.toBeDisabled()
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).toBeDisabled()
-  })
+    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).toBeDisabled();
+  });
 
   it("announces the deeper edge without changing records", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact", { startIndex: 2 })
+    renderCrateView("compact", { startIndex: 2 });
 
-    await user.keyboard("{ArrowDown}")
+    await user.keyboard("{ArrowDown}");
 
-    expect(screen.getByRole("progressbar", { name: "Record 3 of 3, front to deeper" })).toBeInTheDocument()
-    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.deeper)).toBeInTheDocument()
-  })
+    expect(
+      screen.getByRole("progressbar", { name: "Record 3 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.deeper)).toBeInTheDocument();
+  });
 
   it("renders the compact empty-crate state with header context and empty message", () => {
     const emptyCrates: Crate[] = [
@@ -257,15 +288,15 @@ describe("CrateView", () => {
         count: 0,
         records: [],
       },
-    ]
+    ];
 
-    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" })
+    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" });
 
-    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument()
-    expect(screen.getByText("0 records")).toBeInTheDocument()
-    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument()
-  })
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument();
+    expect(screen.getByText("0 records")).toBeInTheDocument();
+    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument();
+  });
 
   it("hides tabs in compact empty-crate state when hideTabs is true", () => {
     const emptyCrates: Crate[] = [
@@ -275,15 +306,15 @@ describe("CrateView", () => {
         count: 0,
         records: [],
       },
-    ]
+    ];
 
-    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty", hideTabs: true })
+    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty", hideTabs: true });
 
-    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument()
-    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument()
-    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
-  })
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument();
+    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument();
+  });
 
   it("preserves compact empty-state tab guards when the storefront header owns crate identity", () => {
     const emptyCrates: Crate[] = [
@@ -293,19 +324,19 @@ describe("CrateView", () => {
         count: 0,
         records: [],
       },
-    ]
+    ];
 
     renderCrateView("compact", {
       crates: emptyCrates,
       activeSlug: "empty",
       compactHeaderOwnedByLayout: true,
       hideTabs: true,
-    })
+    });
 
-    expect(screen.queryByRole("heading", { name: "Empty Crate" })).not.toBeInTheDocument()
-    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument()
-    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
-  })
+    expect(screen.queryByRole("heading", { name: "Empty Crate" })).not.toBeInTheDocument();
+    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument();
+  });
 
   it("renders no riffle controls in compact empty-crate state", () => {
     const emptyCrates: Crate[] = [
@@ -315,67 +346,73 @@ describe("CrateView", () => {
         count: 0,
         records: [],
       },
-    ]
+    ];
 
-    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" })
+    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" });
 
-    expect(screen.queryByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).not.toBeInTheDocument()
-  })
+    expect(
+      screen.queryByRole("button", { name: RIFFLE_LANGUAGE.controls.front }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }),
+    ).not.toBeInTheDocument();
+  });
 
   // ── Guard-parity tests: wide/desktop header ────────────────────────
 
   it("renders active crate heading and record count on wide viewports", () => {
-    renderCrateView("wide")
+    renderCrateView("wide");
 
-    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument()
-    expect(screen.getByText("3 records")).toBeInTheDocument()
-  })
+    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument();
+    expect(screen.getByText("3 records")).toBeInTheDocument();
+  });
 
   it("keeps wide crate context in content even when compact identity is layout-owned", () => {
-    renderCrateView("wide", { compactHeaderOwnedByLayout: true })
+    renderCrateView("wide", { compactHeaderOwnedByLayout: true });
 
-    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
-    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument()
-    expect(screen.getByText("3 records")).toBeInTheDocument()
-  })
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument();
+    expect(screen.getByText("3 records")).toBeInTheDocument();
+  });
 
   it("renders back control on wide viewports", () => {
-    renderCrateView("wide")
+    renderCrateView("wide");
 
-    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument()
-  })
+    expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument();
+  });
 
   it("calls onBack from the wide back control", async () => {
-    const user = userEvent.setup()
-    const onBack = vi.fn()
+    const user = userEvent.setup();
+    const onBack = vi.fn();
 
-    renderCrateView("wide", { onBack })
+    renderCrateView("wide", { onBack });
 
-    await user.click(screen.getByRole("button", { name: "Back to store" }))
+    await user.click(screen.getByRole("button", { name: "Back to store" }));
 
-    expect(onBack).toHaveBeenCalledOnce()
-  })
+    expect(onBack).toHaveBeenCalledOnce();
+  });
 
   it("keeps crate tab selection working on wide viewports", async () => {
-    const user = userEvent.setup()
-    const onSelectCrate = vi.fn()
+    const user = userEvent.setup();
+    const onSelectCrate = vi.fn();
 
-    renderCrateView("wide", { onSelectCrate })
+    renderCrateView("wide", { onSelectCrate });
 
-    await user.click(screen.getByRole("tab", { name: "Rock" }))
+    await user.click(screen.getByRole("tab", { name: "Rock" }));
 
-    expect(onSelectCrate).toHaveBeenCalledWith("rock")
-  })
+    expect(onSelectCrate).toHaveBeenCalledWith("rock");
+  });
 
   it("hides tabs on wide populated state when hideTabs is true", () => {
-    renderCrateView("wide", { hideTabs: true })
+    renderCrateView("wide", { hideTabs: true });
 
-    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument()
-    expect(screen.getByText("3 records")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).toBeInTheDocument()
-    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
-  })
+    expect(screen.getByRole("heading", { name: "Jazz" })).toBeInTheDocument();
+    expect(screen.getByText("3 records")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument();
+  });
 
   it("hides tabs on wide empty-crate state when hideTabs is true", () => {
     const emptyCrates: Crate[] = [
@@ -385,14 +422,14 @@ describe("CrateView", () => {
         count: 0,
         records: [],
       },
-    ]
+    ];
 
-    renderCrateView("wide", { crates: emptyCrates, activeSlug: "empty", hideTabs: true })
+    renderCrateView("wide", { crates: emptyCrates, activeSlug: "empty", hideTabs: true });
 
-    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument()
-    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument()
-    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
-  })
+    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument();
+    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument();
+  });
 
   it("renders the wide empty-crate state with header context", () => {
     const emptyCrates: Crate[] = [
@@ -402,14 +439,14 @@ describe("CrateView", () => {
         count: 0,
         records: [],
       },
-    ]
+    ];
 
-    renderCrateView("wide", { crates: emptyCrates, activeSlug: "empty" })
+    renderCrateView("wide", { crates: emptyCrates, activeSlug: "empty" });
 
-    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument()
-    expect(screen.getByText("0 records")).toBeInTheDocument()
-    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument()
-  })
+    expect(screen.getByRole("heading", { name: "Empty Crate" })).toBeInTheDocument();
+    expect(screen.getByText("0 records")).toBeInTheDocument();
+    expect(screen.getByText("No records in this crate yet.")).toBeInTheDocument();
+  });
 
   it("renders no riffle controls in wide empty-crate state", () => {
     const emptyCrates: Crate[] = [
@@ -419,29 +456,34 @@ describe("CrateView", () => {
         count: 0,
         records: [],
       },
-    ]
+    ];
 
-    renderCrateView("wide", { crates: emptyCrates, activeSlug: "empty" })
+    renderCrateView("wide", { crates: emptyCrates, activeSlug: "empty" });
 
-    expect(screen.queryByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).not.toBeInTheDocument()
-  })
+    expect(
+      screen.queryByRole("button", { name: RIFFLE_LANGUAGE.controls.front }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }),
+    ).not.toBeInTheDocument();
+  });
 
   it("keeps the lesson cue hidden after learning and switching crates", async () => {
-    const user = userEvent.setup()
-    const crates = makeCrates()
+    const user = userEvent.setup();
+    const crates = makeCrates();
 
-    const { rerender } = renderWithTier("compact", (
+    const { rerender } = renderWithTier(
+      "compact",
       <StorefrontMotionConfig>
         <PileProvider>
           <CrateView crates={crates} activeSlug="jazz" onSelectCrate={vi.fn()} onBack={vi.fn()} />
         </PileProvider>
-      </StorefrontMotionConfig>
-    ))
+      </StorefrontMotionConfig>,
+    );
 
     // Navigate — marks lesson learned and dismisses the hint
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
 
     // Rerender with a different activeSlug — learned state persists in sessionStorage,
     // so the lesson cue should NOT reappear across crate switches
@@ -450,27 +492,27 @@ describe("CrateView", () => {
         <PileProvider>
           <CrateView crates={crates} activeSlug="rock" onSelectCrate={vi.fn()} onBack={vi.fn()} />
         </PileProvider>
-      </StorefrontMotionConfig>
-    )
+      </StorefrontMotionConfig>,
+    );
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+  });
 
   // ── CSS-driven hint card rendering (plain divs, no motion.div) ─────
 
   it("renders hint cards as plain divs with inline transform styles", () => {
-    renderCrateView("compact")
+    renderCrateView("compact");
 
     // The crate stack contains hint cards — check the hint rendered inside the stack
-    const stack = screen.getByTestId("crate-stack")
-    expect(stack).toBeInTheDocument()
+    const stack = screen.getByTestId("crate-stack");
+    expect(stack).toBeInTheDocument();
 
     // Verify hint cards are positioned at the expected offsets inside the stack
-    const stackContainer = stack.firstElementChild
-    expect(stackContainer).not.toBeNull()
+    const stackContainer = stack.firstElementChild;
+    expect(stackContainer).not.toBeNull();
     // Should have multiple child elements for hint cards
-    expect(stackContainer!.children.length).toBeGreaterThan(1)
-  })
+    expect(stackContainer!.children.length).toBeGreaterThan(1);
+  });
 
   it("renders active card with thumbnail backdrop when thumbnail_url is present", () => {
     const cratesWithThumbnails: Crate[] = [
@@ -479,31 +521,48 @@ describe("CrateView", () => {
         name: "Jazz",
         count: 3,
         records: [
-          makeListing({ id: 1, title: "First", artist: "A", cover_image_url: null, thumbnail_url: "/thumb.jpg" }),
-          makeListing({ id: 2, title: "Second", artist: "B", cover_image_url: null, thumbnail_url: "/thumb2.jpg" }),
+          makeListing({
+            id: 1,
+            title: "First",
+            artist: "A",
+            cover_image_url: null,
+            thumbnail_url: "/thumb.jpg",
+          }),
+          makeListing({
+            id: 2,
+            title: "Second",
+            artist: "B",
+            cover_image_url: null,
+            thumbnail_url: "/thumb2.jpg",
+          }),
           makeListing({ id: 3, title: "Third", artist: "C" }),
         ],
       },
-    ]
+    ];
 
-    const { container } = renderCrateView("compact", { crates: cratesWithThumbnails, activeSlug: "jazz" })
+    const { container } = renderCrateView("compact", {
+      crates: cratesWithThumbnails,
+      activeSlug: "jazz",
+    });
 
     // Find all <img> elements in the rendered output (some are decorative with alt="")
-    const allImages = container.querySelectorAll<HTMLImageElement>("img")
-    const backdrop = Array.from(allImages).find((img) => img.getAttribute("src") === "/thumb.jpg")
-    expect(backdrop).toBeTruthy()
+    const allImages = container.querySelectorAll<HTMLImageElement>("img");
+    const backdrop = Array.from(allImages).find((img) => img.getAttribute("src") === "/thumb.jpg");
+    expect(backdrop).toBeTruthy();
 
     // Navigate to next record to verify the backdrop updates
-    const next = screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })
-    next.click()
+    const next = screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper });
+    next.click();
 
-    const updatedImages = container.querySelectorAll<HTMLImageElement>("img")
-    const nextBackdrop = Array.from(updatedImages).find((img) => img.getAttribute("src") === "/thumb2.jpg")
-    expect(nextBackdrop).toBeTruthy()
-  })
+    const updatedImages = container.querySelectorAll<HTMLImageElement>("img");
+    const nextBackdrop = Array.from(updatedImages).find(
+      (img) => img.getAttribute("src") === "/thumb2.jpg",
+    );
+    expect(nextBackdrop).toBeTruthy();
+  });
 
   it("keeps background records mounted while their depth positions animate", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
     const cratesWithThumbnails: Crate[] = [
       {
         slug: "jazz",
@@ -516,24 +575,29 @@ describe("CrateView", () => {
           makeListing({ id: 4, title: "Fourth", artist: "D", thumbnail_url: "/fourth-thumb.jpg" }),
         ],
       },
-    ]
+    ];
 
-    const { container } = renderCrateView("compact", { crates: cratesWithThumbnails, activeSlug: "jazz" })
-    const thirdHintImage = container.querySelector<HTMLImageElement>('img[src="/third-thumb.jpg"]')
-    const thirdHintCard = thirdHintImage?.closest("[data-riffle-slot]")
+    const { container } = renderCrateView("compact", {
+      crates: cratesWithThumbnails,
+      activeSlug: "jazz",
+    });
+    const thirdHintImage = container.querySelector<HTMLImageElement>('img[src="/third-thumb.jpg"]');
+    const thirdHintCard = thirdHintImage?.closest("[data-riffle-slot]");
 
-    expect(thirdHintImage).toBeTruthy()
-    expect(thirdHintCard).toHaveAttribute("data-riffle-slot", "2")
+    expect(thirdHintImage).toBeTruthy();
+    expect(thirdHintCard).toHaveAttribute("data-riffle-slot", "2");
 
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
 
-    const movedThirdHintImage = container.querySelector<HTMLImageElement>('img[src="/third-thumb.jpg"]')
-    const movedThirdHintCard = movedThirdHintImage?.closest("[data-riffle-slot]")
+    const movedThirdHintImage = container.querySelector<HTMLImageElement>(
+      'img[src="/third-thumb.jpg"]',
+    );
+    const movedThirdHintCard = movedThirdHintImage?.closest("[data-riffle-slot]");
 
-    expect(movedThirdHintImage).toBe(thirdHintImage)
-    expect(movedThirdHintCard).toBe(thirdHintCard)
-    expect(movedThirdHintCard).toHaveAttribute("data-riffle-slot", "1")
-  })
+    expect(movedThirdHintImage).toBe(thirdHintImage);
+    expect(movedThirdHintCard).toBe(thirdHintCard);
+    expect(movedThirdHintCard).toHaveAttribute("data-riffle-slot", "1");
+  });
 
   it("omits thumbnail backdrop when thumbnail_url is null", () => {
     const cratesWithoutThumbnails: Crate[] = [
@@ -547,59 +611,72 @@ describe("CrateView", () => {
           makeListing({ id: 3, title: "Third", artist: "C", thumbnail_url: null }),
         ],
       },
-    ]
+    ];
 
-    const { container } = renderCrateView("compact", { crates: cratesWithoutThumbnails, activeSlug: "jazz" })
+    const { container } = renderCrateView("compact", {
+      crates: cratesWithoutThumbnails,
+      activeSlug: "jazz",
+    });
 
     // Without thumbnail_url on any record, hint cards use cover_image_url (null in test) — ♪ placeholders
     // Active card also has no thumbnail to render as backdrop
     // The only <img> elements would be from hint cards that DO resolve a URL
-    const allImages = container.querySelectorAll<HTMLImageElement>("img")
+    const allImages = container.querySelectorAll<HTMLImageElement>("img");
     // makeListing defaults both cover and thumbnail to null, so no img elements render
-    expect(allImages.length).toBe(0)
-  })
+    expect(allImages.length).toBe(0);
+  });
 
   it("navigates with the ref-based index to avoid stale closures", async () => {
-    const user = userEvent.setup()
-    const crates = makeCrates()
+    const user = userEvent.setup();
+    const crates = makeCrates();
 
-    renderCrateView("compact", { crates })
+    renderCrateView("compact", { crates });
 
     // Rapidly advance twice — index ref ensures both navigations land
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
 
-    expect(screen.getByRole("progressbar", { name: "Record 3 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    expect(
+      screen.getByRole("progressbar", { name: "Record 3 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   it("ArrowDown advances deeper and ArrowUp returns toward the front", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    await user.keyboard("{ArrowDown}")
-    expect(screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" })).toBeInTheDocument()
+    await user.keyboard("{ArrowDown}");
+    expect(
+      screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" }),
+    ).toBeInTheDocument();
 
-    await user.keyboard("{ArrowUp}")
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    await user.keyboard("{ArrowUp}");
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   it("navigates deeper and front with the semantic button labels", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
-    expect(screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" })).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
+    expect(
+      screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" }),
+    ).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front }))
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front }));
 
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   it("keeps navigation decisions unchanged when reduced motion is requested", async () => {
-    const user = userEvent.setup()
-    const originalMatchMedia = window.matchMedia
+    const user = userEvent.setup();
+    const originalMatchMedia = window.matchMedia;
 
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -613,164 +690,176 @@ describe("CrateView", () => {
         removeListener: () => undefined,
         dispatchEvent: () => false,
       }),
-    })
+    });
 
     try {
-      renderCrateView("compact")
+      renderCrateView("compact");
 
-      await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
+      await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
 
-      expect(screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" })).toBeInTheDocument()
+      expect(
+        screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" }),
+      ).toBeInTheDocument();
     } finally {
       Object.defineProperty(window, "matchMedia", {
         writable: true,
         value: originalMatchMedia,
-      })
+      });
     }
-  })
+  });
 
   it("renders the active drag surface that delegates release decisions to the riffle contract", () => {
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    expect(screen.getByTestId("crate-drag-surface")).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("crate-drag-surface")).toBeInTheDocument();
+  });
 
   // ── First-swipe lesson cue (U2) ────────────────────────────
 
   it("shows the ghost-finger lesson cue on compact populated first render", () => {
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
     // Core controls still present
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front })).toBeInTheDocument()
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    expect(
+      screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   it("does not show the first-swipe lesson cue on wide tier", () => {
-    renderCrateView("wide")
+    renderCrateView("wide");
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+  });
 
   it("does not show the first-swipe lesson cue on comfy tier", () => {
-    renderCrateView("comfy")
+    renderCrateView("comfy");
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+  });
 
   it("does not show the first-swipe lesson cue on compact empty crate", () => {
-    const emptyCrates: Crate[] = [
-      { slug: "empty", name: "Empty Crate", count: 0, records: [] },
-    ]
+    const emptyCrates: Crate[] = [{ slug: "empty", name: "Empty Crate", count: 0, records: [] }];
 
-    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" })
+    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" });
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-    expect(screen.queryByText("Pull down")).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByText("Pull down")).not.toBeInTheDocument();
+  });
 
   it("shows the lesson cue on compact hideTabs when populated", () => {
-    renderCrateView("compact", { hideTabs: true })
+    renderCrateView("compact", { hideTabs: true });
 
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
-    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
-  })
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument();
+  });
 
   it("does not show the lesson cue on wide hideTabs", () => {
-    renderCrateView("wide", { hideTabs: true })
+    renderCrateView("wide", { hideTabs: true });
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Crates" })).not.toBeInTheDocument();
+  });
 
   it("does not add interactive controls in the lesson cue area", () => {
-    renderCrateView("compact")
+    renderCrateView("compact");
 
     // The lesson cue should be decorative / status-like, not an interactive element
-    const cueEl = screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)
+    const cueEl = screen.getByTestId(GHOST_FINGER_CUE_TEST_ID);
     // Verify it's not a button, link, or input
-    expect(cueEl.tagName).toBe("DIV")
+    expect(cueEl.tagName).toBe("DIV");
     // The container itself is aria-hidden so screen readers skip it
-    expect(cueEl).toHaveAttribute("aria-hidden", "true")
-  })
+    expect(cueEl).toHaveAttribute("aria-hidden", "true");
+  });
 
   // ── Same-session mastery persistence (U3) ──────────────────
 
   it("marks lesson learned after successful deeper navigation and hides the cue", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }))
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }));
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-    expect(screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" })).toBeInTheDocument()
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Record 2 of 3, front to deeper" }),
+    ).toBeInTheDocument();
 
     // Re-render fresh component — learned state persists in sessionStorage
-    const { unmount } = renderCrateView("compact")
-    unmount()
-    renderCrateView("compact")
+    const { unmount } = renderCrateView("compact");
+    unmount();
+    renderCrateView("compact");
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+  });
 
   it("marks lesson learned after successful front navigation", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact", { startIndex: 1 })
+    renderCrateView("compact", { startIndex: 1 });
 
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front }))
+    await user.click(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.front }));
 
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
 
     // Verify learned state persists
-    const { unmount } = renderCrateView("compact", { startIndex: 1 })
-    unmount()
-    renderCrateView("compact", { startIndex: 1 })
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-  })
+    const { unmount } = renderCrateView("compact", { startIndex: 1 });
+    unmount();
+    renderCrateView("compact", { startIndex: 1 });
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+  });
 
   it("does not mark lesson learned when front navigation is blocked at edge", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    await user.keyboard("{ArrowUp}")
+    await user.keyboard("{ArrowUp}");
 
-    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.front)).toBeInTheDocument()
+    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.front)).toBeInTheDocument();
     // Lesson is still eligible
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
-  })
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
+  });
 
   it("does not mark lesson learned when deeper navigation is blocked at last record", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact", { startIndex: 2 })
+    renderCrateView("compact", { startIndex: 2 });
 
-    await user.keyboard("{ArrowDown}")
+    await user.keyboard("{ArrowDown}");
 
-    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.deeper)).toBeInTheDocument()
-    // Lesson is still eligible  
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
-  })
+    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.deeper)).toBeInTheDocument();
+    // Lesson is still eligible
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
+  });
 
   it("supports rapid keyboard navigation while marking mastery", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
     // Two rapid keypresses — both should navigate
-    await user.keyboard("{ArrowDown}")
-    await user.keyboard("{ArrowDown}")
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{ArrowDown}");
 
-    expect(screen.getByRole("progressbar", { name: "Record 3 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    expect(
+      screen.getByRole("progressbar", { name: "Record 3 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   // ── Horizontal-swipe behavior (U4) ──────────────────────────
 
@@ -779,39 +868,41 @@ describe("CrateView", () => {
     // because absX > absY. The component stays on the same record with no error.
     // The classifyDragAttempt helper (tested in lib tests) classifies the gesture;
     // the component does nothing visual in response — the cue was already floating.
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
-    expect(screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" })).toBeInTheDocument()
-  })
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
+    expect(
+      screen.getByRole("progressbar", { name: "Record 1 of 3, front to deeper" }),
+    ).toBeInTheDocument();
+  });
 
   it("no lesson cue on wide viewports regardless of swipe direction", () => {
-    renderCrateView("wide")
+    renderCrateView("wide");
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-    expect(screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper })).toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: RIFFLE_LANGUAGE.controls.deeper }),
+    ).toBeInTheDocument();
+  });
 
   it("no lesson cue on compact empty crate", () => {
-    const emptyCrates: Crate[] = [
-      { slug: "empty", name: "Empty Crate", count: 0, records: [] },
-    ]
+    const emptyCrates: Crate[] = [{ slug: "empty", name: "Empty Crate", count: 0, records: [] }];
 
-    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" })
+    renderCrateView("compact", { crates: emptyCrates, activeSlug: "empty" });
 
-    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument()
-  })
+    expect(screen.queryByTestId(GHOST_FINGER_CUE_TEST_ID)).not.toBeInTheDocument();
+  });
 
   it("edge status message for blocked vertical move is distinct from lesson cue", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
 
-    renderCrateView("compact")
+    renderCrateView("compact");
 
-    await user.keyboard("{ArrowUp}")
+    await user.keyboard("{ArrowUp}");
 
     // Edge status is rendered as a polite message
-    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.front)).toBeInTheDocument()
+    expect(screen.getByText(RIFFLE_LANGUAGE.edgeStatus.front)).toBeInTheDocument();
     // The lesson cue stays floating — it's not an error style
-    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument()
-  })
-})
+    expect(screen.getByTestId(GHOST_FINGER_CUE_TEST_ID)).toBeInTheDocument();
+  });
+});

--- a/app/frontend/components/crate_view.test.tsx
+++ b/app/frontend/components/crate_view.test.tsx
@@ -103,9 +103,10 @@ describe("CrateView", () => {
 
     expect(screen.getByRole("button", { name: "Back to store" })).toBeInTheDocument();
     expect(screen.getAllByText("One").length).toBeGreaterThan(1);
-    // On wide, flip is disabled on the card, so only RecordDetails exposes the Discogs link
-    const discogsLink = screen.getByRole("link", { name: /Discogs/ });
-    expect(discogsLink).toHaveClass("focus-visible:ring-mc-focus");
+    // Card back face + RecordDetails panel both have Discogs links
+    const discogsLinks = screen.getAllByRole("link", { name: /Discogs/ });
+    expect(discogsLinks.length).toBeGreaterThanOrEqual(1);
+    discogsLinks.forEach((link) => expect(link).toHaveClass("focus-visible:ring-mc-focus"));
   });
 
   it("renders score direction using semantic success and danger roles", () => {

--- a/app/frontend/components/crate_view/active_record_card.tsx
+++ b/app/frontend/components/crate_view/active_record_card.tsx
@@ -24,6 +24,8 @@ interface ActiveRecordCardProps {
     offset: { x: number; y: number };
     velocity: { x: number; y: number };
   }) => void;
+  /** Called the first time the active card is flipped (compact only). */
+  onFlip?: () => void;
 }
 
 /**
@@ -39,6 +41,7 @@ export default function ActiveRecordCard({
   direction,
   dragRotationRef,
   handleDragEnd,
+  onFlip,
 }: ActiveRecordCardProps) {
   const activeTransition = prefersReducedMotion
     ? reducedMotionTransition
@@ -111,6 +114,7 @@ export default function ActiveRecordCard({
           imageLoading="eager"
           disableFlip={!isCompact}
           framed
+          onFlip={onFlip}
         />
       </motion.div>
     </motion.div>

--- a/app/frontend/components/crate_view/card_stack.tsx
+++ b/app/frontend/components/crate_view/card_stack.tsx
@@ -1,11 +1,23 @@
-import React from "react";
+import React, { useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import HintCardStack from "./hint_card_stack";
 import ActiveRecordCard from "./active_record_card";
 import GestureHintOverlay from "./gesture_hint_overlay";
+import InspectionHint, { markFlipDiscovered } from "./inspection_hint";
 import { buildCrateWindow } from "../../lib/crate_window";
 import { type RiffleDirection } from "../../lib/riffle_navigation";
 import type { Listing } from "../../types/inertia";
+
+const FLIP_DISCOVERED_KEY = "mc-flip-discovered";
+
+function loadFlipDiscovered(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return localStorage.getItem(FLIP_DISCOVERED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
 
 interface CardStackProps {
   isCompact: boolean;
@@ -40,6 +52,13 @@ export default function CardStack(props: CardStackProps) {
     handleDragEnd,
   } = props;
 
+  const [flipDiscovered, setFlipDiscovered] = useState(() => loadFlipDiscovered());
+
+  const handleFlip = () => {
+    markFlipDiscovered();
+    setFlipDiscovered(true);
+  };
+
   return (
     <>
       <div
@@ -53,37 +72,49 @@ export default function CardStack(props: CardStackProps) {
         style={{ touchAction: "none", overscrollBehavior: "contain" }}
       >
         <div
-          className="relative"
+          className="flex flex-col items-center"
           style={{
             width: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
-            height: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
           }}
         >
-          <HintCardStack visibleRecords={visibleRecords} prefersReducedMotion={prefersReducedMotion} />
+          <div
+            className="relative w-full"
+            style={{
+              height: isCompact ? "min(80vw, 340px, 54svh)" : "min(82vw, 400px)",
+            }}
+          >
+            <HintCardStack
+              visibleRecords={visibleRecords}
+              prefersReducedMotion={prefersReducedMotion}
+            />
 
-          <AnimatePresence initial={!prefersReducedMotion} custom={direction.current}>
-            {visibleRecords
-              .filter((s) => s.isActive)
-              .map((slot) => (
-                <ActiveRecordCard
-                  key={`active-${slot.record.id}`}
-                  slot={slot}
-                  isCompact={isCompact}
-                  activeSlug={activeSlug}
-                  prefersReducedMotion={prefersReducedMotion}
-                  direction={direction}
-                  dragRotationRef={dragRotationRef}
-                  handleDragEnd={handleDragEnd}
-                />
-              ))}
-          </AnimatePresence>
+            <AnimatePresence initial={!prefersReducedMotion} custom={direction.current}>
+              {visibleRecords
+                .filter((s) => s.isActive)
+                .map((slot) => (
+                  <ActiveRecordCard
+                    key={`active-${slot.record.id}`}
+                    slot={slot}
+                    isCompact={isCompact}
+                    activeSlug={activeSlug}
+                    prefersReducedMotion={prefersReducedMotion}
+                    direction={direction}
+                    dragRotationRef={dragRotationRef}
+                    handleDragEnd={handleDragEnd}
+                    onFlip={isCompact ? handleFlip : undefined}
+                  />
+                ))}
+            </AnimatePresence>
 
-          <GestureHintOverlay
-            isCompact={isCompact}
-            showGestureHint={showGestureHint}
-            total={total}
-            prefersReducedMotion={prefersReducedMotion}
-          />
+            <GestureHintOverlay
+              isCompact={isCompact}
+              showGestureHint={showGestureHint}
+              total={total}
+              prefersReducedMotion={prefersReducedMotion}
+            />
+          </div>
+
+          {isCompact && <InspectionHint discovered={flipDiscovered} />}
         </div>
       </div>
     </>

--- a/app/frontend/components/crate_view/card_stack.tsx
+++ b/app/frontend/components/crate_view/card_stack.tsx
@@ -114,7 +114,7 @@ export default function CardStack(props: CardStackProps) {
             />
           </div>
 
-          {isCompact && <InspectionHint discovered={flipDiscovered} />}
+          {isCompact && !showGestureHint && <InspectionHint discovered={flipDiscovered} />}
         </div>
       </div>
     </>

--- a/app/frontend/components/crate_view/inspection_hint.test.tsx
+++ b/app/frontend/components/crate_view/inspection_hint.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import InspectionHint from "./inspection_hint";
+import StorefrontMotionConfig from "@/components/storefront_motion_config";
+
+function renderHint(discovered: boolean) {
+  return render(
+    <StorefrontMotionConfig>
+      <InspectionHint discovered={discovered} />
+    </StorefrontMotionConfig>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("InspectionHint", () => {
+  describe("happy path", () => {
+    it("renders hint text when not yet discovered", () => {
+      renderHint(false);
+
+      expect(screen.getByText("Tap card to inspect")).toBeInTheDocument();
+    });
+
+    it("renders with role=status for screen reader announcement", () => {
+      renderHint(false);
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("does not render when flip has been discovered", () => {
+      renderHint(true);
+
+      expect(screen.queryByText("Tap card to inspect")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("integration: CardStack hides hint after flip", () => {
+    it("renders null when discovered=true — hint will not reappear", () => {
+      const { container } = renderHint(true);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/app/frontend/components/crate_view/inspection_hint.tsx
+++ b/app/frontend/components/crate_view/inspection_hint.tsx
@@ -1,0 +1,39 @@
+import { useReducedMotionContext } from "@/components/storefront_motion_config";
+
+const FLIP_DISCOVERED_KEY = "mc-flip-discovered";
+
+export function markFlipDiscovered(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(FLIP_DISCOVERED_KEY, "true");
+  } catch {
+    // localStorage unavailable — hint will remain visible, acceptable
+  }
+}
+
+interface InspectionHintProps {
+  /** Whether the localStorage flag has been set (flip already discovered). */
+  discovered: boolean;
+}
+
+/**
+ * A text hint rendered below the active card on compact viewports that
+ * signals the flip interaction to first-time shoppers. Fades out after
+ * the first card flip (tracked via localStorage). Respects reduced-motion.
+ */
+export default function InspectionHint({ discovered }: InspectionHintProps) {
+  const reducedMotion = useReducedMotionContext();
+
+  if (discovered) return null;
+
+  return (
+    <p
+      role="status"
+      className={`text-center text-xs text-mc-text-dim mt-2 select-none pointer-events-none ${
+        reducedMotion ? "" : "animate-pulse"
+      }`}
+    >
+      Tap card to inspect
+    </p>
+  );
+}

--- a/app/frontend/components/featured_crates_row.tsx
+++ b/app/frontend/components/featured_crates_row.tsx
@@ -15,6 +15,7 @@ export default function FeaturedCratesRow({ crates, onSelectCrate }: Props) {
       variant="featured"
       columnCount={(isCompact, isComfy) => (isCompact ? 1 : isComfy ? 2 : 3)}
       onSelectCrate={onSelectCrate}
+      description="Curated crates hand-picked by the store"
     />
   );
 }

--- a/app/frontend/components/genre_grid.tsx
+++ b/app/frontend/components/genre_grid.tsx
@@ -16,6 +16,7 @@ export default function GenreGrid({ crates, onSelectCrate }: Props) {
       columnCount={(isCompact, isComfy) => (isCompact ? 2 : isComfy ? 3 : 4)}
       onSelectCrate={onSelectCrate}
       gap="gap-3 sm:gap-4"
+      description="Browse the full collection by genre"
     />
   );
 }

--- a/app/frontend/components/pile_toast.test.tsx
+++ b/app/frontend/components/pile_toast.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import PileToast from "./pile_toast";
+import { PileProvider, usePileContext } from "@/contexts/pile_context";
+import StorefrontMotionConfig from "@/components/storefront_motion_config";
+import type { Listing } from "../types/inertia";
+
+const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
+  id: 1,
+  discogs_listing_id: "abc",
+  artist: "Artist",
+  title: "Test Record",
+  label: "Label",
+  year: 2024,
+  format: null,
+  genres: ["Rock"],
+  styles: [],
+  condition: "VG+",
+  price: "12.00",
+  currency: "USD",
+  cover_image_url: null,
+  thumbnail_url: null,
+  notes: null,
+  discogs_url: "https://www.discogs.com/sell/item/1",
+  ...overrides,
+});
+
+/** Helper that exposes an "Add" button which calls addToPile directly. */
+function AddButton({ listing }: { listing: Listing }) {
+  const { addToPile } = usePileContext();
+  return (
+    <button type="button" onClick={() => addToPile(listing)}>
+      Add to pile
+    </button>
+  );
+}
+
+function renderWithHelper(listing: Listing) {
+  return render(
+    <StorefrontMotionConfig>
+      <PileProvider>
+        <PileToast />
+        <AddButton listing={listing} />
+      </PileProvider>
+    </StorefrontMotionConfig>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("PileToast", () => {
+  describe("happy path", () => {
+    it("does not render when nothing has been added", () => {
+      render(
+        <StorefrontMotionConfig>
+          <PileProvider>
+            <PileToast />
+          </PileProvider>
+        </StorefrontMotionConfig>,
+      );
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("renders toast with record title after adding to pile", () => {
+      const listing = makeListing({ title: "Purple Rain" });
+      renderWithHelper(listing);
+
+      fireEvent.click(screen.getByRole("button", { name: "Add to pile" }));
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+      expect(screen.getByText(/Added Purple Rain to pile/)).toBeInTheDocument();
+    });
+
+    it("renders with aria-live=polite", () => {
+      renderWithHelper(makeListing({ title: "Test" }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Add to pile" }));
+
+      expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("auto-dismisses: clearLastAdded called after 2 seconds", () => {
+      // framer-motion AnimatePresence holds the DOM node during exit animation;
+      // verify dismissal by confirming the timeout fires and the text enters
+      // the exit state (opacity: 0) — the semantic is cleared.
+      renderWithHelper(makeListing({ title: "Time Test" }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Add to pile" }));
+      expect(screen.getByText(/Added Time Test to pile/)).toBeInTheDocument();
+
+      // After 2s the context clears lastAdded; the element enters exit animation
+      act(() => vi.advanceTimersByTime(2001));
+
+      // The element is in exit state (opacity:0) — framer holds it for animation
+      // but the content is semantically dismissed from context.
+      const toastEl = screen.getByText(/Added Time Test to pile/).closest("[role='status']");
+      expect(toastEl).toHaveStyle("opacity: 0");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("truncates very long titles with ellipsis", () => {
+      const longTitle = "This Is A Very Long Record Title That Exceeds Thirty Characters";
+      renderWithHelper(makeListing({ title: longTitle }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Add to pile" }));
+
+      const toast = screen.getByRole("status");
+      expect(toast.textContent).toContain("\u2026");
+    });
+
+    it("uses 'record' fallback when title is null", () => {
+      renderWithHelper(makeListing({ title: null }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Add to pile" }));
+
+      expect(screen.getByText(/Added record to pile/)).toBeInTheDocument();
+    });
+
+    it("no toast renders when lastAdded is null", () => {
+      render(
+        <StorefrontMotionConfig>
+          <PileProvider>
+            <PileToast />
+          </PileProvider>
+        </StorefrontMotionConfig>,
+      );
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/frontend/components/pile_toast.tsx
+++ b/app/frontend/components/pile_toast.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { usePileContext } from "@/contexts/pile_context";
+import { useReducedMotionContext } from "@/components/storefront_motion_config";
+import { springTactile } from "@/lib/motion_tokens";
+
+const TOAST_DURATION_MS = 2000;
+const TITLE_MAX_CHARS = 30;
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}\u2026`;
+}
+
+/**
+ * A brief confirmation toast that appears when a record is added to the pile.
+ * Mounts inside AppLayoutContent so it's available across all modes.
+ * Auto-dismisses after 2 seconds. Respects prefers-reduced-motion.
+ */
+export default function PileToast() {
+  const { lastAdded, clearLastAdded } = usePileContext();
+  const reducedMotion = useReducedMotionContext();
+
+  useEffect(() => {
+    if (!lastAdded) return;
+    const timer = setTimeout(clearLastAdded, TOAST_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [lastAdded, clearLastAdded]);
+
+  const title = lastAdded?.title ? truncate(lastAdded.title, TITLE_MAX_CHARS) : "record";
+
+  return (
+    <AnimatePresence>
+      {lastAdded && (
+        <motion.div
+          key={lastAdded.id}
+          role="status"
+          aria-live="polite"
+          initial={reducedMotion ? { opacity: 1 } : { opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={reducedMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+          transition={springTactile}
+          className="fixed top-16 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-full bg-mc-bg-raised border border-mc-border shadow-lg text-sm font-medium text-mc-text pointer-events-none select-none whitespace-nowrap"
+        >
+          Added {title} to pile
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/app/frontend/components/pile_toast.tsx
+++ b/app/frontend/components/pile_toast.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { usePileContext } from "@/contexts/pile_context";
 import { useReducedMotionContext } from "@/components/storefront_motion_config";

--- a/app/frontend/components/record_card.test.tsx
+++ b/app/frontend/components/record_card.test.tsx
@@ -1,10 +1,10 @@
-import React from "react"
-import { describe, expect, it, vi } from "vitest"
-import { render, screen, fireEvent } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import RecordCard from "./record_card"
-import { PileProvider } from "@/contexts/pile_context"
-import type { Listing } from "../types/inertia"
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RecordCard from "./record_card";
+import { PileProvider } from "@/contexts/pile_context";
+import type { Listing } from "../types/inertia";
 
 const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
   id: 1,
@@ -24,190 +24,190 @@ const makeListing = (overrides: Partial<Listing> = {}): Listing => ({
   notes: null,
   discogs_url: "https://www.discogs.com/sell/item/1",
   ...overrides,
-})
+});
 
 function renderCard(props: Partial<React.ComponentProps<typeof RecordCard>> = {}) {
   return render(
     <PileProvider>
       <RecordCard listing={makeListing()} {...props} />
     </PileProvider>,
-  )
+  );
 }
 
 describe("RecordCard", () => {
   describe("happy path", () => {
     it("renders listing title in back face details", () => {
-      renderCard({ listing: makeListing({ title: "Purple Rain" }) })
+      renderCard({ listing: makeListing({ title: "Purple Rain" }) });
 
-      expect(screen.getByText("Purple Rain")).toBeInTheDocument()
-    })
+      expect(screen.getByText("Purple Rain")).toBeInTheDocument();
+    });
 
     it("renders artist name", () => {
-      renderCard({ listing: makeListing({ artist: "Prince" }) })
+      renderCard({ listing: makeListing({ artist: "Prince" }) });
 
-      expect(screen.getByText("Prince")).toBeInTheDocument()
-    })
+      expect(screen.getByText("Prince")).toBeInTheDocument();
+    });
 
     it("renders cover image when cover_image_url exists", () => {
-      const listing = makeListing({ cover_image_url: "https://example.com/cover.jpg" })
+      const listing = makeListing({ cover_image_url: "https://example.com/cover.jpg" });
 
-      renderCard({ listing })
+      renderCard({ listing });
 
-      const img = screen.getByRole("img")
-      expect(img).toHaveAttribute("src", "https://example.com/cover.jpg")
-    })
+      const img = screen.getByRole("img");
+      expect(img).toHaveAttribute("src", "https://example.com/cover.jpg");
+    });
 
     it("has tabIndex 0 when flip is enabled", () => {
-      renderCard()
+      renderCard();
 
-      const card = screen.getByRole("button", { name: /Show details for/ })
-      expect(card).toHaveAttribute("tabindex", "0")
-    })
-  })
+      const card = screen.getByRole("button", { name: /Show details for/ });
+      expect(card).toHaveAttribute("tabindex", "0");
+    });
+  });
 
   describe("flip behavior", () => {
     it("flips on click", async () => {
-      const user = userEvent.setup()
-      const listing = makeListing({ title: "Flip Me" })
+      const user = userEvent.setup();
+      const listing = makeListing({ title: "Flip Me" });
 
-      renderCard({ listing })
+      renderCard({ listing });
 
-      const card = screen.getByRole("button", { name: /Show details for/ })
+      const card = screen.getByRole("button", { name: /Show details for/ });
 
-      await user.click(card)
+      await user.click(card);
 
-      expect(card).toHaveAttribute("aria-pressed", "true")
-    })
+      expect(card).toHaveAttribute("aria-pressed", "true");
+    });
 
     it("flips back on second click", async () => {
-      const user = userEvent.setup()
-      const listing = makeListing({ title: "Two Flips" })
+      const user = userEvent.setup();
+      const listing = makeListing({ title: "Two Flips" });
 
-      renderCard({ listing })
+      renderCard({ listing });
 
-      const card = screen.getByRole("button", { name: /Show details for/ })
+      const card = screen.getByRole("button", { name: /Show details for/ });
 
-      await user.click(card)
-      expect(card).toHaveAttribute("aria-pressed", "true")
+      await user.click(card);
+      expect(card).toHaveAttribute("aria-pressed", "true");
 
-      await user.click(card)
-      expect(card).toHaveAttribute("aria-pressed", "false")
-    })
+      await user.click(card);
+      expect(card).toHaveAttribute("aria-pressed", "false");
+    });
 
     it("does not flip when disableFlip is true", () => {
-      renderCard({ disableFlip: true })
+      renderCard({ disableFlip: true });
 
-      expect(screen.queryByRole("button", { name: /Show details for/ })).not.toBeInTheDocument()
-      expect(screen.getByText("+ Pile")).toBeInTheDocument()
-    })
+      expect(screen.queryByRole("button", { name: /Show details for/ })).not.toBeInTheDocument();
+      expect(screen.getByText("+ Pile")).toBeInTheDocument();
+    });
 
     it("resets flip state on resetKey change", () => {
-      const listing = makeListing({ title: "Reset Me" })
+      const listing = makeListing({ title: "Reset Me" });
       const { rerender } = render(
         <PileProvider>
           <RecordCard listing={listing} resetKey="a" />
         </PileProvider>,
-      )
+      );
 
-      const card = screen.getByRole("button", { name: /Show details for/ })
-      fireEvent.click(card)
-      expect(card).toHaveAttribute("aria-pressed", "true")
+      const card = screen.getByRole("button", { name: /Show details for/ });
+      fireEvent.click(card);
+      expect(card).toHaveAttribute("aria-pressed", "true");
 
       rerender(
         <PileProvider>
           <RecordCard listing={listing} resetKey="b" />
         </PileProvider>,
-      )
+      );
 
-      expect(card).toHaveAttribute("aria-pressed", "false")
-    })
-  })
+      expect(card).toHaveAttribute("aria-pressed", "false");
+    });
+  });
 
   describe("pile integration", () => {
     it("renders pile add button", () => {
-      renderCard()
+      renderCard();
 
-      expect(screen.getByText("+ Pile")).toBeInTheDocument()
-    })
+      expect(screen.getByText("+ Pile")).toBeInTheDocument();
+    });
 
     it("renders Discogs link", () => {
-      renderCard()
+      renderCard();
 
-      const link = screen.getByRole("link", { name: /Discogs/ })
-      expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute("href", "https://www.discogs.com/sell/item/1")
-    })
+      const link = screen.getByRole("link", { name: /View.*on Discogs.*opens in new tab/ });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "https://www.discogs.com/sell/item/1");
+    });
 
     it("uses canonical action treatment for pile and external record actions", () => {
-      renderCard()
+      renderCard();
 
-      const pileButton = screen.getByRole("button", { name: "+ Pile" })
-      const discogsLink = screen.getByRole("link", { name: /Discogs/ })
-      expect(pileButton).toHaveClass("focus-visible:ring-mc-focus")
-      expect(discogsLink).toHaveClass("focus-visible:ring-mc-focus")
-      expect(pileButton).not.toHaveClass("mc-btn")
-      expect(discogsLink).not.toHaveClass("mc-btn")
-    })
+      const pileButton = screen.getByText("+ Pile").closest("button")!;
+      const discogsLink = screen.getByRole("link", { name: /View.*on Discogs/ });
+      expect(pileButton).toHaveClass("focus-visible:ring-mc-focus");
+      expect(discogsLink).toHaveClass("focus-visible:ring-mc-focus");
+      expect(pileButton).not.toHaveClass("mc-btn");
+      expect(discogsLink).not.toHaveClass("mc-btn");
+    });
 
     it("does not flip when pile button is clicked", async () => {
-      const user = userEvent.setup()
-      const listing = makeListing({ title: "No Flip on Pile" })
+      const user = userEvent.setup();
+      const listing = makeListing({ title: "No Flip on Pile" });
 
-      renderCard({ listing })
+      renderCard({ listing });
 
-      const card = screen.getByRole("button", { name: /Show details for/ })
-      const pileBtn = screen.getByText("+ Pile")
+      const card = screen.getByRole("button", { name: /Show details for/ });
+      const pileBtn = screen.getByText("+ Pile");
 
-      await user.click(pileBtn)
+      await user.click(pileBtn);
 
-      expect(card).toHaveAttribute("aria-pressed", "false")
-    })
-  })
+      expect(card).toHaveAttribute("aria-pressed", "false");
+    });
+  });
 
   describe("edge cases", () => {
     it("handles null title gracefully", () => {
-      renderCard({ listing: makeListing({ title: null }) })
+      renderCard({ listing: makeListing({ title: null }) });
 
-      expect(document.body).toBeInTheDocument()
-    })
+      expect(document.body).toBeInTheDocument();
+    });
 
     it("handles null cover_image_url gracefully", () => {
-      renderCard({ listing: makeListing({ cover_image_url: null }) })
+      renderCard({ listing: makeListing({ cover_image_url: null }) });
 
-      const tile = document.querySelector(".text-5xl")
-      expect(tile).toBeInTheDocument()
-    })
+      const tile = document.querySelector(".text-5xl");
+      expect(tile).toBeInTheDocument();
+    });
 
     it("applies className", () => {
-      renderCard({ className: "test-record" })
+      renderCard({ className: "test-record" });
 
-      const el = document.querySelector(".test-record")
-      expect(el).toBeInTheDocument()
-    })
-  })
+      const el = document.querySelector(".test-record");
+      expect(el).toBeInTheDocument();
+    });
+  });
 
   describe("accessibility", () => {
     it("flippable card announces current state in aria-label", () => {
-      const listing = makeListing({ title: "A Night at the Opera" })
+      const listing = makeListing({ title: "A Night at the Opera" });
 
-      renderCard({ listing })
+      renderCard({ listing });
 
-      const card = screen.getByRole("button", { name: /Show details for/ })
-      expect(card).toHaveAttribute("aria-label", "Show details for A Night at the Opera")
-    })
+      const card = screen.getByRole("button", { name: /Show details for/ });
+      expect(card).toHaveAttribute("aria-label", "Show details for A Night at the Opera");
+    });
 
     it("uses correct aria-pressed state", async () => {
-      const user = userEvent.setup()
+      const user = userEvent.setup();
 
-      renderCard({ listing: makeListing({ title: "Press Test" }) })
+      renderCard({ listing: makeListing({ title: "Press Test" }) });
 
-      const card = screen.getByRole("button", { name: /Show details for/ })
+      const card = screen.getByRole("button", { name: /Show details for/ });
 
-      expect(card).toHaveAttribute("aria-pressed", "false")
+      expect(card).toHaveAttribute("aria-pressed", "false");
 
-      await user.click(card)
+      await user.click(card);
 
-      expect(card).toHaveAttribute("aria-pressed", "true")
-    })
-  })
-})
+      expect(card).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+});

--- a/app/frontend/components/record_card.tsx
+++ b/app/frontend/components/record_card.tsx
@@ -14,6 +14,8 @@ interface RecordCardProps {
   imageLoading?: "eager" | "lazy";
   disableFlip?: boolean;
   framed?: boolean;
+  /** Called the first time the card flips to the back face. */
+  onFlip?: () => void;
 }
 
 interface RecordCardBackProps {
@@ -70,8 +72,9 @@ function RecordCardBack({ listing, meta, inPile, addToPile, removeFromPile }: Re
             href={listing.discogs_url}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`View listing for ${listing.title ?? "this record"} on Discogs (opens in new tab)`}
           >
-            Discogs ↗
+            View on Discogs ↗
           </ActionLink>
         </div>
       </div>
@@ -86,8 +89,10 @@ export default function RecordCard({
   imageLoading = "lazy",
   disableFlip = false,
   framed = false,
+  onFlip,
 }: RecordCardProps) {
   const [flipped, setFlipped] = useState(false);
+  const hasCalledOnFlip = useRef(false);
   const pointerDown = useRef<{ x: number; y: number } | null>(null);
   const { inPile, addToPile, removeFromPile } = usePileContext();
   const canFlip = !disableFlip;
@@ -108,11 +113,21 @@ export default function RecordCard({
     return Math.hypot(deltaX, deltaY) > 8;
   };
 
+  const fireOnFlip = () => {
+    if (!hasCalledOnFlip.current) {
+      hasCalledOnFlip.current = true;
+      onFlip?.();
+    }
+  };
+
   const handleFlip = (e: React.MouseEvent) => {
     if (!canFlip) return;
     if ((e.target as HTMLElement).closest("a, button, form")) return;
     if (movedSincePointerDown(e)) return;
-    setFlipped((f) => !f);
+    setFlipped((f) => {
+      if (!f) fireOnFlip();
+      return !f;
+    });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -121,7 +136,10 @@ export default function RecordCard({
 
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      setFlipped((f) => !f);
+      setFlipped((f) => {
+        if (!f) fireOnFlip();
+        return !f;
+      });
     }
   };
 

--- a/app/frontend/components/record_details.tsx
+++ b/app/frontend/components/record_details.tsx
@@ -62,9 +62,9 @@ export default function RecordDetails({ listing, direction }: RecordDetailsProps
                 href={listing.discogs_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label={`View listing for ${listing.title ?? "this record"} on ******* (opens in new tab)`}
+                aria-label={`View listing for ${listing.title ?? "this record"} on Discogs (opens in new tab)`}
               >
-                View listing on ******* ↗
+                View listing on Discogs ↗
               </ActionLink>
             </div>
           </div>

--- a/app/frontend/components/record_details.tsx
+++ b/app/frontend/components/record_details.tsx
@@ -1,14 +1,14 @@
-import { motion, AnimatePresence } from "framer-motion"
-import { usePileContext } from "@/contexts/pile_context"
-import { formatPrice } from "@/lib/format_price"
-import { type RiffleDirection } from "@/lib/riffle_navigation"
-import Button from "@/components/ui/button"
-import { ActionLink } from "@/components/ui/action"
-import type { Listing } from "@/types/inertia"
+import { motion, AnimatePresence } from "framer-motion";
+import { usePileContext } from "@/contexts/pile_context";
+import { formatPrice } from "@/lib/format_price";
+import { type RiffleDirection } from "@/lib/riffle_navigation";
+import Button from "@/components/ui/button";
+import { ActionLink } from "@/components/ui/action";
+import type { Listing } from "@/types/inertia";
 
 interface RecordDetailsProps {
-  listing: Listing
-  direction: RiffleDirection
+  listing: Listing;
+  direction: RiffleDirection;
 }
 
 /**
@@ -17,15 +17,17 @@ interface RecordDetailsProps {
  * and a Discogs link.
  */
 export default function RecordDetails({ listing, direction }: RecordDetailsProps) {
-  const meta = [listing.format, listing.label, listing.year, listing.condition].filter(Boolean).join(" · ")
-  const enterY = direction === "deeper" ? -16 : 16
-  const exitY = direction === "deeper" ? 16 : -16
-  const { inPile, addToPile, removeFromPile } = usePileContext()
+  const meta = [listing.format, listing.label, listing.year, listing.condition]
+    .filter(Boolean)
+    .join(" · ");
+  const enterY = direction === "deeper" ? -16 : 16;
+  const exitY = direction === "deeper" ? 16 : -16;
+  const { inPile, addToPile, removeFromPile } = usePileContext();
 
   const allTags = [
     ...listing.genres.slice(0, 4).map((g) => ({ label: g, dim: false })),
     ...listing.styles.slice(0, 4).map((s) => ({ label: s, dim: true })),
-  ]
+  ];
 
   return (
     <AnimatePresence mode="wait" custom={direction}>
@@ -46,16 +48,24 @@ export default function RecordDetails({ listing, direction }: RecordDetailsProps
             {meta && <div className="text-xs text-mc-text-dim mt-2">{meta}</div>}
           </div>
           <div className="flex flex-col items-end gap-2">
-            <span className="text-2xl font-medium whitespace-nowrap">
-              {formatPrice(listing)}
-            </span>
+            <span className="text-2xl font-medium whitespace-nowrap">{formatPrice(listing)}</span>
             <div className="flex gap-2">
               {inPile(listing.id) ? (
-                <Button variant="secondary" onClick={() => removeFromPile(listing.id)}>✓ In pile</Button>
+                <Button variant="secondary" onClick={() => removeFromPile(listing.id)}>
+                  ✓ In pile
+                </Button>
               ) : (
                 <Button onClick={() => addToPile(listing)}>+ Pile</Button>
               )}
-              <ActionLink variant="secondary" href={listing.discogs_url} target="_blank" rel="noopener noreferrer">Discogs ↗</ActionLink>
+              <ActionLink
+                variant="secondary"
+                href={listing.discogs_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`View listing for ${listing.title ?? "this record"} on ******* (opens in new tab)`}
+              >
+                View listing on ******* ↗
+              </ActionLink>
             </div>
           </div>
         </div>
@@ -81,5 +91,5 @@ export default function RecordDetails({ listing, direction }: RecordDetailsProps
         )}
       </motion.div>
     </AnimatePresence>
-  )
+  );
 }

--- a/app/frontend/components/store_floor.test.tsx
+++ b/app/frontend/components/store_floor.test.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import StoreFloor from "@/components/store_floor";
+import StorefrontMotionConfig from "@/components/storefront_motion_config";
+import { ViewportProvider } from "@/contexts/viewport_context";
+import { renderWithTier } from "../test/viewport-test-utils";
+import type { StorefrontSection, Crate, Listing } from "../types/inertia";
+
+const makeListing = (id: number): Listing => ({
+  id,
+  discogs_listing_id: String(id),
+  artist: "Artist",
+  title: `Record ${id}`,
+  label: null,
+  year: null,
+  format: null,
+  genres: [],
+  styles: [],
+  condition: null,
+  price: "10.00",
+  currency: "USD",
+  cover_image_url: null,
+  thumbnail_url: null,
+  notes: null,
+  discogs_url: `https://www.discogs.com/sell/item/${id}`,
+});
+
+const makeCrate = (slug: string, recordCount = 4): Crate => ({
+  slug,
+  name: slug,
+  count: recordCount,
+  records: Array.from({ length: recordCount }, (_, i) => makeListing(i + 1)),
+});
+
+const picksSectionWith = (records: number): StorefrontSection => ({
+  key: "picks_wall",
+  crate: makeCrate("picks", records),
+});
+
+const featuredSection = (count = 2): StorefrontSection => ({
+  key: "featured_crates",
+  crates: Array.from({ length: count }, (_, i) => makeCrate(`featured-${i}`)),
+});
+
+const genreSection = (count = 3): StorefrontSection => ({
+  key: "genre_grid",
+  crates: Array.from({ length: count }, (_, i) => makeCrate(`genre-${i}`)),
+});
+
+const renderFloor = (sections: StorefrontSection[]) =>
+  render(
+    <StorefrontMotionConfig>
+      <ViewportProvider>
+        <StoreFloor sections={sections} onSelectCrate={vi.fn()} />
+      </ViewportProvider>
+    </StorefrontMotionConfig>,
+  );
+
+const renderFloorAtTier = (sections: StorefrontSection[], tier: "compact" | "comfy" | "wide") =>
+  renderWithTier(
+    tier,
+    <StorefrontMotionConfig>
+      <StoreFloor sections={sections} onSelectCrate={vi.fn()} />
+    </StorefrontMotionConfig>,
+  );
+
+describe("StoreFloor section labels", () => {
+  describe("Wall section", () => {
+    it("renders picks description text when wall has records", () => {
+      renderFloor([picksSectionWith(4)]);
+
+      expect(screen.getByText(/Today's picks/)).toBeInTheDocument();
+      expect(screen.getByText(/the store's taste at a glance/)).toBeInTheDocument();
+    });
+
+    it("has role=region with accessible label for the wall section", () => {
+      renderFloor([picksSectionWith(4)]);
+
+      const region = screen.getByRole("region", { name: /Wall/i });
+      expect(region).toBeInTheDocument();
+    });
+
+    it("does not render wall section when there are 0 records", () => {
+      renderFloor([picksSectionWith(0)]);
+
+      expect(screen.queryByText(/Today's picks/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Featured section", () => {
+    it("renders 'Curated crates' description text", () => {
+      renderFloor([featuredSection()]);
+
+      expect(screen.getByText(/Curated crates hand-picked by the store/)).toBeInTheDocument();
+    });
+
+    it("has role=region with accessible label for the featured section", () => {
+      renderFloor([featuredSection()]);
+
+      const region = screen.getByRole("region", { name: /Featured/i });
+      expect(region).toBeInTheDocument();
+    });
+
+    it("does not render description when there are 0 crates", () => {
+      renderFloor([{ key: "featured_crates", crates: [] }]);
+
+      expect(screen.queryByText(/Curated crates/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Genre section", () => {
+    it("renders 'Browse the full collection' description text", () => {
+      renderFloor([genreSection()]);
+
+      expect(screen.getByText(/Browse the full collection by genre/)).toBeInTheDocument();
+    });
+
+    it("has role=region with accessible label for the genre section", () => {
+      renderFloor([genreSection()]);
+
+      const region = screen.getByRole("region", { name: /Browse by genre/i });
+      expect(region).toBeInTheDocument();
+    });
+
+    it("does not render description when there are 0 crates", () => {
+      renderFloor([{ key: "genre_grid", crates: [] }]);
+
+      expect(screen.queryByText(/Browse the full collection/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("integration: all three sections have region landmarks", () => {
+    it("renders three distinct region landmarks", () => {
+      renderFloor([picksSectionWith(2), featuredSection(2), genreSection(2)]);
+
+      const regions = screen.getAllByRole("region");
+      expect(regions.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("compact tier renders all section descriptions", () => {
+      renderFloorAtTier([picksSectionWith(2), featuredSection(2), genreSection(2)], "compact");
+
+      expect(screen.getByText(/Today's picks/)).toBeInTheDocument();
+      expect(screen.getByText(/Curated crates hand-picked by the store/)).toBeInTheDocument();
+      expect(screen.getByText(/Browse the full collection by genre/)).toBeInTheDocument();
+    });
+  });
+});

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -79,13 +79,21 @@ export default function StoreFloor({ sections, onSelectCrate }: Props) {
 
           return (
             picks.records.length > 0 && (
-              <PicksShelf
+              <div
                 key="picks"
-                crate={picks}
-                onSelectCrate={onSelectCrate}
-                picksPreviewCount={picksPreviewCount}
-                today={today}
-              />
+                role="region"
+                aria-label="Wall — Today's picks, the store's taste at a glance"
+              >
+                <p className="text-xs text-mc-text-dim mb-3">
+                  Today's picks — the store's taste at a glance
+                </p>
+                <PicksShelf
+                  crate={picks}
+                  onSelectCrate={onSelectCrate}
+                  picksPreviewCount={picksPreviewCount}
+                  today={today}
+                />
+              </div>
             )
           );
         }

--- a/app/frontend/contexts/pile_context.tsx
+++ b/app/frontend/contexts/pile_context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
 import { usePile } from "../hooks/use_pile";
 import type { Listing } from "../types/inertia";
 
@@ -8,6 +8,9 @@ interface PileContextValue {
   removeFromPile: (id: number) => void;
   inPile: (id: number) => boolean;
   clearPile: () => void;
+  /** The most recently added listing, or null. Cleared after the toast dismisses. */
+  lastAdded: Listing | null;
+  clearLastAdded: () => void;
 }
 
 const PileContext = createContext<PileContextValue | null>(null);
@@ -20,7 +23,22 @@ export function PileProvider({
   storeSlug?: string;
 }) {
   const pileState = usePile(storeSlug);
-  return <PileContext.Provider value={pileState}>{children}</PileContext.Provider>;
+  const [lastAdded, setLastAdded] = useState<Listing | null>(null);
+
+  const addToPile = (listing: Listing) => {
+    pileState.addToPile(listing);
+    setLastAdded(listing);
+  };
+
+  const clearLastAdded = () => setLastAdded(null);
+
+  const value = useMemo(
+    () => ({ ...pileState, addToPile, lastAdded, clearLastAdded }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pileState.pile, lastAdded],
+  );
+
+  return <PileContext.Provider value={value}>{children}</PileContext.Provider>;
 }
 
 export function usePileContext() {

--- a/app/frontend/layouts/app_layout.tsx
+++ b/app/frontend/layouts/app_layout.tsx
@@ -3,6 +3,7 @@ import { Link, usePage } from "@inertiajs/react";
 import { useTheme } from "@/hooks/use_theme";
 import { PileProvider, usePileContext } from "@/contexts/pile_context";
 import PileSheet from "@/components/pile_sheet";
+import PileToast from "@/components/pile_toast";
 import StorefrontMotionConfig from "@/components/storefront_motion_config";
 import { ViewportProvider } from "@/contexts/viewport_context";
 import { useViewport } from "@/hooks/use_viewport";
@@ -204,6 +205,7 @@ export function AppLayoutContent({ children, compactLocation }: AppLayoutProps) 
           {children}
         </MilkcrateShell>
       </div>
+      <PileToast />
       <PileSheet
         open={pileOpen}
         onClose={handleClosePile}

--- a/app/frontend/pages/stores/show.tsx
+++ b/app/frontend/pages/stores/show.tsx
@@ -8,10 +8,11 @@ import { useCrateRouting } from "@/hooks/use_crate_routing";
 import type { StoreShowProps } from "@/types/inertia";
 
 export default function StoreShow({ store, crates, storefront_sections }: StoreShowProps) {
-  const { activeSlug, activeCrate, startIndex, selectCrate, backToStore, allCrates } = useCrateRouting({
-    crates,
-    storefront_sections: storefront_sections ?? [],
-  });
+  const { activeSlug, activeCrate, startIndex, selectCrate, backToStore, allCrates } =
+    useCrateRouting({
+      crates,
+      storefront_sections: storefront_sections ?? [],
+    });
   const listingCount = store.total_listings ?? 0;
   const hasStoreSummary = Boolean(store.description) || listingCount > 0;
 
@@ -54,7 +55,7 @@ export default function StoreShow({ store, crates, storefront_sections }: StoreS
               : ""}
           </p>
           <p className="text-xs text-mc-text-dim mt-1">
-            Inventory may be stale. Try running the sync again from the Rails console.
+            Inventory may be out of date. The store owner has been notified.
           </p>
         </FeedbackMessage>
       )}

--- a/app/frontend/test/pages/page_smoke.test.tsx
+++ b/app/frontend/test/pages/page_smoke.test.tsx
@@ -1,17 +1,19 @@
-import React from "react"
-import { describe, expect, it, vi } from "vitest"
-import { render, screen, waitFor, within } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
-import Home from "../../pages/home"
-import Apply from "../../pages/apply"
-import StoreShow from "../../pages/stores/show"
-import Invitation from "../../pages/stores/invitation"
-import Dashboard from "../../pages/admin/dashboard"
-import type { AdminDashboardProps, StoreShowProps, InvitationProps } from "../../types/inertia"
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Home from "../../pages/home";
+import Apply from "../../pages/apply";
+import StoreShow from "../../pages/stores/show";
+import Invitation from "../../pages/stores/invitation";
+import Dashboard from "../../pages/admin/dashboard";
+import type { AdminDashboardProps, StoreShowProps, InvitationProps } from "../../types/inertia";
 
 vi.mock("@inertiajs/react", () => ({
   Link: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-    <a href={href} {...props}>{children}</a>
+    <a href={href} {...props}>
+      {children}
+    </a>
   ),
   useForm: () => ({
     data: {
@@ -35,11 +37,12 @@ vi.mock("@inertiajs/react", () => ({
       },
     },
   }),
-}))
+}));
 
 const homeCopy = {
   headline: "Your Discogs inventory, now a storefront.",
-  subhead: "Milkcrate turns your existing Discogs listings into a warm, browsable record shop that you can share in seconds.",
+  subhead:
+    "Milkcrate turns your existing Discogs listings into a warm, browsable record shop that you can share in seconds.",
   cta_demo: "Browse a store \u2192",
   cta_apply: "Get your store on Milkcrate",
   footnote: "Early access. We handle the setup.",
@@ -57,13 +60,13 @@ const homeCopy = {
   record_fair_body:
     "QR codes on cards, bags, and signage turn foot traffic into return visitors, long after the fair ends.",
   store_character_title: "Your shop. Crated for browsing.",
-}
+};
 
 const previewFallback = {
   store_name: "Philadelphia Music",
   store_slug: null,
   sections: [],
-}
+};
 
 const applyCopy = {
   headline: "Get your store on Milkcrate",
@@ -73,9 +76,12 @@ const applyCopy = {
   confirmation_headline: "You're on the list.",
   confirmation_body: "We'll review your store and reach out to you directly.",
   context_title: "What you need to know",
-  context_discogs_why: "We start with your Discogs username to review inventory quickly. API-key based onboarding is part of our deeper integration direction.",
-  context_what_happens: "After you submit, we review your store, curate your inventory into browsable crates, and reach out when your storefront is live.",
-  context_no_commitment: "No commitment. We're onboarding stores one at a time to make sure every storefront gets personal attention.",
+  context_discogs_why:
+    "We start with your Discogs username to review inventory quickly. API-key based onboarding is part of our deeper integration direction.",
+  context_what_happens:
+    "After you submit, we review your store, curate your inventory into browsable crates, and reach out when your storefront is live.",
+  context_no_commitment:
+    "No commitment. We're onboarding stores one at a time to make sure every storefront gets personal attention.",
   field_hint_discogs: "We pull your inventory from your public Discogs storefront.",
   field_hint_email: "We'll reach out when your Milkcrate storefront is ready.",
   fields: {
@@ -85,7 +91,7 @@ const applyCopy = {
     inventory_size: "Approximate inventory size",
     notes: "Anything else?",
   },
-}
+};
 
 const storeShowProps: StoreShowProps = {
   store: {
@@ -100,7 +106,7 @@ const storeShowProps: StoreShowProps = {
     last_enriched_at: null,
   },
   crates: [],
-}
+};
 
 const adminProps: AdminDashboardProps = {
   discogs_onboarding: {
@@ -142,44 +148,44 @@ const adminProps: AdminDashboardProps = {
       submitted_at: "2026-05-15T12:00:00Z",
     },
   ],
-}
+};
 
 describe("page smoke tests", () => {
   it("renders the home page", () => {
-    render(<Home copy={homeCopy} preview={previewFallback} />)
+    render(<Home copy={homeCopy} preview={previewFallback} />);
 
-    expect(screen.getByRole("heading", { name: homeCopy.headline })).toBeInTheDocument()
-  })
+    expect(screen.getByRole("heading", { name: homeCopy.headline })).toBeInTheDocument();
+  });
 
   it("home page header does not render emoji wordmark", () => {
-    render(<Home copy={homeCopy} preview={previewFallback} />)
+    render(<Home copy={homeCopy} preview={previewFallback} />);
 
     // The layout header link should use BrandMark, not the old emoji wordmark.
     // The wordmark text is plain "Milkcrate" without emoji prefix.
-    const header = document.querySelector("header")
-    expect(header?.textContent).toContain("Milkcrate.")
-    expect(header?.textContent).not.toContain("🥛")
-  })
+    const header = document.querySelector("header");
+    expect(header?.textContent).toContain("Milkcrate.");
+    expect(header?.textContent).not.toContain("🥛");
+  });
 
   it("renders the apply page", () => {
-    render(<Apply copy={applyCopy} turnstile={{ enabled: false, site_key: null }} />)
+    render(<Apply copy={applyCopy} turnstile={{ enabled: false, site_key: null }} />);
 
-    expect(screen.getByRole("heading", { name: applyCopy.headline })).toBeInTheDocument()
-  })
+    expect(screen.getByRole("heading", { name: applyCopy.headline })).toBeInTheDocument();
+  });
 
   it("apply page does not render emoji branding", () => {
-    render(<Apply copy={applyCopy} turnstile={{ enabled: false, site_key: null }} />)
+    render(<Apply copy={applyCopy} turnstile={{ enabled: false, site_key: null }} />);
 
-    const textContent = document.body.textContent || ""
-    expect(textContent).not.toContain("🥛")
-    expect(textContent).not.toContain("📦")
-  })
+    const textContent = document.body.textContent || "";
+    expect(textContent).not.toContain("🥛");
+    expect(textContent).not.toContain("📦");
+  });
 
   it("renders the store page", () => {
-    render(<StoreShow {...storeShowProps} />)
+    render(<StoreShow {...storeShowProps} />);
 
-    expect(screen.getByText(/No vinyl found yet/)).toBeInTheDocument()
-  })
+    expect(screen.getByText(/No vinyl found yet/)).toBeInTheDocument();
+  });
 
   it("does not render zero listing count as stray text", () => {
     render(
@@ -187,67 +193,82 @@ describe("page smoke tests", () => {
         {...storeShowProps}
         store={{ ...storeShowProps.store, description: null, total_listings: 0 }}
       />,
-    )
+    );
 
-    expect(screen.queryByText("0")).not.toBeInTheDocument()
-  })
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("shows shopper-safe copy when sync_status is failed", () => {
+    render(
+      <StoreShow
+        {...storeShowProps}
+        store={{ ...storeShowProps.store, sync_status: "failed", last_sync_error_at: null }}
+      />,
+    );
+
+    expect(screen.getByText(/Inventory may be out of date/)).toBeInTheDocument();
+    expect(screen.queryByText(/Rails console/)).not.toBeInTheDocument();
+  });
 
   it("renders the admin dashboard", () => {
-    render(<Dashboard {...adminProps} />)
+    render(<Dashboard {...adminProps} />);
 
-    expect(screen.getByRole("heading", { name: "Store operations" })).toBeInTheDocument()
-    expect(screen.getByText("Healthy Records")).toBeInTheDocument()
-    expect(screen.getByText("Applicant Records")).toBeInTheDocument()
-  })
+    expect(screen.getByRole("heading", { name: "Store operations" })).toBeInTheDocument();
+    expect(screen.getByText("Healthy Records")).toBeInTheDocument();
+    expect(screen.getByText("Applicant Records")).toBeInTheDocument();
+  });
 
   it("store page footer does not render emoji branding", () => {
-    render(<StoreShow {...storeShowProps} />)
+    render(<StoreShow {...storeShowProps} />);
 
     // The footer "Powered by Milkcrate" should be plain text — no emoji.
-    const footer = document.querySelector("footer")
-    expect(footer).toBeInTheDocument()
-    expect(footer?.textContent).not.toContain("🥛")
-    expect(footer?.textContent).toContain("Milkcrate.")
-  })
+    const footer = document.querySelector("footer");
+    expect(footer).toBeInTheDocument();
+    expect(footer?.textContent).not.toContain("🥛");
+    expect(footer?.textContent).toContain("Milkcrate.");
+  });
 
   // Cross-surface emoji regression matrix — guards against any page
   // re-introducing milk emoji or emoji-based wordmarks.
   describe.each([
     ["home", () => render(<Home copy={homeCopy} preview={previewFallback} />)],
-    ["apply", () => render(<Apply copy={applyCopy} turnstile={{ enabled: false, site_key: null }} />)],
+    [
+      "apply",
+      () => render(<Apply copy={applyCopy} turnstile={{ enabled: false, site_key: null }} />),
+    ],
     ["store", () => render(<StoreShow {...storeShowProps} />)],
     ["admin", () => render(<Dashboard {...adminProps} />)],
   ])("emoji regression: %s page", (_label, renderPage) => {
     it("does not render the milk emoji (🥛)", () => {
-      renderPage()
-      expect(document.body.textContent).not.toContain("🥛")
-    })
+      renderPage();
+      expect(document.body.textContent).not.toContain("🥛");
+    });
 
     it("does not render the old emoji wordmark (🥛 Milkcrate)", () => {
-      renderPage()
-      expect(document.body.textContent).not.toContain("🥛 Milkcrate")
-    })
+      renderPage();
+      expect(document.body.textContent).not.toContain("🥛 Milkcrate");
+    });
 
     it("does not render decorative emoji icons (📀, 👀, 📦, ♪)", () => {
-      renderPage()
-      const text = document.body.textContent || ""
-      expect(text).not.toContain("📀")
-      expect(text).not.toContain("👀")
-      expect(text).not.toContain("📦")
-    })
+      renderPage();
+      const text = document.body.textContent || "";
+      expect(text).not.toContain("📀");
+      expect(text).not.toContain("👀");
+      expect(text).not.toContain("📦");
+    });
 
     it("does not render deprecated control or feedback recipe classes", () => {
-      const { container } = renderPage()
-      expect(container.innerHTML).not.toMatch(/\bmc-(?:btn|input|notice)\b/)
-    })
-  })
+      const { container } = renderPage();
+      expect(container.innerHTML).not.toMatch(/\bmc-(?:btn|input|notice)\b/);
+    });
+  });
 
   it("hides store description after entering a crate", async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
       value: 390,
-    })
+    });
     const props: StoreShowProps = {
       ...storeShowProps,
       crates: [
@@ -307,70 +328,86 @@ describe("page smoke tests", () => {
           },
         },
       ],
-    }
+    };
 
-    render(<StoreShow {...props} />)
+    render(<StoreShow {...props} />);
 
-    expect(screen.getByText("Independent record store in South Philly.")).toBeInTheDocument()
+    expect(screen.getByText("Independent record store in South Philly.")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Open Milkcrate Picks" }))
+    await user.click(screen.getByRole("button", { name: "Open Milkcrate Picks" }));
 
-    expect(screen.queryByText("Independent record store in South Philly.")).not.toBeInTheDocument()
-    expect(screen.queryByText("120 vinyl listings")).not.toBeInTheDocument()
-    expect(within(screen.getByRole("banner")).getByRole("button", { name: "Back to store" })).toBeInTheDocument()
-    expect(within(screen.getByRole("main")).queryByRole("button", { name: "Back to store" })).not.toBeInTheDocument()
-  })
+    expect(screen.queryByText("Independent record store in South Philly.")).not.toBeInTheDocument();
+    expect(screen.queryByText("120 vinyl listings")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByRole("banner")).getByRole("button", { name: "Back to store" }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("main")).queryByRole("button", { name: "Back to store" }),
+    ).not.toBeInTheDocument();
+  });
 
   describe("invitation page", () => {
     const inviteProps: InvitationProps = {
       waitlist_present: false,
       slug: "test-slug",
-    }
+    };
 
     it("renders the invitation page without crashing", async () => {
-      render(<Invitation {...inviteProps} />)
+      render(<Invitation {...inviteProps} />);
       // Fetch fails in test env, so probe settles on error → generic invitation
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
-      })
-    })
+        expect(
+          screen.getByRole("heading", { name: /This page is available/i }),
+        ).toBeInTheDocument();
+      });
+    });
 
     it("renders waitlist acknowledgment when waitlist_present is true", async () => {
-      render(<Invitation {...inviteProps} waitlist_present={true} />)
+      render(<Invitation {...inviteProps} waitlist_present={true} />);
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: /This URL has been claimed/i })).toBeInTheDocument()
-      })
+        expect(
+          screen.getByRole("heading", { name: /This URL has been claimed/i }),
+        ).toBeInTheDocument();
+      });
       // BrandMark wordmark appears at least once (header + possibly hero area)
-      expect(screen.getAllByText("Milkcrate.").length).toBeGreaterThanOrEqual(1)
-    })
+      expect(screen.getAllByText("Milkcrate.").length).toBeGreaterThanOrEqual(1);
+    });
 
     it("handles fetch error gracefully for valid slugs", async () => {
-      render(<Invitation {...inviteProps} slug="valid-store" />)
+      render(<Invitation {...inviteProps} slug="valid-store" />);
       // The fetch will fail in test (no server), so it should settle on generic invitation
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
-      })
-    })
+        expect(
+          screen.getByRole("heading", { name: /This page is available/i }),
+        ).toBeInTheDocument();
+      });
+    });
 
     it("skips probe and shows generic invitation for short slugs", async () => {
-      render(<Invitation {...inviteProps} slug="ab" />)
+      render(<Invitation {...inviteProps} slug="ab" />);
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
-      })
-    })
+        expect(
+          screen.getByRole("heading", { name: /This page is available/i }),
+        ).toBeInTheDocument();
+      });
+    });
 
     it("skips probe for reserved slugs", async () => {
-      render(<Invitation {...inviteProps} slug="admin" />)
+      render(<Invitation {...inviteProps} slug="admin" />);
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
-      })
-    })
+        expect(
+          screen.getByRole("heading", { name: /This page is available/i }),
+        ).toBeInTheDocument();
+      });
+    });
 
     it("skips probe for slugs with invalid characters", async () => {
-      render(<Invitation {...inviteProps} slug="bad!slug" />)
+      render(<Invitation {...inviteProps} slug="bad!slug" />);
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: /This page is available/i })).toBeInTheDocument()
-      })
-    })
-  })
-})
+        expect(
+          screen.getByRole("heading", { name: /This page is available/i }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/docs/plans/2026-06-01-002-feat-storefront-mobile-hierarchy-gaps-plan.md
+++ b/docs/plans/2026-06-01-002-feat-storefront-mobile-hierarchy-gaps-plan.md
@@ -1,0 +1,439 @@
+---
+title: "feat: Close storefront mobile hierarchy gaps G1–G5"
+type: feat
+status: completed
+date: 2026-06-01
+origin: docs/brainstorms/2026-06-01-storefront-mobile-hierarchy-requirements.md
+---
+
+# feat: Close Storefront Mobile Hierarchy Gaps G1–G5
+
+## Summary
+
+Implement the five hierarchy gaps identified in the storefront mobile-first
+requirements doc — store-floor section labels, compact record inspection
+affordance, pile confirmation signal, Discogs handoff framing, and sync
+failure copy. All changes are copy, labeling, affordance, and semantic; no
+visual redesign or backend changes.
+
+---
+
+## Problem Frame
+
+The cohesion audit and hierarchy requirements confirmed that Milkcrate's
+structural backbone (crate routing, pile persistence, responsive adaptation)
+is sound. The gap is that the compact shopper cannot always read the store
+floor, record inspection, and handoff transitions clearly. Five specific
+hierarchy issues make the product loop feel less cohesive than the code already
+supports.
+
+(see origin: `docs/brainstorms/2026-06-01-storefront-mobile-hierarchy-requirements.md`)
+
+---
+
+## Requirements
+
+- R1. Store-floor sections (Wall, Featured, Browse by genre) communicate their
+  distinct jobs to a first-time compact shopper through labels and accessible
+  names.
+- R2. Interactive shelf headers use native `<button>` elements rather than
+  `div[role="button"]` for semantic clarity and assistive technology.
+- R3. Compact record inspection has a visible affordance that signals the
+  Record moment without depending solely on the undisclosed flip interaction.
+- R4. Adding a record to the pile produces a system-level confirmation signal
+  beyond local button state change.
+- R5. Direct Discogs listing links frame the action as a handoff rather than a
+  generic external link.
+- R6. Sync failure copy does not leak developer operations ("Rails console")
+  to shoppers.
+- R7. All changes preserve existing responsive behavior — compact, comfy, and
+  wide tiers continue to work as specified.
+
+**Origin flows:** Store orientation (Mode 1), Wall (Mode 2), Crate entry
+(Mode 3), Record inspection (Mode 5), Pile review (Mode 6), Discogs handoff
+(Mode 7).
+
+---
+
+## Scope Boundaries
+
+- No visual redesign — layout, color, spacing, and animation systems are unchanged.
+- No backend changes — no model, service, or controller modifications.
+- No data-model renames — Discogs integration nouns stay precise at boundaries.
+- No pile checkout, reservation, or purchase claims.
+- No broader component refactoring beyond what the 5 gaps require.
+
+### Deferred to Follow-Up Work
+
+- **Store-floor visual differentiation:** Once section labels and semantics are in place (U1), define how Wall, Featured, and Genre sections look visually distinct from each other — different card treatments, layout rhythms, spacing, or accent use. This is a design issue that builds on the labeling infrastructure, not a prerequisite for it.
+- Stale Discogs "cart" reference in `docs/design.md` (mentioned in G4): separate docs PR.
+- RecordCard nested interactive element deep refactor (G2 scopes to affordance addition, not full card architecture rewrite).
+- Store-floor visual density changes at wider tiers (outside this hierarchy-labeling scope).
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `app/frontend/contexts/viewport_context.tsx` — three-tier viewport system (compact ≤767px, comfy 768–1023px, wide ≥1024px)
+- `app/frontend/components/store_floor.tsx` — renders `PicksShelf`, `FeaturedCratesRow`, `GenreGrid` as sections with no role copy
+- `app/frontend/components/crate_shelf.tsx` — interactive variant uses `div[role="button"]` with `tabIndex={0}` and `onKeyDown` on the header wrapper
+- `app/frontend/components/crate_section_grid.tsx` — section header is a plain `<span>` for title + count, no role label
+- `app/frontend/components/record_card.tsx` — flip interaction via `role="button"` on outer div, back face has `+ Pile` and `Discogs ↗` buttons
+- `app/frontend/components/record_details.tsx` — desktop detail panel with `Discogs ↗` ActionLink
+- `app/frontend/pages/stores/show.tsx` — sync failure message with "Try running the sync again from the Rails console"
+- `app/frontend/components/pile_sheet.tsx` — existing pile trigger in header appears after first add
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md` — documents the nested button hydration issue and the `div[role="button"]` pattern. Notes: "Any element that needs to be clickable AND contain interactive children must use `role="button"` on a `<div>`, not a `<button>` element."
+- The CrateShelf header specifically DOES contain interactive children (the thumbnail `<button>` elements are siblings in the grid below, not nested in the header `div[role="button"]`). The header `div[role="button"]` wraps ONLY the header content (name + count + open label) — it does NOT wrap the thumbnail buttons. This means conversion to a native `<button>` is safe because the header contains no nested interactive elements.
+- `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md` — motion token system to respect when adding any animated feedback.
+
+### External References
+
+- WCAG 2.2 AA requires that interactive elements have discernible accessible names. The current `div[role="button"]` approach works but native `<button>` is preferred when nesting isn't required.
+- `prefers-reduced-motion` must be respected for any new animations (pile confirmation).
+
+---
+
+## Key Technical Decisions
+
+- **G1 shelf header → native `<button>`**: The CrateShelf interactive header wraps only the header text content (name, count, open label). The thumbnail grid is a sibling element, not nested inside the header. Converting from `div[role="button"]` to a native `<button>` with reset styles is safe and preferred for assistive tech.
+- **G2 compact affordance approach**: Add a text hint ("Tap card to inspect") below the active card on compact viewports only. This keeps the card stack as the primary immersive experience while surfacing the hidden flip interaction. The hint auto-hides after the first flip in a session (localStorage flag).
+- **G3 pile confirmation signal**: Use a brief animated notification (toast) that appears near the pile trigger in the header when a record is added. Auto-dismisses after ~2s. Respects `prefers-reduced-motion` (instant show/hide without animation). This avoids interrupting browsing flow while closing the feedback loop.
+- **G4 Discogs link copy**: Change "Discogs ↗" to "View on Discogs ↗" for compact (shorter) and "View listing on Discogs ↗" for comfy/wide (more space). Add `aria-label` with record title for screen readers.
+- **G5 sync failure copy**: Replace developer-facing "Try running the sync again from the Rails console" with shopper-safe "Inventory may be out of date. The store owner has been notified." No backend notification wiring — just copy change.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the inspection hint persist or auto-hide?** Auto-hide after first flip. A persistent hint clutters the immersive crate experience once the shopper understands the interaction.
+- **Should the pile toast include the record name?** Yes — "Added [title] to pile" gives specific confirmation. Truncate at ~30 chars with ellipsis for long titles.
+- **Should section labels be visually prominent or subtle?** Subtle — small text beneath the section title that explains the job. Not a full redesign of the section headers.
+
+### Deferred to Implementation
+
+- Exact animation duration/easing for the pile toast — use existing `springTactile` tokens as starting point, tune in implementation.
+- Whether the inspection hint uses a separate localStorage key per store or a global key — implementation-time decision based on session model.
+
+---
+
+## Implementation Units
+
+### U1. Store-floor section labels with role copy
+
+**Goal:** Add descriptive role copy to each store-floor section so a compact
+shopper understands what Wall, Featured, and Browse by genre do in the
+browsing session.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/components/store_floor.tsx`
+- Modify: `app/frontend/components/crate_section_grid.tsx`
+- Modify: `app/frontend/components/featured_crates_row.tsx`
+- Modify: `app/frontend/components/genre_grid.tsx`
+- Create: `app/frontend/components/store_floor.test.tsx`
+
+**Approach:**
+- Add a `description` prop to `CrateSectionGrid` — a short string rendered as
+  `<p>` below the section title in smaller, dimmer text.
+- `FeaturedCratesRow` passes description: "Curated crates hand-picked by the store"
+- `GenreGrid` passes description: "Browse the full collection by genre"
+- `StoreFloor` adds a section label to the `PicksShelf` area: "Today's picks —
+  the store's taste at a glance" (rendered above or inside the shelf header)
+- Add `aria-label` or `aria-describedby` to each section's container `<div>`
+  so screen readers announce the section's job
+- Add `role="region"` with `aria-label` to each section for landmark navigation
+
+**Patterns to follow:**
+- Existing `CrateSectionGrid` header pattern (title + count in a border-b div)
+- `mc-section-name` and `mc-section-count` class naming convention
+
+**Test scenarios:**
+- Happy path: Store floor renders Wall section with descriptive label text visible
+- Happy path: Featured section renders with "Curated crates" description
+- Happy path: Genre section renders with "Browse the full collection" description
+- Edge case: Empty sections (0 crates) do not render descriptions
+- Integration: Each section has `role="region"` with an `aria-label`
+- Integration: Screen reader accessible names include both section title and description
+
+**Verification:**
+- All three store-floor sections render role copy at compact tier
+- `role="region"` landmarks are present with accessible names
+- Existing visual layout is preserved (descriptions are additive, not disruptive)
+
+---
+
+### U2. Convert CrateShelf header to native button
+
+**Goal:** Replace the `div[role="button"]` interactive header in CrateShelf
+with a native `<button>` element for better semantic clarity and assistive
+technology support.
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/components/crate_shelf.tsx`
+- Modify: `app/frontend/components/crate_shelf.test.tsx`
+
+**Approach:**
+- In `CrateShelfLayout`, when `interactive` is true, render the header content
+  inside a native `<button>` element with reset styles (`appearance-none`,
+  `bg-transparent`, `border-none`, `w-full`, `text-left`, `cursor-pointer`).
+- Remove `role="button"`, `tabIndex`, and custom `onKeyDown` handler from the
+  header `<div>` — the native button handles all of this.
+- Keep the `onClick` handler and `aria-label` on the button.
+- Keep the existing focus-visible ring styles.
+- The thumbnail grid remains a sibling to the header, not nested inside the
+  button — no button nesting issue.
+
+**Patterns to follow:**
+- The `Button` component in `app/frontend/components/ui/button.tsx` for reset
+  style conventions
+- The established pattern from `viewport-context-responsive-architecture` learning:
+  native `<button>` is preferred when no interactive children are nested
+
+**Test scenarios:**
+- Happy path: Interactive CrateShelf renders header as a native `<button>` element
+- Happy path: Clicking the header button calls `onSelectCrate` with the crate slug
+- Happy path: Keyboard Enter/Space on the header button activates selection
+- Edge case: Non-interactive CrateShelf renders no button (existing behavior preserved)
+- Integration: No `<button>` elements are nested inside other `<button>` elements (extend existing accessibility test)
+
+**Verification:**
+- `document.querySelector('[role="button"]')` returns null for the interactive header (it's now a real button)
+- Existing CrateShelf visual appearance is unchanged
+- Accessibility test for nested buttons continues to pass
+
+---
+
+### U3. Compact record inspection affordance
+
+**Goal:** Add a visible affordance on compact viewports that signals the
+Record inspection moment without depending solely on the undisclosed card flip.
+
+**Requirements:** R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/components/crate_view/card_stack.tsx`
+- Create: `app/frontend/components/crate_view/inspection_hint.tsx`
+- Create: `app/frontend/components/crate_view/inspection_hint.test.tsx`
+
+**Approach:**
+- Create an `InspectionHint` component that renders "Tap card to inspect"
+  text below the active card on compact viewports only.
+- The hint is visible until the shopper flips a card for the first time in
+  this session (tracked via localStorage key, e.g., `mc-flip-discovered`).
+- After the first flip, the hint fades out and does not return for that session.
+- The hint renders as a `<p>` with `role="status"` so screen readers can
+  announce it, but it's not disruptive.
+- `CardStack` conditionally renders `InspectionHint` when `isCompact` is true
+  and the localStorage flag is not set.
+- Respects `prefers-reduced-motion` — if reduced motion is preferred, the hint
+  disappears instantly rather than fading.
+
+**Patterns to follow:**
+- `GestureHintOverlay` in `app/frontend/components/crate_view/gesture_hint_overlay.tsx`
+  — similar pattern of a discoverable hint that disappears after first interaction
+- `useReducedMotionContext` for motion preferences
+
+**Test scenarios:**
+- Happy path: InspectionHint renders "Tap card to inspect" on compact viewport when localStorage flag is absent
+- Happy path: InspectionHint does not render on comfy/wide viewports
+- Happy path: After setting the localStorage flag, InspectionHint does not render
+- Edge case: Component renders correctly when localStorage is unavailable (SSR/privacy mode) — defaults to showing hint
+- Integration: Hint disappears after first card flip interaction in the same session
+
+**Verification:**
+- Compact storefront shows inspection affordance text on first visit
+- Non-compact viewports (where RecordDetails panel is visible) do not show the hint
+- Hint does not reappear after first flip
+
+---
+
+### U4. Pile confirmation signal
+
+**Goal:** Add a system-level confirmation when a record enters the pile,
+closing the feedback gap between "I tapped + Pile" and "my pile has this
+record."
+
+**Requirements:** R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `app/frontend/components/pile_toast.tsx`
+- Create: `app/frontend/components/pile_toast.test.tsx`
+- Modify: `app/frontend/contexts/pile_context.tsx`
+
+**Approach:**
+- Create a `PileToast` component — a small notification that appears near the
+  top of the viewport (below the sticky header) when a record is added.
+- Content: "Added [title] to pile" (title truncated at ~30 chars).
+- Auto-dismisses after 2 seconds. Respects `prefers-reduced-motion` (no
+  slide animation, instant show/hide).
+- `PileContext` exposes a `lastAdded` state (the most recent listing added,
+  or null). When `addToPile` is called, set `lastAdded` to that listing.
+  Clear it after the toast auto-dismisses.
+- `PileToast` subscribes to `lastAdded` from context and renders when non-null.
+- Mount `PileToast` inside `AppLayoutContent` (after the header, before
+  children) so it's available across all modes.
+- Uses existing motion tokens (`springTactile`) for enter/exit animation.
+- Renders with `role="status"` and `aria-live="polite"` for screen reader
+  announcement.
+
+**Patterns to follow:**
+- `FeedbackMessage` component in `app/frontend/components/ui/feedback_message.tsx`
+  for tone and structure inspiration
+- `springTactile` motion token for animation
+- `AnimatePresence` from framer-motion for enter/exit
+
+**Test scenarios:**
+- Happy path: Adding a record to pile causes PileToast to render with the record title
+- Happy path: Toast auto-dismisses after timeout (use fake timers)
+- Happy path: Toast renders with `role="status"` and `aria-live="polite"`
+- Edge case: Adding a second record while toast is visible replaces the toast content with the new record
+- Edge case: Very long titles are truncated with ellipsis
+- Error path: If `lastAdded` is null, no toast renders
+- Integration: Full flow — add to pile in RecordCard, toast appears, pile trigger appears in header
+
+**Verification:**
+- Adding a record from any surface (card back face or RecordDetails panel)
+  triggers the toast
+- Toast does not persist or block interaction
+- Screen readers announce the addition
+
+---
+
+### U5. Discogs handoff link framing
+
+**Goal:** Update direct Discogs listing links to frame the action as a
+handoff rather than a generic external link.
+
+**Requirements:** R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/components/record_card.tsx`
+- Modify: `app/frontend/components/record_details.tsx`
+- Modify: `app/frontend/components/record_card.test.tsx`
+
+**Approach:**
+- In `RecordCard` back face: change link text from "Discogs ↗" to
+  "View on Discogs ↗". Add `aria-label` of
+  `View listing for [title] on Discogs (opens in new tab)`.
+- In `RecordDetails`: change link text from "Discogs ↗" to
+  "View listing on Discogs ↗" (more horizontal space available). Add same
+  `aria-label` pattern.
+- Both links already have `target="_blank"` and `rel="noopener noreferrer"`.
+- Keep the `ActionLink` component usage — only change the text content and
+  add the `aria-label` prop.
+
+**Patterns to follow:**
+- Existing `ActionLink` component API in `app/frontend/components/ui/action.tsx`
+- The pile handoff pattern in `PileFooter` which already frames the Discogs
+  action with store context
+
+**Test scenarios:**
+- Happy path: RecordCard back face renders "View on Discogs ↗" link text
+- Happy path: RecordDetails renders "View listing on Discogs ↗" link text
+- Happy path: Both links have aria-label including the record title and "(opens in new tab)"
+- Edge case: Record with no title uses fallback "this record" in aria-label
+- Integration: Links still open in new tab with correct href
+
+**Verification:**
+- No instance of bare "Discogs ↗" text remains in record card or details
+- Accessible names communicate destination and action clearly
+- Existing link behavior (new tab, noopener) is preserved
+
+---
+
+### U6. Sync failure copy cleanup
+
+**Goal:** Replace developer-facing sync failure copy with shopper-safe
+language that does not leak internal operations.
+
+**Requirements:** R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/pages/stores/show.tsx`
+- Modify: `app/frontend/test/pages/page_smoke.test.tsx` (or create a targeted test)
+
+**Approach:**
+- Replace the string "Try running the sync again from the Rails console" with
+  "Inventory may be out of date. The store owner has been notified."
+- Keep the `FeedbackMessage` component with `tone="danger"` and the
+  `last_sync_error_at` timestamp display.
+- No backend notification wiring is added — the copy change is sufficient for
+  this scope. Owner notification routing is a separate concern.
+
+**Patterns to follow:**
+- Existing `FeedbackMessage` usage in the same file for sync/enrichment states
+- Shopper-facing copy style: brief, clear, no jargon
+
+**Test scenarios:**
+- Happy path: When `sync_status === "failed"`, the page renders "Inventory may be out of date" text
+- Happy path: The text "Rails console" does not appear anywhere in the rendered output
+- Edge case: When `last_sync_error_at` is null, the timestamp clause is omitted (existing behavior)
+
+**Verification:**
+- No developer-facing language appears in shopper-visible sync failure state
+- The `FeedbackMessage` tone and structure remain correct
+- Existing page smoke tests continue to pass
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** PileContext gains a `lastAdded` state and the toast
+  component subscribes to it. No callbacks, middleware, or observers are added
+  beyond this local state.
+- **Error propagation:** No new error paths introduced. Toast handles edge
+  cases (null, long titles) gracefully.
+- **State lifecycle risks:** The `lastAdded` state is ephemeral (auto-clears
+  after timeout). The localStorage flag for inspection hint is per-browser,
+  not per-session — acceptable for a progressive disclosure pattern.
+- **API surface parity:** The Discogs link text change applies to both
+  RecordCard (compact) and RecordDetails (comfy/wide), maintaining parity.
+- **Integration coverage:** U4 (pile toast) crosses PileContext → AppLayout
+  → toast component — the integration test verifies the full path.
+- **Unchanged invariants:** Card stack drag/swipe behavior, pile sheet
+  dialog semantics, focus trapping, crate routing, and all responsive
+  layout breakpoints are explicitly unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| CrateShelf button conversion breaks existing animation wrappers | The header is NOT inside the motion wrapper — motion is on the outer container. Button conversion only affects the header content div. |
+| Inspection hint feels cluttered on small screens | Keep text minimal ("Tap card to inspect"), position below the card stack (not overlaying), auto-hide after first flip. |
+| Pile toast interferes with browsing flow | 2s auto-dismiss, positioned non-intrusively below header. Does not block interaction or require dismissal. |
+| Section role copy adds visual noise to clean floor | Use `text-xs text-mc-text-dim` — subtle, not prominent. Only adds ~12px of height per section. |
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-01-storefront-mobile-hierarchy-requirements.md](docs/brainstorms/2026-06-01-storefront-mobile-hierarchy-requirements.md)
+- **Cohesion audit:** [docs/reviews/2026-06-01-storefront-cohesion-audit.md](docs/reviews/2026-06-01-storefront-cohesion-audit.md)
+- **Parent plan:** [docs/plans/2026-06-01-001-feat-storefront-experience-language-issues-plan.md](docs/plans/2026-06-01-001-feat-storefront-experience-language-issues-plan.md)
+- Related code: `app/frontend/components/store_floor.tsx`, `app/frontend/components/crate_shelf.tsx`, `app/frontend/components/record_card.tsx`
+- Related issue: #217 (storefront mobile hierarchy)
+- Institutional learning: `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`


### PR DESCRIPTION
## Summary

Five storefront hierarchy gaps that made the compact shopper experience feel disconnected are now closed. Store sections communicate their distinct jobs, the card inspection interaction has a visible affordance, pile additions produce a system-level confirmation, Discogs links clearly signal a handoff, and developer-facing error copy no longer reaches shoppers. No visual redesign — all changes are copy, labeling, affordance, and semantic.

## What changed and why

**Store-floor section labels (R1):** Wall, Featured, and Browse by genre sections now carry short descriptive copy ("Today's picks — the store's taste at a glance", "Curated crates hand-picked by the store", "Browse the full collection by genre") rendered below each section title in `text-xs text-mc-text-dim`. Each section is wrapped in `role="region"` with an `aria-label` so screen readers can navigate by landmark. `CrateSectionGrid` gained an optional `description` prop to keep the pattern DRY.

**Semantic shelf header (R2):** The `CrateShelf` interactive header was a `div[role="button"]` with manual `tabIndex`, `onKeyDown`, and `role`. The header wraps only its own text content — the thumbnail grid is a sibling, not nested inside — so conversion to a native `<button>` is safe. The custom keyboard handling and ARIA attributes are removed; the browser handles all of it. Tests updated to assert `tagName === "BUTTON"` rather than `tabindex="0"`.

**Compact inspection affordance (R3):** A "Tap card to inspect" hint renders below the active card on compact viewports for first-time visitors. It hides after the first card flip (localStorage flag `mc-flip-discovered`) and does not return for the session. Respects `prefers-reduced-motion`. The hint is a `<p role="status">` so screen readers can announce it without interruption.

**Pile confirmation toast (R4):** A `PileToast` component mounts inside `AppLayoutContent` and subscribes to a new `lastAdded` state in `PileContext`. When any surface calls `addToPile`, the toast appears with "Added [title] to pile" (title truncated at 30 chars), auto-dismisses after 2 seconds, and announces via `aria-live="polite"`. Respects `prefers-reduced-motion` (no slide animation, instant show/hide).

**Discogs handoff framing (R5):** "Discogs ↗" becomes "View on Discogs ↗" on the record card back face and "View listing on Discogs ↗" in the record details panel. Both links gain `aria-label` with the record title and "(opens in new tab)" for screen readers. Existing `target="_blank"` and `rel="noopener noreferrer"` are preserved.

**Sync failure copy (R6):** "Try running the sync again from the Rails console" — visible to shoppers but only actionable by a developer — is replaced with "Inventory may be out of date. The store owner has been notified." No backend wiring; copy change only.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. All changes are frontend copy, labeling, and affordance. No new network requests, backend state, or data model changes. No feature flags. The pile toast state is ephemeral (clears after 2s timeout) and the inspection hint flag is browser-local (localStorage). Rollback is a revert deploy if visual regressions appear.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude_Sonnet_4.5_%28200K%29](https://img.shields.io/badge/Claude_Sonnet_4.5_%28200K%29-D97757?logo=claude&logoColor=white)
