### PR TITLE
feat(wall): Editorial Marquee — borderless grid, ghost cue, tap feedback

### DIFF
--- a/app/frontend/components/crate_shelf.tsx
+++ b/app/frontend/components/crate_shelf.tsx
@@ -19,6 +19,10 @@ interface BaseCrateShelfProps {
   tactileThumbnails?: boolean;
   /** Additional class for the outer container (used by CrateCard to strip border). */
   className?: string;
+  /** Optional CSS transform scale applied to RecordTile wrappers (e.g. 1.5 for Wall). */
+  coverScale?: number;
+  /** Optional Tailwind gap class override for the record grid (e.g. "gap-3"). */
+  gridGap?: string;
 }
 
 interface StaticCrateShelfProps extends BaseCrateShelfProps {
@@ -55,6 +59,8 @@ interface ShelfInteractionConfig {
 
 interface ShelfGridConfig {
   gridCols: number;
+  gridGap: string;
+  coverScale?: number;
 }
 
 function CrateShelfLayout({
@@ -72,7 +78,7 @@ function CrateShelfLayout({
 }) {
   const { headerSize = "genre", meta, openLabel, previewCount } = header;
   const { interactive, onSelectCrate, isHovered, tactileThumbnails } = interaction;
-  const { gridCols } = grid;
+  const { gridCols, gridGap, coverScale } = grid;
   const innerHoverScale = 1 + (SCALE_HOVER - 1) / 2;
   const nameClass = headerSize === "featured" ? "text-base font-semibold" : "text-sm font-semibold";
 
@@ -112,11 +118,29 @@ function CrateShelfLayout({
       {/* Record grid */}
       {crate.records.length > 0 ? (
         <div
-          className="grid gap-1.5 px-3 pb-3 pt-1.5"
+          className={`grid ${gridGap} px-3 pb-3 pt-1.5`}
           style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
         >
-          {crate.records.slice(0, previewCount).map((record, i) =>
-            interactive ? (
+          {crate.records.slice(0, previewCount).map((record, i) => {
+            const tileWrapperStyle = coverScale
+              ? { transform: `scale(${coverScale})`, transformOrigin: "center center" as const }
+              : undefined;
+
+            const tileElement = (
+              <span style={tileWrapperStyle} className="inline-block">
+                <RecordTile listing={record} imageLoading="lazy" tactileHover={tactileThumbnails} />
+              </span>
+            );
+
+            if (!interactive) {
+              return (
+                <span key={record.id}>
+                  <RecordTile listing={record} imageLoading="lazy" />
+                </span>
+              );
+            }
+
+            return (
               <button
                 key={record.id}
                 type="button"
@@ -128,17 +152,11 @@ function CrateShelfLayout({
                   animate={{ scale: isHovered ? innerHoverScale : 1 }}
                   transition={springTactile}
                 >
-                  <RecordTile
-                    listing={record}
-                    imageLoading="lazy"
-                    tactileHover={tactileThumbnails}
-                  />
+                  {tileElement}
                 </motion.div>
               </button>
-            ) : (
-              <RecordTile key={record.id} listing={record} imageLoading="lazy" />
-            ),
-          )}
+            );
+          })}
         </div>
       ) : (
         <div className="aspect-square flex items-center justify-center text-mc-text-dim text-xs px-3 pb-3">
@@ -166,8 +184,11 @@ function StaticCrateShelf(params: StaticCrateShelfProps) {
     headerSize = "genre",
     tactileThumbnails = false,
     className,
+    coverScale,
+    gridGap,
   } = params;
   const gridCols = gridColumnCount(previewCount);
+  const effectiveGap = gridGap ?? "gap-1.5";
   const containerClassName = [
     "flex flex-col w-full rounded-lg bg-mc-bg-card border border-mc-border overflow-hidden text-left",
     className,
@@ -186,7 +207,7 @@ function StaticCrateShelf(params: StaticCrateShelfProps) {
           onSelectCrate: undefined,
           tactileThumbnails,
         }}
-        grid={{ gridCols }}
+        grid={{ gridCols, gridGap: effectiveGap, coverScale }}
         headerProps={{}}
       />
     </div>
@@ -206,8 +227,11 @@ function InteractiveCrateShelf(params: InteractiveCrateShelfProps) {
     tactileThumbnails = false,
     className,
     isHovered: externalHovered,
+    coverScale,
+    gridGap,
   } = params;
   const gridCols = gridColumnCount(previewCount);
+  const effectiveGap = gridGap ?? "gap-1.5";
 
   // When wrapped by CrateCard (or another parent that manages hover), use the
   // external hover state. Otherwise, compute our own.
@@ -239,7 +263,7 @@ function InteractiveCrateShelf(params: InteractiveCrateShelfProps) {
         crate={crate}
         header={{ headerSize, meta, openLabel, previewCount }}
         interaction={{ interactive: true, onSelectCrate, isHovered, tactileThumbnails }}
-        grid={{ gridCols }}
+        grid={{ gridCols, gridGap: effectiveGap, coverScale }}
         headerProps={{
           as: "button",
           onClick: handleSelectCrate,

--- a/app/frontend/components/store_floor.test.tsx
+++ b/app/frontend/components/store_floor.test.tsx
@@ -87,6 +87,38 @@ describe("StoreFloor section labels", () => {
 
       expect(screen.queryByText(/Today's picks/)).not.toBeInTheDocument();
     });
+
+    it("renders borderless on compact tier", () => {
+      renderFloorAtTier([picksSectionWith(4)], "compact");
+
+      // The CrateShelf container should not have border classes.
+      const shelfContainer = document.querySelector(".border-0.rounded-none.bg-transparent");
+      expect(shelfContainer).toBeInTheDocument();
+    });
+
+    it("does not render 'DIG →' entry label", () => {
+      renderFloor([picksSectionWith(4)]);
+
+      expect(screen.queryByText(/DIG/)).not.toBeInTheDocument();
+    });
+
+    it("renders 6-record grid (3 columns × 2 rows on compact)", () => {
+      renderFloorAtTier([picksSectionWith(6)], "compact");
+
+      // With previewCount=6 and gridColumnCount(6)=3 columns, expect a 3-col grid.
+      const grid = document.querySelector("[style*='grid-template-columns']");
+      expect(grid).toBeInTheDocument();
+      expect(grid?.getAttribute("style")).toContain("repeat(3");
+    });
+
+    it("press feedback wrapper is present on compact", () => {
+      renderFloorAtTier([picksSectionWith(4)], "compact");
+
+      // The compact path wraps in a motion.div for press-only feedback.
+      // Verify the wrapper exists (it's a motion.div with w-full class).
+      const wrapper = document.querySelector(".w-full");
+      expect(wrapper).toBeInTheDocument();
+    });
   });
 
   describe("Featured section", () => {

--- a/app/frontend/components/store_floor.test.tsx
+++ b/app/frontend/components/store_floor.test.tsx
@@ -67,11 +67,12 @@ const renderFloorAtTier = (sections: StorefrontSection[], tier: "compact" | "com
 
 describe("StoreFloor section labels", () => {
   describe("Wall section", () => {
-    it("renders picks description text when wall has records", () => {
+    it("does not render picks description text when wall has records", () => {
       renderFloor([picksSectionWith(4)]);
 
-      expect(screen.getByText(/Today's picks/)).toBeInTheDocument();
-      expect(screen.getByText(/the store's taste at a glance/)).toBeInTheDocument();
+      // Description paragraph was removed — identity is carried by aria-label.
+      expect(screen.queryByText(/Today's picks/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/the store's taste at a glance/)).not.toBeInTheDocument();
     });
 
     it("has role=region with accessible label for the wall section", () => {
@@ -141,7 +142,7 @@ describe("StoreFloor section labels", () => {
     it("compact tier renders all section descriptions", () => {
       renderFloorAtTier([picksSectionWith(2), featuredSection(2), genreSection(2)], "compact");
 
-      expect(screen.getByText(/Today's picks/)).toBeInTheDocument();
+      // Wall section does not render visible description — identity is aria-label only.
       expect(screen.getByText(/Curated crates hand-picked by the store/)).toBeInTheDocument();
       expect(screen.getByText(/Browse the full collection by genre/)).toBeInTheDocument();
     });

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -42,6 +42,7 @@ function PicksShelf({
   today: string;
 }) {
   const { isCompact } = useViewport();
+  const { isHovered, isPressed, handlers } = useTactileHover();
 
   // Wall is always borderless — the only unbordered surface on the store floor.
   const shelf = (
@@ -60,8 +61,6 @@ function PicksShelf({
 
   // Comfy/wide: wrap in a hover-animated motion container (no rotate, Wall is editorial)
   if (!isCompact) {
-    const { isHovered, isPressed, handlers } = useTactileHover();
-
     return (
       <motion.div
         className="w-full rounded-lg overflow-hidden"
@@ -77,8 +76,17 @@ function PicksShelf({
     );
   }
 
-  // Compact: plain shelf, no hover wrapper
-  return shelf;
+  // Compact: wrap in press-only motion container (no hover, no lift — tap feedback only)
+  return (
+    <motion.div
+      className="w-full"
+      animate={{ scale: isPressed ? SCALE_PRESS : 1 }}
+      transition={springPress}
+      {...handlers}
+    >
+      {shelf}
+    </motion.div>
+  );
 }
 
 export default function StoreFloor({ sections, onSelectCrate }: Props) {

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -13,6 +13,17 @@ interface Props {
   onSelectCrate: (slug: string, startIndex?: number) => void;
 }
 
+/**
+ * Returns the column count for the Wall grid based on record count.
+ * Adaptive: fewer records use fewer columns so the grid always looks filled.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- used by column override (U3)
+function wallGridColumns(recordCount: number, isCompact: boolean): number {
+  if (recordCount <= 2) return 1;
+  if (recordCount <= 4) return 2;
+  return isCompact ? 2 : 3;
+}
+
 function PicksShelf({
   crate,
   onSelectCrate,
@@ -26,6 +37,7 @@ function PicksShelf({
 }) {
   const { isCompact } = useViewport();
 
+  // Wall is always borderless — the only unbordered surface on the store floor.
   const shelf = (
     <CrateShelf
       crate={crate}
@@ -33,24 +45,21 @@ function PicksShelf({
       onSelectCrate={onSelectCrate}
       previewCount={picksPreviewCount}
       meta={today}
-      openLabel="DIG →"
       tactileThumbnails={!isCompact}
-      className={!isCompact ? "border-0 rounded-none" : undefined}
+      className="border-0 rounded-none bg-transparent"
     />
   );
 
-  // Desktop: wrap in a hover-animated motion container
+  // Comfy/wide: wrap in a hover-animated motion container (no rotate, Wall is editorial)
   if (!isCompact) {
     const { isHovered, isPressed, handlers } = useTactileHover();
 
     return (
       <motion.div
-        className="w-full rounded-lg overflow-hidden border"
+        className="w-full rounded-lg overflow-hidden"
         animate={{
-          borderColor: isHovered ? "var(--mc-accent)" : "var(--mc-border)",
           scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
           y: isHovered ? -3 : 0,
-          rotate: isHovered ? 0 : -0.5,
         }}
         transition={isPressed ? springPress : springTactile}
         {...handlers}
@@ -65,10 +74,9 @@ function PicksShelf({
 }
 
 export default function StoreFloor({ sections, onSelectCrate }: Props) {
-  const { isCompact } = useViewport();
-
-  // Tier-specific preview density: compact shows fewer, wide shows more
-  const picksPreviewCount = isCompact ? 4 : 8;
+  // Wall preview density: always 6 records (2×3 compact, 3×2 comfy/wide).
+  // Column count adapts dynamically via wallGridColumns in CrateShelf (U3).
+  const picksPreviewCount = 6;
 
   return (
     <div className="flex flex-col gap-8 sm:gap-10">
@@ -84,9 +92,6 @@ export default function StoreFloor({ sections, onSelectCrate }: Props) {
                 role="region"
                 aria-label="Wall — Today's picks, the store's taste at a glance"
               >
-                <p className="text-xs text-mc-text-dim mb-3">
-                  Today's picks — the store's taste at a glance
-                </p>
                 <PicksShelf
                   crate={picks}
                   onSelectCrate={onSelectCrate}

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -4,7 +4,13 @@ import FeaturedCratesRow from "./featured_crates_row";
 import GenreGrid from "./genre_grid";
 import { useTactileHover } from "@/hooks/use_tactile_hover";
 import { useViewport } from "@/hooks/use_viewport";
-import { springTactile, springPress, SCALE_HOVER, SCALE_PRESS } from "@/lib/motion_tokens";
+import {
+  springTactile,
+  springPress,
+  SCALE_HOVER,
+  SCALE_PRESS,
+  SCALE_MARQUEE,
+} from "@/lib/motion_tokens";
 import type { Crate } from "../types/inertia";
 import type { StorefrontSection } from "../types/inertia";
 
@@ -45,6 +51,8 @@ function PicksShelf({
       onSelectCrate={onSelectCrate}
       previewCount={picksPreviewCount}
       meta={today}
+      coverScale={SCALE_MARQUEE}
+      gridGap="gap-3"
       tactileThumbnails={!isCompact}
       className="border-0 rounded-none bg-transparent"
     />

--- a/app/frontend/components/store_floor.tsx
+++ b/app/frontend/components/store_floor.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import CrateShelf from "./crate_shelf";
 import FeaturedCratesRow from "./featured_crates_row";
 import GenreGrid from "./genre_grid";
+import WallGlowCue from "./wall_glow_cue";
 import { useTactileHover } from "@/hooks/use_tactile_hover";
 import { useViewport } from "@/hooks/use_viewport";
 import {
@@ -62,30 +63,36 @@ function PicksShelf({
   // Comfy/wide: wrap in a hover-animated motion container (no rotate, Wall is editorial)
   if (!isCompact) {
     return (
-      <motion.div
-        className="w-full rounded-lg overflow-hidden"
-        animate={{
-          scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
-          y: isHovered ? -3 : 0,
-        }}
-        transition={isPressed ? springPress : springTactile}
-        {...handlers}
-      >
-        {shelf}
-      </motion.div>
+      <div className="relative">
+        <WallGlowCue />
+        <motion.div
+          className="w-full rounded-lg overflow-hidden"
+          animate={{
+            scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1,
+            y: isHovered ? -3 : 0,
+          }}
+          transition={isPressed ? springPress : springTactile}
+          {...handlers}
+        >
+          {shelf}
+        </motion.div>
+      </div>
     );
   }
 
   // Compact: wrap in press-only motion container (no hover, no lift — tap feedback only)
   return (
-    <motion.div
-      className="w-full"
-      animate={{ scale: isPressed ? SCALE_PRESS : 1 }}
-      transition={springPress}
-      {...handlers}
-    >
-      {shelf}
-    </motion.div>
+    <div className="relative">
+      <WallGlowCue />
+      <motion.div
+        className="w-full"
+        animate={{ scale: isPressed ? SCALE_PRESS : 1 }}
+        transition={springPress}
+        {...handlers}
+      >
+        {shelf}
+      </motion.div>
+    </div>
   );
 }
 

--- a/app/frontend/components/wall_glow_cue.tsx
+++ b/app/frontend/components/wall_glow_cue.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState, useRef } from "react";
+import { motion } from "framer-motion";
+import { isCueLearned, markCueLearned } from "@/lib/cue_lesson";
+import { useReducedMotionContext } from "./storefront_motion_config";
+
+export const WALL_CUE_STORAGE_KEY = "mc-wall-cue-dismissed";
+
+const CUE_DURATION_MS = 3000;
+
+interface Props {
+  /** Called when the cue has been dismissed (tap, timer, or reduced motion). */
+  onDismiss?: () => void;
+}
+
+/**
+ * One-time ghost glow cue for the Wall — a soft radial glow in the accent
+ * color that breathes once across the grid area, then dissolves.
+ *
+ * Fires on first visit (localStorage key mc-wall-cue-dismissed), dissolves
+ * on pointer-down or after 3 seconds. Respects prefers-reduced-motion by
+ * never rendering. Never blocks interaction (pointer-events: none).
+ */
+export default function WallGlowCue({ onDismiss }: Props) {
+  const reducedMotion = useReducedMotionContext();
+  const [visible, setVisible] = useState(false);
+  const dismissCalled = useRef(false);
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  useEffect(() => {
+    // Respect OS preference — no motion means no cue.
+    if (reducedMotion) {
+      return;
+    }
+
+    // Already seen this cue? Don't render.
+    if (isCueLearned(WALL_CUE_STORAGE_KEY)) {
+      return;
+    }
+
+    setVisible(true);
+
+    // Auto-dismiss after CUE_DURATION_MS.
+    const timer = setTimeout(() => {
+      dismiss();
+    }, CUE_DURATION_MS);
+
+    function dismiss() {
+      if (dismissCalled.current) return;
+      dismissCalled.current = true;
+
+      markCueLearned(WALL_CUE_STORAGE_KEY);
+      setVisible(false);
+      onDismissRef.current?.();
+    }
+
+    return () => clearTimeout(timer);
+  }, [reducedMotion]);
+
+  // Clear the auto-dismiss timer on pointer-down so the glow doesn't
+  // dissolve mid-press while the grid is in its pressed-scale state.
+  function handlePointerDown() {
+    if (dismissCalled.current) return;
+    dismissCalled.current = true;
+
+    markCueLearned(WALL_CUE_STORAGE_KEY);
+    setVisible(false);
+    onDismissRef.current?.();
+  }
+
+  if (!visible || reducedMotion) {
+    return null;
+  }
+
+  return (
+    <motion.div
+      className="pointer-events-none absolute inset-0 z-10 rounded-lg"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: [0, 0.25, 0] }}
+      exit={{ opacity: 0 }}
+      transition={{
+        duration: 2,
+        ease: "easeInOut",
+      }}
+      onPointerDown={handlePointerDown}
+      style={{
+        background: "radial-gradient(ellipse at center, var(--mc-accent) 0%, transparent 70%)",
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/app/frontend/lib/cue_lesson.ts
+++ b/app/frontend/lib/cue_lesson.ts
@@ -1,0 +1,66 @@
+/**
+ * cue_lesson.ts
+ *
+ * Pure helper for one-time instructional cues (glow, ghost finger, etc.).
+ * Owns learned-state persistence with configurable storage backend
+ * (localStorage by default; sessionStorage override for per-session cues).
+ *
+ * Does not import React, viewport hooks, Framer Motion, or DOM layout.
+ */
+
+export type CueStorageBackend = "local" | "session";
+
+// ── Storage helpers ──────────────────────────────────────────
+
+function safeGetStorage(backend: CueStorageBackend): Storage | null {
+  try {
+    const s = backend === "session" ? globalThis.sessionStorage : globalThis.localStorage;
+    void s?.length;
+    return s ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true when the cue with the given key has already been
+ * dismissed. Returns false conservatively when storage is unavailable.
+ */
+export function isCueLearned(key: string, backend: CueStorageBackend = "local"): boolean {
+  try {
+    const storage = safeGetStorage(backend);
+    if (!storage) return false;
+    return storage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persists the dismissed flag for the given cue key.
+ * Silently no-ops when storage is unavailable.
+ */
+export function markCueLearned(key: string, backend: CueStorageBackend = "local"): void {
+  try {
+    const storage = safeGetStorage(backend);
+    if (!storage) return;
+    storage.setItem(key, "1");
+  } catch {
+    // Storage write failure is non-critical; the cue remains visible
+    // for this render but does not crash the surface.
+  }
+}
+
+/**
+ * Clears the dismissed flag for the given cue key.
+ * Useful for testing and reset scenarios.
+ */
+export function clearCueLesson(key: string, backend: CueStorageBackend = "local"): void {
+  try {
+    const storage = safeGetStorage(backend);
+    if (!storage) return;
+    storage.removeItem(key);
+  } catch {
+    // Non-critical.
+  }
+}

--- a/app/frontend/lib/first_swipe_lesson.ts
+++ b/app/frontend/lib/first_swipe_lesson.ts
@@ -1,42 +1,24 @@
 /**
  * first_swipe_lesson.ts
  *
- * Pure helper for the compact first-swipe lesson. Owns learned-state
- * persistence (sessionStorage), cue eligibility decisions, and
- * horizontal-swipe recovery classification.
+ * Pure helper for the compact first-swipe lesson. Delegates learned-state
+ * persistence to cue_lesson.ts with sessionStorage backend.
+ * Also owns eligibility decisions and horizontal-swipe recovery classification.
  *
  * Does not import React, viewport hooks, Framer Motion, DOM layout, or
  * Rails data types. Navigation remains owned by riffle_navigation.ts.
  */
 
-export const FIRST_SWIPE_STORAGE_KEY = "mc-first-swipe-learned"
+import { isCueLearned, markCueLearned } from "./cue_lesson";
 
-// ── Storage helpers ──────────────────────────────────────────
-
-function safeGetStorage(): Storage | null {
-  try {
-    const s = globalThis.sessionStorage
-    // Access a property to confirm it's usable (not just present)
-    void s?.length
-    return s ?? null
-  } catch {
-    return null
-  }
-}
+export const FIRST_SWIPE_STORAGE_KEY = "mc-first-swipe-learned";
 
 /**
  * Returns true when the first-swipe lesson has already been learned
- * during this browser session. Returns false conservatively when
- * storage is unavailable.
+ * during this browser session.
  */
 export function isLessonLearned(): boolean {
-  try {
-    const storage = safeGetStorage()
-    if (!storage) return false
-    return storage.getItem(FIRST_SWIPE_STORAGE_KEY) === "1"
-  } catch {
-    return false
-  }
+  return isCueLearned(FIRST_SWIPE_STORAGE_KEY, "session");
 }
 
 /**
@@ -44,21 +26,14 @@ export function isLessonLearned(): boolean {
  * Silently no-ops when storage is unavailable.
  */
 export function markLessonLearned(): void {
-  try {
-    const storage = safeGetStorage()
-    if (!storage) return
-    storage.setItem(FIRST_SWIPE_STORAGE_KEY, "1")
-  } catch {
-    // Storage write failure is non-critical; the lesson remains
-    // visible for this render but does not crash the crate surface.
-  }
+  markCueLearned(FIRST_SWIPE_STORAGE_KEY, "session");
 }
 
 // ── Eligibility ──────────────────────────────────────────────
 
 export interface LessonEligibilityInput {
-  isCompact: boolean
-  isPopulated: boolean
+  isCompact: boolean;
+  isPopulated: boolean;
 }
 
 /**
@@ -67,22 +42,22 @@ export interface LessonEligibilityInput {
  * learned during this browser session.
  */
 export function isLessonEligible({ isCompact, isPopulated }: LessonEligibilityInput): boolean {
-  if (!isCompact) return false
-  if (!isPopulated) return false
-  if (isLessonLearned()) return false
-  return true
+  if (!isCompact) return false;
+  if (!isPopulated) return false;
+  if (isLessonLearned()) return false;
+  return true;
 }
 
 // ── Horizontal-swipe recovery ────────────────────────────────
 
-const HORIZONTAL_MIN_DISTANCE = 30
+const HORIZONTAL_MIN_DISTANCE = 30;
 
 export interface DragAttemptInput {
-  offsetX: number
-  offsetY: number
+  offsetX: number;
+  offsetY: number;
 }
 
-export type DragAttemptResult = "horizontal-recovery" | "none"
+export type DragAttemptResult = "horizontal-recovery" | "none";
 
 /**
  * Classifies a drag release to distinguish horizontal card-swipe
@@ -95,14 +70,14 @@ export type DragAttemptResult = "horizontal-recovery" | "none"
  * small tap-like movements below the classification threshold.
  */
 export function classifyDragAttempt({ offsetX, offsetY }: DragAttemptInput): DragAttemptResult {
-  const absX = Math.abs(offsetX)
-  const absY = Math.abs(offsetY)
+  const absX = Math.abs(offsetX);
+  const absY = Math.abs(offsetY);
 
   // Must be mostly horizontal: horizontal distance dominates vertical.
-  if (absX <= absY) return "none"
+  if (absX <= absY) return "none";
 
   // Must exceed minimum distance to avoid classifying taps / tiny flicks.
-  if (absX < HORIZONTAL_MIN_DISTANCE) return "none"
+  if (absX < HORIZONTAL_MIN_DISTANCE) return "none";
 
-  return "horizontal-recovery"
+  return "horizontal-recovery";
 }

--- a/app/frontend/lib/motion_tokens.ts
+++ b/app/frontend/lib/motion_tokens.ts
@@ -36,10 +36,12 @@ export const springDrawer = {
 export const SCALE_PRESS = 0.985;
 export const SCALE_HOVER = 1.025;
 export const SCALE_INNER_HOVER = 1.015;
+export const SCALE_MARQUEE = 1.5;
 
 // ── Lift / tilt magnitudes ────────────────────────────────────
 
 export const LIFT_HOVER = 2; // px
+export const LIFT_MARQUEE = -3; // px — deeper lift for editorial surfaces
 export const TILT_HOVER = 1.5; // deg
 
 // ── Transition presets ────────────────────────────────────────

--- a/docs/brainstorms/2026-06-01-wall-editorial-marquee-requirements.md
+++ b/docs/brainstorms/2026-06-01-wall-editorial-marquee-requirements.md
@@ -1,0 +1,142 @@
+---
+date: 2026-06-01
+topic: wall-editorial-marquee
+---
+
+# Wall as Editorial Marquee — Mobile-First Requirements
+
+## Summary
+
+Transform the Wall from a bordered `CrateShelf` card into a borderless, full-width 6-record grid that owns the mobile viewport — an editorial threshold inviting entry into the core crate-browsing loop. Entry is the grid itself (tap any cover), taught through a one-time ghost cue and confirmed by press-down feedback, with no persistent CTA label. Minimal implementation: prop differentiation on `CrateShelf` through the existing `PicksShelf` wrapper.
+
+---
+
+## Problem Frame
+
+The store floor renders three vertically stacked sections — Wall, Featured, Genre — all using the same bordered-card visual primitive. On a phone, a first-time shopper sees a uniform scroll of identical rectangles. The Wall, which the product model names as the store's primary taste signal and the first mode after store orientation, is visually indistinguishable from the crate navigation below it. The cohesion audit scored the Wall's hierarchy and copy at 2/4.
+
+The cost of this sameness is editorial absence. The Wall is supposed to communicate "this is what this store is about" before the shopper enters any crate. Instead, it reads as the first item in a list. A shopper who scrolls past without entering has missed the store's taste signal entirely.
+
+The product strategy's "Digital storefront character" track calls for translating the personality of a physical shop into a digital space. The Wall is the surface that carries that personality. Today it carries none.
+
+---
+
+## Actors
+
+- A1. **Shopper (first-time):** Lands on a store page for the first time on a phone. Has no prior knowledge of Milkcrate's interaction model. Needs to understand where to start and what the store's taste is.
+- A2. **Shopper (returning):** Has visited the store before. Knows the Wall changes daily. Wants a quick taste read before entering a crate or scrolling to a specific genre.
+- A3. **System (curation pipeline):** Regenerates the Wall's picks daily via `CrateStrategies::Picks`. The Wall renders whatever the pipeline produces — it does not control curation.
+
+---
+
+## Key Flows
+
+- F1. **First-visit Wall orientation**
+  - **Trigger:** Shopper lands on a store page with no prior visit flag in `localStorage`.
+  - **Actors:** A1, A3
+  - **Steps:** The Wall renders as a borderless 6-record grid below the store header. A one-time ghost cue (soft animated attention line or glow) fires across the grid, then dissolves on first tap or after 3 seconds. The shopper sees a visually distinct, open surface that reads differently from the bordered cards below.
+  - **Outcome:** The shopper understands the Wall is an interactive entry point, even if they don't tap immediately. The ghost cue does not fire again on subsequent visits.
+  - **Covered by:** R2, R3, R7
+
+- F2. **Wall entry — tap a cover**
+  - **Trigger:** Shopper taps any record cover in the Wall grid.
+  - **Actors:** A1, A2
+  - **Steps:** On touch-down, the grid area gives a subtle scale-down feedback (using `springPress`). On release, navigation proceeds into the Wall crate at the tapped record's position. The crate opens in the standard `CrateView` card stack.
+  - **Outcome:** The shopper is browsing the Wall crate, starting at the selected record. The store header updates to show crate context.
+  - **Covered by:** R1, R4, R8
+
+- F3. **Returning visit — Wall as taste read**
+  - **Trigger:** Shopper returns to a store page on a subsequent day.
+  - **Actors:** A2, A3
+  - **Steps:** The ghost cue does not fire. The Wall renders today's new picks. The crate name and "Today" date are visible above the grid. The shopper scans the 6 covers, forms a taste impression, then either taps to enter or scrolls down to Featured/Genre.
+  - **Outcome:** The shopper gets a quick taste read from the Wall without friction. The daily rotation is legible via the date marker.
+  - **Covered by:** R5, R6
+
+---
+
+## Requirements
+
+**Grid treatment**
+- R1. The Wall renders as a borderless, full-width grid with no card container (`border-0`, `rounded-none`, transparent background). It is the only unbordered surface on the store floor.
+- R2. The grid displays 6 record covers (2 columns × 3 rows) on compact viewports (≤767px).
+- R3. Covers are rendered at 1.5× the standard `RecordTile` thumbnail size used in Featured/Genre crate cards.
+
+**Entry and affordance**
+- R4. Tapping any record cover in the grid enters the Wall crate at that record's position in the card stack.
+- R5. On touch-down (press start) anywhere on the grid area, a subtle scale-down feedback is applied. On release, the feedback releases and navigation proceeds. The feedback uses the existing `springPress` animation token.
+- R6. On a shopper's first visit to any store page (tracked via `localStorage` flag), a one-time ghost cue fires on the Wall — a soft radial or edge glow in the warm accent color that breathes once across the grid area (~2 second duration), then dissolves. Also dissolves on first tap. The cue never fires again for that browser. The pattern reuses the existing `GhostFingerCue` lifecycle mechanism from `CrateView` (one-shot, dissolve-on-interaction) with a glow shape instead of a swipe arrow.
+
+**Header**
+- R7. The Wall's header consists of the crate name (e.g., "Milkcrate Picks") and today's date (e.g., "Jun 1") displayed above the grid. No section description paragraph. No persistent CTA label ("DIG →" or "Enter →").
+
+**Responsive adaptation**
+- R8. At comfy (768–1023px) and wide (≥1024px) viewports, the grid expands to 3 columns × 2 rows, and hover enrichment (deeper lift via `springTactile`, subtle sample cue) is applied to the grid area. The ghost cue and tap-down feedback still function at compact but tap-down is not the primary affordance on pointer-based devices.
+
+**Accessibility**
+- R9. The Wall section retains its existing `role="region"` and `aria-label` describing its purpose. Each cover in the grid is a focusable, keyboard-accessible element with an `aria-label` indicating the record title and the action ("Open [crate name] at [record title]").
+
+**Integration**
+- R10. The Wall is implemented through the existing `PicksShelf` wrapper in `StoreFloor`, which passes differentiated props (`borderless`, `previewCount`, tap handler) to `CrateShelf`. No dedicated `WallMarquee` component is introduced at this stage.
+- R11. No changes to `CrateCard` — the Wall does not use it. Featured and Genre sections are unchanged.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R4.** On a phone (375px wide), a first-time shopper sees the store header, then a borderless 2×3 grid of 6 record covers filling most of the viewport. Tapping the third cover enters the Wall crate at the third record. Featured crates are partially visible below.
+- AE2. **Covers R5, R6.** On first visit, a soft glow traces across the Wall grid and dissolves after 3 seconds. The shopper taps a cover: on touch-down, the grid area scales down slightly; on release, the crate opens. On the next visit, the glow does not fire, but tap-down feedback still works.
+- AE3. **Covers R3, R8.** At 1024px wide, the Wall grid shows 3 columns × 2 rows with larger covers. Hovering the grid area triggers a subtle lift. Tap-down feedback still functions but is not the primary affordance.
+- AE4. **Covers R7, R9.** A screen reader encounters the Wall region and announces: "Wall — Today's picks, the store's taste at a glance. Milkcrate Picks, June 1." Each cover is announced as "Open Milkcrate Picks at [record title]."
+
+---
+
+## Success Criteria
+
+- A first-time compact shopper can identify the Wall as visually distinct from the card-based sections below it without reading any section label.
+- A first-time compact shopper discovers that the Wall is an interactive entry point within 3 seconds of the ghost cue firing, or through tap-down feedback on first touch.
+- The Wall's borderless grid treatment reads as an editorial surface — the shopper perceives the store's curation intent before perceiving inventory.
+- The implementation stays within the existing `CrateShelf`/`PicksShelf` primitive system — no parallel visual system is introduced.
+- The ghost cue is implemented such that it never interferes with navigation (dissolves before or on interaction, never blocks).
+- All existing Wall behavior (crate entry, record navigation, `aria-label`, viewport adaptation) continues to function.
+
+---
+
+## Scope Boundaries
+
+- No dedicated `WallMarquee` component — deferred until the borderless grid concept is validated in production.
+- No single hero record with editorial copy — the 6-record grid IS the taste statement.
+- No horizontal scroll, carousel, or swipe interaction — the grid is static, tap-to-enter.
+- No "Fresh Today" animated temporal reveal — the date is shown as static text.
+- No changes to Featured or Genre sections — this work is Wall-only.
+- No changes to the crate entry transition or `CrateView` behavior.
+- No backend, curation pipeline, or data model changes.
+- No persistent CTA label — the grid communicates interactivity through the ghost cue and tap feedback.
+
+---
+
+## Key Decisions
+
+- **Grid-as-entry:** The Wall grid is the entry point — tapping any cover enters the crate. No separate CTA button. Rationale: preserves editorial purity; the covers themselves are the invitation.
+- **No persistent label:** Interactivity is taught through the one-time ghost cue and tap-down feedback, not a permanently visible text label. Rationale: a persistent label competes with the visual moment; the ghost cue + contrast with card-based sections below is sufficient teaching.
+- **2×3 on compact:** 2 columns × 3 rows produces a taller, more commanding presence on a vertical phone screen than 3×2. Rationale: fills the viewport more effectively and creates a stronger editorial threshold before the Featured section appears.
+- **Minimal implementation:** Prop differentiation on `CrateShelf` through `PicksShelf`. No new component. Rationale: validates the concept with the fewest lines changed before committing to architectural extraction.
+
+---
+
+## Dependencies / Assumptions
+
+- The `GhostFingerCue` pattern from `CrateView` (`app/frontend/components/crate_view/ghost_finger_cue.tsx` or similar) is extractable or reusable for the Wall. If it is tightly coupled to the crate view, a lightweight equivalent will be built for the store floor.
+- `localStorage` is available and acceptable for the first-visit flag. An alternative (session cookie, server-side flag) can be evaluated at planning if `localStorage` introduces concerns.
+- The curation pipeline continues to produce 6+ records for the Wall. If a store has fewer than 6 picks, the grid renders with whatever is available (no minimum enforcement in this change).
+- The `CrateShelf` component can accept a `borderless` prop and a tap-down handler without introducing breaking changes to its existing interactive/static contract.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R5][Technical] How does the tap-down scale feedback interact with `CrateShelf`'s existing interactive mode, which already handles press states via `useTactileHover`? The integration point needs careful design to avoid conflicting gesture handlers.
+- [Affects R7][Technical] Does the crate name come from `CuratedCrate#name` (already available in props) or should it use a fixed "Milkcrate Picks" label? The current code uses `crate.name`.
+- [Affects R8][Technical] At what breakpoint does the grid switch from 2×3 to 3×2? The current viewport tiers (compact ≤767px, comfy 768–1023px, wide ≥1024px) provide natural thresholds, but the exact breakpoint for the grid layout change is a planning detail.
+- [Affects R6][Needs research] Is the `GhostFingerCue` component in `CrateView` sufficiently decoupled to reuse on the store floor, or does a new cue component need to be built? The planner should read the existing implementation and assess.

--- a/docs/ideation/2026-06-01-store-page-visual-refresh-ideation.md
+++ b/docs/ideation/2026-06-01-store-page-visual-refresh-ideation.md
@@ -57,7 +57,7 @@ The ideas below lead with the compact experience. Desktop descriptions follow as
 
 **Complexity:** Medium
 
-**Status:** Unexplored
+**Status:** Explored
 
 ---
 

--- a/docs/ideation/2026-06-01-store-page-visual-refresh-ideation.md
+++ b/docs/ideation/2026-06-01-store-page-visual-refresh-ideation.md
@@ -1,0 +1,172 @@
+---
+date: 2026-06-01
+topic: store-page-visual-refresh
+focus: Distinguishing Wall/Picks, Featured Crates, and Genre Crates using real-world record store concepts
+mode: repo-grounded
+---
+
+# Ideation: Store Page Visual Refresh
+
+## Design Principle: Mobile-First, Desktop-Outward
+
+Per the storefront experience language doc and mobile hierarchy spec, **compact (≤767px) is the source hierarchy.** Every mode, every label, and every transition must make sense on a phone first. Comfy (768–1023px) and wide (≥1024px) layouts are adaptations that reveal more of the same session — they do not introduce a second product.
+
+The ideas below lead with the compact experience. Desktop descriptions follow as outward adaptation. No idea depends on hover, pointer precision, or screen real estate to communicate its intent — those enrich the same vocabulary on larger surfaces.
+
+**Core mobile constraint:** Today, on a phone, the store floor is three vertically stacked card grids with zero visual distinction. The Wall's hover animation wrapper is stripped. The "DIG →" entry label is permanently invisible (hover-only). A first-time compact shopper sees a uniform scroll of bordered rectangles. All five ideas below start by fixing this specific experience.
+
+## Grounding Context
+
+**Codebase:** Rails/Inertia/React record store browser. Store page (`StoreFloor`) renders 3 sections: `picks_wall` (single crate), `featured_crates` (row of crates), `genre_grid` (grid of genre crates). ALL three currently use the same visual primitive — `CrateShelf` inside `CrateCard` — bordered cards with thumbnail grids and identical hover animations. The experience language doc (`docs/brainstorms/2026-05-31-storefront-experience-language-requirements.md`) names these Wall, Featured, Genre as distinct session modes, but today they're visually near-identical.
+
+**Key gap:** "A first-time shopper cannot tell which section is the Wall vs. a crate menu." The Wall (Mode 2 in the mobile hierarchy) should signal the store's taste at a glance. Featured crates and genre crates (Mode 3) should feel like choosing which crate to enter.
+
+**Semantic hierarchy:** Picks = editorial/taste-signaling (marquee treatment), Featured = staff-selected (badge/accent), Genre = categorized-browsing (systematic/grid).
+
+**Architecture constraint:** Build on `CrateShelf`/`CrateCard` primitives with differentiated props, layout variants, or section-specific wrappers — not parallel visual systems. Three viewport tiers (compact ≤767px, comfy 768–1023px, wide ≥1024px). Use the shared animation token system (`motion_tokens.ts`) for any motion.
+
+**Past learnings cited:** Vendor brand surface system, crate strategies pattern, viewport-context responsive architecture, animation token system.
+
+**External research:** Unavailable (no web fetch tool in environment).
+
+## Topic Axes
+
+1. **Section identity & signage** — How each section announces itself (labels, headers, copy)
+2. **Layout & spatial differentiation** — How sections occupy space differently (size, density, arrangement)
+3. **Interaction & affordance** — How the shopper engages with each section (hover, entry, feedback)
+4. **Visual treatment & mood** — How sections feel (color, typography, imagery, motion)
+5. **Progressive disclosure** — How sections reveal depth (glance vs. enter, temporal signals)
+
+## Ranked Ideas
+
+### 1. Wall as Editorial Marquee
+
+**Description:** *Mobile-first:* On a phone, the Wall is the first surface after the store header. Instead of being a bordered card identical to every crate below it, the Wall renders as an open, borderless surface. A single prominent record cover spans most of the viewport width with the crate name set in confident, scaled typography and a small "Today" date marker. Below the lead cover, 4 supporting thumbnails sit in a borderless grid — like albums spread on a counter. A visible "DIG →" entry label sits below the grid (always visible — no hover dependency). The Wall is the only unbordered surface on the store floor, creating an immediate spatial threshold.
+
+*Desktop outward:* At comfy and wide, the lead cover and supporting grid expand into a full-width editorial band. The hero record and thumbnails can sit side-by-side with generous negative space. Hover enriches the experience with immersive editorial motion (deeper lift, slower spring). The "Fresh Today" marker gains a subtle one-shot reveal animation on first load of the day, dissolved via `sessionStorage`.
+
+**Axis:** Layout & spatial differentiation + Visual treatment & mood
+
+**Basis:** `direct:` `PicksShelf` already strips the border at non-compact (`border-0 rounded-none` — `store_floor.tsx:42`) but leaves it on compact — the exact opposite of what mobile-first demands. The borderless treatment should originate on compact and persist upward. `CrateShelf` always renders with `border border-mc-border rounded-lg`. The Wall's `meta` prop already carries today's date. `direct:` Experience language doc: "Wall: The Milkcrate Picks surface, a quick read on the store's taste." A "quick read" on a phone means one commanding image, not a grid of 4 equal squares. `external:` Bandcamp's mobile daily feature and Apple Music's editorial cards use lead-image + supporting-grid compositions that work at phone scale.
+
+**Rationale:** The Wall is the product's primary taste signal. On a phone, rendering it as a bordered card in a stack of bordered cards communicates "one more thing to scroll past." Removing the border and scaling up one cover makes the Wall feel like a moment — the store's voice — before the shopper enters the crate-navigation zone below. The open surface creates a clear threshold: editorial zone above, card-based navigation below.
+
+**Downsides:** The lead cover + grid increases vertical height on compact (more scroll before Featured reaches the viewport). A Wall-specific layout variant in `CrateShelf` or a lightweight `WallMarquee` wrapper is needed. The lead record choice (which of 50 picks gets the hero spot) is a curation decision — defaults to first record from `RecordScorer` ranking.
+
+**Confidence:** 85%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+---
+
+### 2. Differentiated Section Layout System
+
+**Description:** *Mobile-first:* On a phone, three vertically stacked card grids (Wall → Featured → Genre) produce a monotonous scroll with no spatial rhythm. Each section should have a distinct scroll footprint. Wall = open, borderless editorial surface (see #1). Featured = a compact single-column stack, but the crate cards have a different aspect ratio — wider and shorter (landscape), with the crate name beside the thumbnails rather than stacked above — creating a visual pace change from the Wall's verticality. Genre = a tight 2-column grid with minimal gap, optimized for fast category scanning. Section spacing follows a deliberate rhythm: Wall bottom margin is generous (signals "this was a moment"), Featured moderate, Genre tightest (signals "dive in").
+
+*Desktop outward:* At comfy and wide, Featured crates expand to a horizontal scrollable row with snap points — the shopper scrolls *across* through staff picks rather than *down*. Genre gains columns (3 comfy, 4 wide). The spacing rhythm amplifies: the Wall's breathing room becomes more pronounced, the Featured-to-Genre transition tightens. The layout differences are encoded as declarative `ResponsiveMap<T>` configs on a unified `CrateSectionGrid` primitive, collapsing the near-identical `FeaturedCratesRow` and `GenreGrid` wrappers.
+
+**Axis:** Layout & spatial differentiation
+
+**Basis:** `direct:` On compact, `FeaturedCratesRow` uses `columnCount: 1` — a single vertical column indistinguishable from the Wall's card and the Genre grid's 2 columns. `GenreGrid` uses `gap-3` vs Featured's `gap-4` — a 4px difference invisible to users. The uniform `gap-8` on `StoreFloor` applies to all sections. `direct:` `FeaturedCratesRow` (8 lines) and `GenreGrid` (6 lines) are passthrough wrappers — collapsing them into a layout-driven unified primitive reduces code and centralizes responsive decisions. `external:` Spotify and Apple Music mobile apps use horizontal scroll rows for curated collections and vertical grids for browse-all — users recognize the scroll-axis shift as a section boundary.
+
+**Rationale:** The mobile hierarchy spec defines Wall (Mode 2) and Crate Entry (Mode 3) as distinct session modes. Three vertical stacks blur that distinction — the shopper's thumb does the same motion for every section. A different card shape at Featured (landscape) creates a visual pace change; tighter Genre spacing creates a "you are now in the catalog zone" signal. Both work without hover, without labels, and without new components — just layout differentiation.
+
+**Downsides:** Landscape Featured cards on compact require a layout variant in `CrateShelf` (currently always `flex-col`). Horizontal scroll on desktop with 2-3 crates may feel sparse; needs `justify-center` fallback. The `ResponsiveMap<T>` abstraction is engineering overhead if not adopted consistently across the storefront.
+
+**Confidence:** 75%
+
+**Complexity:** Low-Medium
+
+**Status:** Unexplored
+
+---
+
+### 3. Section Identity & Signage Grammar
+
+**Description:** *Mobile-first:* On a phone, section labels must work at small scale. A `<SectionSign>` primitive takes `type: "wall" | "featured" | "genre"` and renders a compact identity treatment. Wall carries a 2px warm accent top-edge line — visible even when the Wall content has scrolled partially off-screen — plus the crate name as a section heading. Featured crate cards carry a subtle amber/gold badge or ribbon (e.g., a small filled-star icon beside the crate name) — visible at rest, no hover required. Genre crates use thin 2px left-edge color accents derived from a genre-to-color mapping (navy for Jazz, purple for Electronic, amber for Hip-Hop, etc.) — the mobile equivalent of the physical genre divider tabs in a record store bin. The accent is systematic and low-opacity — it colors the card's left border, visible when scanning.
+
+*Desktop outward:* At comfy and wide, the Wall's accent rule gains more presence. Featured badges have room for a short text label ("Staff Pick") in addition to the icon. Genre color accents become more saturated and the genre-name heading can optionally render in the accent color. The `<SectionSign>` primitive handles all ARIA labeling, heading levels, and region roles — a single point of accessibility enforcement.
+
+**Axis:** Section identity & signage + Visual treatment & mood
+
+**Basis:** `direct:` `CrateCard` receives a `variant` prop (`"featured" | "genre"`) but only uses it for `headerSize` (text-base vs text-sm) — a typographic detail invisible at phone scale. The variant pipeline carries zero visual payload. `CrateSectionGrid` renders section-level chrome (`border-b`, `description`) that is visually identical across sections — same `border-mc-border` divider on every section. `direct:` Audit finding: "A first-time shopper cannot tell which section is the Wall vs. a crate menu." `external:` Physical record stores use genre divider cards — thick cardstock tabs with hand-lettered genres — ubiquitous in every independent record store worldwide. Shoppers navigate bins by tab color before reading text. Mobile apps like Spotify use color-coded genre tiles.
+
+**Rationale:** Color and iconography are pre-attentive — a shopper scrolling at speed on a phone can locate "the oxblood section" (Wall) or find "Jazz" by the navy left-edge accent before reading a single label. Badges on Featured cards communicate "this one is different" without requiring the shopper to parse the section heading. The SectionSign primitive is a single point to enforce accessibility across all sections — today `StoreFloor` and `CrateSectionGrid` manage ARIA independently with different patterns.
+
+**Downsides:** Genre-to-color mapping needs a maintainable palette — 4-6 colors covers typical crate counts, but more genres could exhaust distinct colors at low opacity. The badge must map to a real semantic distinction (staff-selected = true) to avoid feeling decorative. Color must not be the only differentiator (accessibility: pair with icon/shape).
+
+**Confidence:** 70%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+---
+
+### 4. Interaction Rhythms by Section Role
+
+**Description:** *Mobile-first:* On a phone, there is no hover. Today, the "DIG →" entry label is permanently invisible on touch screens (`opacity: isHovered ? 1 : 0`), and crate cards offer no visual cue that they're tappable. This idea fixes the compact contract first: every crate card gets a persistent, always-visible entry affordance — a small "Enter →" label below the thumbnail grid or a right-edge chevron on the card header. The Wall gets the only "DIG →" label (editorial copy reserved for the taste-signaling surface). Genre cards are deliberately still on tap — a simple CSS opacity transition on press, no lift, no tilt. Stillness is the Genre interaction signal: "this is the catalog — scan, pick, move on." Featured cards get a subtle press-scale (0.98) — enough to confirm the tap without distracting from the browsing rhythm.
+
+*Desktop outward:* At comfy and wide, hover enriches the contracts established on compact. Wall gains immersive editorial motion — a slower, deeper lift with a subtle sample cue on load. Featured cards get the standard tactile hover (lift, tilt, border glow) with a badge pulse. Genre cards remain still on hover — just a border-color transition. The motion hierarchy is: Wall = stop and look, Featured = these are highlighted, Genre = scan and move.
+
+**Axis:** Interaction & affordance
+
+**Basis:** `direct:` `CrateShelf`'s `openLabel` animates in with `opacity: isHovered ? 1 : 0` (`crate_shelf.tsx:95-99`) — permanently invisible on touch screens. Audit P1 gap: "a compact shopper must tap the shelf area without any affordance." `direct:` `CrateCard` applies identical `springTactile` / `springPress` animation to all variants via `useTactileHover()` — no differentiation. `external:` Nielsen Norman Group: identical interactions signal identical functions. If sections have different semantic jobs, identical interaction responses train the shopper to ignore those differences.
+
+**Rationale:** On a phone, interaction IS teaching. A persistent "Enter →" label says "you can go deeper here" — the current hidden hover label says nothing. Reserving "DIG →" for the Wall makes it an editorial beacon, not boilerplate. Stillness on Genre cards is the most information-dense signal: when the shopper encounters a section that doesn't animate, they learn "this is different — this is for scanning, not considering." The interaction rhythm (immersion → invitation → stillness) mirrors the semantic hierarchy (editorial → curated → systematic) without requiring a single label.
+
+**Downsides:** A persistent entry affordance on every card adds visual weight — needs to be subtle enough not to compete with cover art. Still Genre on desktop may feel like a bug on first hover. Three motion profiles need maintenance in `motion_tokens.ts`.
+
+**Confidence:** 80%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+---
+
+### 5. Progressive Disclosure & Density
+
+**Description:** *Mobile-first:* On a phone, a first-time shopper sees three stacked sections with no guidance on where to start. A one-time subtle orientation cue — a soft animated attention line or gentle glow on the Wall section — fires once per browser via `localStorage`. It says "start here" through visual emphasis alone: no tooltip, no popup, no text. The cue dissolves on any interaction (tap, scroll) or after a 3-second dwell, and never returns. Pattern reuses the existing `GhostFingerCue` from `CrateView`. Thumbnail density also carries semantic weight on compact: Wall shows 4 covers (editorial abundance — "look at all this taste"), Featured crates show 3 (curated highlights — "open to see more"), Genre crates show 2 per card (category labels — "recognize the genre and enter"). The varying thumbnail counts act as a pacing rhythm as the shopper's thumb scrolls.
+
+*Desktop outward:* At comfy and wide, the wayfinding cue has more spatial room — the glow or attention line can be more pronounced. Thumbnail density contrast amplifies: Wall 8, Featured 4, Genre 4. The density rhythm (abundant → moderate → systematic) becomes a learnable signal across visits.
+
+**Axis:** Progressive disclosure
+
+**Basis:** `direct:` `CrateCard` hardcodes `previewCount={4}` for all Featured and Genre crates — zero semantic differentiation. `StoreFloor` computes a dynamic `picksPreviewCount` (4/8) for the Wall only — evidence that density matters but is applied inconsistently. `direct:` `GhostFingerCue.tsx` already implements the one-shot dissolve-on-interaction pattern in the codebase — proven, tested, reusable. `external:` Museum orientation galleries, Apple Store product table placement, and Spotify's first-run "Made for You" promotion all use spatial cues on first visit to teach layout without permanent labels.
+
+**Rationale:** The first-visit wayfinding cue directly addresses the audit's core gap on compact: a first-time shopper doesn't know where to look. It teaches the store's spatial grammar once, then dissolves — the grammar persists through the layout, signage, and interaction treatments from ideas #1–4. Density variation makes the information hierarchy visible without additional chrome or labels. A shopper scrolling at speed perceives "4 covers = stop here" vs. "2 covers = scan and pick" before reading any text.
+
+**Downsides:** The wayfinding cue could feel gimmicky if animated heavily — should be a subtle gradient glow or short attention line, not a bouncing arrow. The `localStorage` flag needs a dismissal path (shopper must be able to ignore it by scrolling). Density differences at compact (2 vs. 3 vs. 4 thumbnails) are subtle — needs companion treatments from ideas #2–4 to register fully.
+
+**Confidence:** 70%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+---
+
+## Axis Coverage
+
+| Axis | Primary survivors |
+|---|---|
+| Layout & spatial differentiation | #1 Wall Marquee, #2 Differentiated Layouts |
+| Section identity & signage | #3 Signage Grammar |
+| Interaction & affordance | #4 Interaction Rhythms |
+| Visual treatment & mood | #1 Wall Marquee, #3 Signage Grammar |
+| Progressive disclosure | #5 Disclosure & Density |
+
+## Rejection Summary
+
+39 of 44 raw ideas cut. Key categories:
+
+| Category | Count | Examples |
+|---|---|---|
+| Merged into a survivor | 24 | Wall-as-Marque → #1; Staff Picks Shelf → #2; Genre Divider Color → #3; Still Genre → #4; Wayfinding → #5 |
+| Too radical / fights product model | 5 | Window Display (single viewport breaks mobile hierarchy), Shuffle the Floor, Dig Up (bottom-up order), Silent Store (not shippable), Accent Monopoly (greyscale harms browsing) |
+| Too speculative / high complexity | 4 | Genre as Constellation (force-directed layout), Bleed Zones (z-index/a11y), Featured as Drawer (hides staff curation), Wall as Persistent Context (sticky band) |
+| Covered by existing patterns | 3 | Silent Sections, Density as Rhythm, Unsign the Wall |
+| Below ambition floor / thin basis | 3 | Shuffle the Floor, Genre Abundance, Listening Station standalone |

--- a/docs/plans/2026-06-01-003-feat-wall-editorial-marquee-plan.md
+++ b/docs/plans/2026-06-01-003-feat-wall-editorial-marquee-plan.md
@@ -1,0 +1,375 @@
+---
+title: "feat: Wall as Editorial Marquee — borderless grid with ghost cue and tap feedback"
+type: feat
+status: active
+date: 2026-06-01
+origin: docs/brainstorms/2026-06-01-wall-editorial-marquee-requirements.md
+---
+
+# Wall as Editorial Marquee
+
+## Summary
+
+Transform the Wall from a bordered `CrateShelf` card into a borderless, full-width 6-record grid (2×3 compact, 3×2 comfy/wide) with 1.5× cover scale, tap-down feedback via `springPress`, and a one-time ghost glow cue — all through prop differentiation on `CrateShelf` via the existing `PicksShelf` wrapper. No new component for the grid; a new `WallGlowCue` for the one-time cue.
+
+---
+
+## Problem Frame
+
+The Wall renders as a bordered card identical to every crate below it. On compact, the border remains and the hover-dependent "DIG →" entry label is invisible. A first-time shopper sees a uniform scroll with no editorial threshold. The fix is mobile-first: borderless grid, larger covers, press feedback that teaches interactivity without hover, and a one-time glow cue that says "start here."
+
+---
+
+## Requirements
+
+- R1. Wall renders borderless (`border-0 rounded-none bg-transparent`), full-width, no card container — the only unbordered surface on the store floor.
+- R2. 6-record grid: 2 columns × 3 rows on compact, 3 columns × 2 rows on comfy/wide. Adaptive layout for < 6 records (see U2).
+- R3. Covers at 1.5× standard `RecordTile` thumbnail size via CSS transform.
+- R4. Tapping any cover enters the Wall crate at that record's position.
+- R5. Tap-down (onPointerDown) scales the grid container to `SCALE_PRESS` (0.985) with `springPress` transition.
+- R6. One-time ghost glow cue on first visit: soft radial glow in `--mc-accent`, ~2s duration, dissolves on `onPointerDown` or after 3s. Tracked via `localStorage` key `mc-wall-cue-dismissed`. Never fires again.
+- R7. Header: crate name + today's date above the grid. No description paragraph. No "DIG →" label.
+- R8. Comfy/wide: 3×2 grid, hover enrichment (deeper lift via `springTactile`). Sample cue deferred.
+- R9. `role="region"` + `aria-label` preserved. Each cover is a focusable, keyboard-accessible button.
+- R10. Implemented through `PicksShelf` → `CrateShelf` props. No `WallMarquee` component. Featured/Genre unchanged.
+
+**Origin actors:** A1 (first-time shopper), A2 (returning shopper), A3 (curation pipeline)
+**Origin flows:** F1 (first-visit orientation), F2 (Wall entry via tap), F3 (returning visit taste read)
+**Origin acceptance examples:** AE1 (covers R1, R2, R4), AE2 (covers R5, R6), AE3 (covers R3, R8), AE4 (covers R7, R9)
+
+---
+
+## Scope Boundaries
+
+- No dedicated `WallMarquee` component — prop differentiation only.
+- No horizontal scroll, carousel, or swipe interaction.
+- No "Fresh Today" animated temporal reveal — static date text only.
+- No sample cue (audio or visual) at comfy/wide — deferred.
+- No changes to Featured or Genre sections.
+- No changes to crate entry transition or `CrateView`.
+- No backend, curation pipeline, or data model changes.
+- Ghost cue and CrateView's ghost finger cue remain independent — they teach different interactions.
+
+### Deferred to Follow-Up Work
+
+- Sample cue (R8's "subtle sample cue") — separate feature.
+- "Fresh Today" animated reveal — separate feature.
+- `WallMarquee` component extraction — after validation.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `app/frontend/components/store_floor.tsx:16-58` — `PicksShelf` (private closure, Wall renderer)
+- `app/frontend/components/crate_shelf.tsx` — `CrateShelf` discriminated union (interactive/static)
+- `app/frontend/components/record_tile.tsx` — `RecordTile` (aspect-square, no scale prop)
+- `app/frontend/components/ghost_finger_cue.tsx` — `GhostFingerCue` (swipe icon, sessionStorage lifecycle)
+- `app/frontend/lib/first_swipe_lesson.ts` — lesson state machine (`isLessonLearned`, `markLessonLearned`)
+- `app/frontend/lib/motion_tokens.ts` — `SCALE_PRESS` (0.985), `SCALE_HOVER` (1.025), `springPress`, `springTactile`
+- `app/frontend/hooks/use_tactile_hover.ts` — `useTactileHover` hook (continuous cursor proximity, touch fallback)
+- `app/frontend/contexts/viewport_context.tsx` — viewport tiers (compact ≤767px, comfy 768–1023px, wide ≥1024px)
+- `app/frontend/test/viewport-test-utils.tsx` — `renderWithTier()` for tier-injected tests
+
+### Institutional Learnings
+
+- **Guard-parity audit:** After responsive branching, audit every guard condition (prop gates, data gates, empty/error states) on every branch. `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`
+- **Nested button hydration:** Clickable wrappers containing interactive children must use `role="button"` on `<div>`, never `<button>` or `motion.button`. `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`
+- **Animation token CI:** All spring configs and scale values must use tokens from `motion_tokens.ts`. The CI lint scanner rejects inline values. `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`
+- **Viewport tier testing:** Inject tier via `renderWithTier()`, never mock `matchMedia`. Use `describe.each(['compact', 'comfy', 'wide'])` matrix. `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`
+- **CrateShelf primitives:** Extend existing primitive system with differentiated props — don't fork. `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md`
+
+---
+
+## Key Technical Decisions
+
+- **Press scale value:** Use `SCALE_PRESS` (0.985) from motion tokens, not the hardcoded `0.99` in `CrateShelf`'s interactive variant. Aligns the Wall with the token system and `CrateView`'s card stack.
+- **Ghost cue component:** New `WallGlowCue` — dedicated component with its own visual (radial glow) sharing the lifecycle pattern from `first_swipe_lesson.ts` (extracted as `cue_lesson.ts`). Not generalizing `GhostFingerCue` — that component is tightly coupled to the swipe-down icon.
+- **Ghost cue storage:** `localStorage` key `mc-wall-cue-dismissed` — one-shot permanent. Deliberate departure from the existing `sessionStorage` pattern (`mc-first-swipe-learned`) because the Wall cue teaches a simpler interaction (tap) that doesn't need per-session repetition.
+- **Timer dismissal:** Ghost cue's 3s auto-dismiss timer cancels on `onPointerDown`, not on click. Prevents the glow dissolve animation from overlapping with the press-scale feedback during a tap-in-progress.
+- **Cover scale approach:** CSS `transform: scale(1.5)` applied on a wrapper `<span>` around `RecordTile` inside the grid cell. Does not change grid cell size — the 1.5× cover overflows its cell slightly. At the current grid-gap of `gap-1.5` (6px), the overflow is contained within the gap and does not overlap adjacent covers.
+- **Sparse grid layout:** Dynamic. ≤2 records → 1 column (1×N). 3-4 records → 2 columns (2 rows). 5 records → 2 columns (one trailing empty cell). 6 records → 2 columns compact / 3 columns comfy+ (3×2). Implemented as a `wallGridColumns(count)` helper.
+- **Container press + button click:** Follows existing `CrateShelf` interactive pattern — `useTactileHover` provides `isPressed` on the grid `motion.div`, individual `<button>` children handle `onClick`. No new event architecture. Test on mobile Safari early.
+- **Ghost cue visual:** A `motion.div` with `position: absolute; inset: 0` on the grid container, animated `box-shadow` or `radial-gradient` in `--mc-accent` from opacity 0 → 0.3 → 0 over ~2s. `pointer-events-none` so it never blocks interaction.
+
+---
+
+## Implementation Units
+
+### U1. Add `SCALE_MARQUEE` token and cue lifecycle helper
+
+**Goal:** Extend the animation token and lesson systems to support the Wall treatment.
+
+**Requirements:** R3, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/frontend/lib/motion_tokens.ts`
+- Create: `app/frontend/lib/cue_lesson.ts`
+- Modify: `app/frontend/lib/first_swipe_lesson.ts`
+- Test: `app/frontend/lib/cue_lesson.test.ts`
+
+**Approach:**
+- Add `SCALE_MARQUEE = 1.5` to `motion_tokens.ts` alongside existing scale constants. The CI lint scanner already enforces token-only imports — no additional lint rule changes needed.
+- Extract the shared lesson lifecycle from `first_swipe_lesson.ts` into `cue_lesson.ts`: functions `isCueLearned(key: string, storage?: Storage)`, `markCueLearned(key: string, storage?: Storage)`, and `clearCueLesson(key: string, storage?: Storage)`. Default storage parameter is `localStorage`.
+- Refactor `first_swipe_lesson.ts` to delegate to `cue_lesson.ts` with `sessionStorage` and key `mc-first-swipe-learned`. Existing behavior unchanged — this is a pure extraction.
+- Unit test `cue_lesson.ts` for: marking sets the key, isLearned returns true after mark, clearCueLesson resets, defaulting to localStorage, explicit sessionStorage override, missing key returns false.
+
+**Patterns to follow:**
+- `app/frontend/lib/first_swipe_lesson.ts` — existing lesson state machine
+- `app/frontend/lib/motion_tokens.ts` — token export pattern
+
+**Test scenarios:**
+- Happy path: `markCueLearned('test-key')` → `isCueLearned('test-key')` returns true
+- Happy path: Defaults to localStorage when no storage parameter
+- Happy path: Explicit sessionStorage override works
+- Edge case: `isCueLearned('nonexistent')` returns false
+- Edge case: `clearCueLesson` removes the key, `isCueLearned` returns false after
+
+**Verification:**
+- `SCALE_MARQUEE` is exported and importable from `@/lib/motion_tokens`
+- `cue_lesson.ts` passes unit tests
+- `first_swipe_lesson.ts` behavior is unchanged (existing tests pass after refactor)
+
+---
+
+### U2. Update PicksShelf and StoreFloor — grid, border, density, sparse layout
+
+**Goal:** Change `PicksShelf` in `StoreFloor` to render the Wall borderless with 6-record adaptive grid and no entry label.
+
+**Requirements:** R1, R2, R7, R10
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/frontend/components/store_floor.tsx`
+- Test: `app/frontend/components/store_floor.test.tsx`
+
+**Approach:**
+- Change `picksPreviewCount`: `const picksPreviewCount = isCompact ? 6 : 6;` (always 6, comfy/wide grid adapts via `gridColumnCount(6)` → 3 cols → 2 rows). Revisit if comfy/wide should remain 8 per origin R8 — but R2 specifies 6 across all tiers after user dialogue resolved 2×3 compact, 3×2 comfy/wide.
+- Remove the `!isCompact` condition from `className`: pass `className="border-0 rounded-none"` unconditionally. Also pass `bg-transparent` to override CrateShelf's default `bg-mc-bg-card`. To avoid fighting Tailwind specificity with CrateShelf's hardcoded `bg-mc-bg-card`, use `!bg-transparent` (important prefix) or pass the classes after the default is composed: CrateShelf appends `className` after `bg-mc-bg-card border border-mc-border rounded-lg`, so `className="border-0 rounded-none bg-transparent"` will correctly override all three via CSS cascade (same specificity, later in source order wins).
+- Remove `openLabel="DIG →"` prop — no entry label.
+- Remove visible description paragraph: delete the `<p className="text-xs text-mc-text-dim mb-3">Today's picks — the store's taste at a glance</p>` in `StoreFloor`'s picks section render. The `role="region"` `aria-label` already carries this copy.
+- Add `wallGridColumns(count: number): number` helper function: ≤2 → 1, ≤4 → 2, otherwise → 2 for compact / 3 for comfy/wide. Use this to pass a `columnOverride` prop to `CrateShelf` (added in U3) or compute columns in `PicksShelf` and pass via `previewCount` + a new `forceColumns` logic.
+- On non-compact, the PicksShelf wrapper `motion.div` already applies its own border — this wrapper itself should also become borderless by removing the `border` class from its `className` when the inner shelf is borderless.
+
+**Patterns to follow:**
+- Existing `PicksShelf` structure in `store_floor.tsx:16-58`
+- `CrateShelf`'s `gridColumnCount` mapping pattern
+
+**Test scenarios:**
+- Happy path: Wall renders with 6 records, 2 columns on compact (`renderWithTier("compact", ...)`)
+- Happy path: Wall renders with 6 records, 3 columns on comfy/wide
+- Edge case: 3 records → 2 columns, 2 rows (one empty cell)
+- Edge case: 2 records → 1 column, 2 rows
+- Edge case: 1 record → 1 column, 1 row
+- Edge case: 0 records → Wall section not rendered at all (existing behavior, unchanged)
+- Edge case: `aria-label` still present on the `role="region"` wrapper
+- Edge case: No "DIG →" text visible at any viewport tier
+- Edge case: No description paragraph visible
+- Integration: `border-0 rounded-none bg-transparent` classes present on CrateShelf container at all tiers
+
+**Verification:**
+- Wall renders borderless on compact and non-compact
+- Grid adapts column count to record count
+- No entry label or description paragraph visible
+- Existing Featured and Genre sections unchanged
+
+---
+
+### U3. Add `coverScale` prop to CrateShelf
+
+**Goal:** Enable 1.5× cover scaling on `RecordTile` thumbnails via a new prop.
+
+**Requirements:** R3, R10
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `app/frontend/components/crate_shelf.tsx`
+- Test: `app/frontend/components/crate_shelf.test.tsx`
+
+**Approach:**
+- Add `coverScale?: number` to `BaseCrateShelfProps`. Default undefined (no scaling).
+- In `CrateShelfLayout`, when `coverScale` is set, wrap each `RecordTile` or its container in a `<span>` with `style={{ transform: 'scale(${coverScale})' }}` and `transform-origin: center center`.
+- The scale wrapper sits inside the grid cell — the grid cell size is unchanged, so the 1.5× cover overflows into the cell's `gap-1.5` margin. At 6px gap, 1.5× overflow on a ~150px cell is ~37.5px per side, which may encroach on adjacent cells. Mitigation: set `overflow-hidden` on the grid cell container, or increase gap for the Wall specifically. The flow analyzer (G14) flagged this — if overflow clipping is unacceptable, use a dedicated `wallGap` prop or increase gap via the existing `gap` override in `CrateSectionGrid` (but the Wall doesn't use `CrateSectionGrid` — gap is in `CrateShelf`'s grid container at `gap-1.5`). Pass a `gap` prop alongside `coverScale`.
+- For the Wall, `PicksShelf` passes `coverScale={SCALE_MARQUEE}` and `gap="gap-3"` (12px instead of 6px) to accommodate the overflow.
+- The scale must not affect the `tactileThumbnails` CSS hover scale — the 1.5× is visual size, hover scale is a separate interaction effect. CrateShelf applies `tactileThumbnails` via a CSS class on RecordTile; the wrapper scale applies independently.
+
+**Patterns to follow:**
+- Existing prop addition pattern in `CrateShelf` (e.g., `headerSize`, `tactileThumbnails`, `meta`)
+- Discriminated union: `coverScale` goes on `BaseCrateShelfProps` (shared by both static and interactive)
+
+**Test scenarios:**
+- Happy path: `coverScale={1.5}` applies `transform: scale(1.5)` to each RecordTile wrapper
+- Happy path: `coverScale` undefined → no scale wrapper (existing behavior unchanged)
+- Edge case: `coverScale={1}` → wrapper present but visually unchanged
+- Edge case: Scale does not affect grid layout — column count unchanged with `coverScale`
+
+**Verification:**
+- CrateShelf accepts `coverScale` prop
+- RecordTile renders with scale wrapper when prop is set
+- Existing CrateShelf tests pass (no regression)
+- PicksShelf passes `coverScale={SCALE_MARQUEE}` from U2
+
+---
+
+### U4. Integrate tap-down feedback on Wall grid
+
+**Goal:** Apply `SCALE_PRESS` (0.985) with `springPress` transition to the Wall grid container on touch-down.
+
+**Requirements:** R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `app/frontend/components/store_floor.tsx` (PicksShelf)
+- Test: `app/frontend/components/store_floor.test.tsx`
+
+**Approach:**
+- PicksShelf already uses `useTactileHover` on non-compact in its `motion.div` wrapper. On compact, it renders `CrateShelf` directly with no wrapper — and therefore no press animation.
+- The fix: wrap the compact path as well, but with a minimalist `motion.div` that only handles press scale (no border animation, no lift, no tilt — those are non-compact enrichments). On compact: `animate={{ scale: isPressed ? SCALE_PRESS : 1 }}` with `transition={springPress}`.
+- The `motion.div` uses `useTactileHover` for `isPressed` detection. On compact, `useTactileHover` already handles touch correctly: `onPointerDown` sets `isPressed = true`, `onPointerUp` sets it false. No hover flash (the touch hover flash fix from 2026-05-14 is applied).
+- The individual cover `<button>` children inside `CrateShelf` handle `onClick` for crate entry. The container `motion.div` does NOT intercept click — it only handles pointer events for scale animation. Test on mobile Safari to confirm button clicks still register (flow analyzer G2).
+- On non-compact, the existing `PicksShelf` wrapper already applies press scale via `SCALE_PRESS` — change the hardcoded `SCALE_HOVER` and `SCALE_PRESS` references to use the imported tokens if not already doing so (they are).
+- Remove the `rotate` animation on the wrapper for the Wall specifically — the Wall is an editorial surface, not a card being picked up. On non-compact: `animate={{ scale: isPressed ? SCALE_PRESS : isHovered ? SCALE_HOVER : 1, y: isHovered ? -3 : 0 }}` (no rotate). On compact: `animate={{ scale: isPressed ? SCALE_PRESS : 1 }}` (no hover enrichment at all).
+
+**Patterns to follow:**
+- Existing `PicksShelf` motion.div wrapper pattern (`store_floor.tsx:42-56`)
+- `useTactileHover` usage in `CrateCard` (`crate_card.tsx:22`)
+
+**Test scenarios:**
+- Happy path: On compact, pointer-down on grid → container scales to 0.985
+- Happy path: On compact, pointer-up → container scales back to 1.0
+- Edge case: Tap on a specific cover → press scale fires, crate entry at correct record index
+- Edge case: Rapid double-tap → no duplicate navigation (existing CrateShelf onClick handles this)
+- Integration: Non-compact hover still works (lift, scale) but no rotate animation on the Wall wrapper
+
+**Verification:**
+- Press-down feedback visible on compact touch
+- Individual cover taps correctly route to crate entry
+- No rotate animation on Wall wrapper
+
+---
+
+### U5. Build WallGlowCue component
+
+**Goal:** A one-time soft glow cue that fires on first visit, dissolves on interaction or after 3s.
+
+**Requirements:** R6
+
+**Dependencies:** U1 (cue_lesson.ts), U2
+
+**Files:**
+- Create: `app/frontend/components/wall_glow_cue.tsx`
+- Test: `app/frontend/components/wall_glow_cue.test.tsx`
+- Modify: `app/frontend/components/store_floor.tsx` (integrate into PicksShelf)
+
+**Approach:**
+- `WallGlowCue` is a `motion.div` with `position: absolute; inset: 0; pointer-events: none; z-index: 1` overlaid on the Wall grid container.
+- Visual: radial gradient or large `box-shadow` in `var(--mc-accent)` that animates opacity 0 → 0.25 → 0 over ~2 seconds, then holds at 0. Respects `prefersReducedMotion` (skips animation, never renders).
+- Lifecycle: On mount, checks `isCueLearned('mc-wall-cue-dismissed')` from `cue_lesson.ts`. If already learned, renders nothing. If not learned, renders the glow animation.
+- Dismissal paths: (a) `onPointerDown` on the parent grid container fires `markCueLearned('mc-wall-cue-dismissed')` and the component unmounts or hides, (b) a 3s `setTimeout` fires `markCueLearned` and the component hides. Timer is cleared on `onPointerDown` to prevent the timer firing during an active press (flow analyzer G4).
+- The component accepts `onDismiss?: () => void` for the parent to know when the cue has been dismissed (useful for potential animation sequencing).
+- Integration in `PicksShelf`: wrap the grid area in a `relative` container and render `<WallGlowCue>` as an overlay. Only renders on compact? Per R6, it fires on any tier for first visit — but on desktop, the glow may feel out of place since there's no tap lesson to teach. The ghost cue is about "start here," which applies to all tiers — the glow signals importance, not interaction. Render on all tiers.
+- The glow's visual shape: a radial gradient centered on the grid, using `var(--mc-accent)` with low opacity. Animation: `framer-motion` `animate={{ opacity: [0, 1, 0] }}` with `transition={{ duration: 2, ease: 'easeInOut' }}`. On `onPointerDown`, animate opacity to 0 over 0.3s and call `markCueLearned`.
+
+**Patterns to follow:**
+- `app/frontend/components/ghost_finger_cue.tsx` — presentational component with `reducedMotion` support
+- `app/frontend/lib/cue_lesson.ts` — lifecycle helper (from U1)
+- `app/frontend/hooks/use_reduced_motion.ts` — reduced motion context
+
+**Test scenarios:**
+- Happy path: First visit → glow renders, fades over ~2s, marks localStorage
+- Happy path: Second visit → `isCueLearned` returns true → renders nothing
+- Edge case: `onPointerDown` during glow animation → cue dissolves immediately, localStorage marked
+- Edge case: Timer fires at 3s → cue dissolves, localStorage marked
+- Edge case: Timer fires while `onPointerDown` is active → timer cleared, no double-dismiss (flow G4)
+- Edge case: `prefersReducedMotion` → never renders
+- Edge case: `localStorage` unavailable (private browsing) → `cue_lesson.ts` handles the error silently, cue renders (no persistence), dismiss is a no-op on storage write failure
+
+**Verification:**
+- Glow cue renders on first visit
+- Does not render on subsequent visits
+- Dismisses on tap or timer
+- Respects reduced motion
+
+---
+
+### U6. Integration, responsive tests, and guard-parity audit
+
+**Goal:** Wire all units together, add responsive matrix tests, run the guard-parity audit.
+
+**Requirements:** R1–R10 (all), AE1–AE4
+
+**Dependencies:** U2, U3, U4, U5
+
+**Files:**
+- Modify: `app/frontend/components/store_floor.tsx` (final integration)
+- Modify: `app/frontend/components/crate_shelf.tsx` (final prop wiring)
+- Test: `app/frontend/components/store_floor.test.tsx` (add Wall-specific tests)
+- Test: `app/frontend/components/crate_shelf.test.tsx` (add coverScale tests)
+- Test: `app/frontend/test/pages/responsive_surface_matrix.test.tsx` (add Wall tier tests)
+
+**Approach:**
+- In `PicksShelf`: pass `coverScale={SCALE_MARQUEE}`, `gap="gap-3"`, `previewCount=6`, `className="border-0 rounded-none bg-transparent"`, no `openLabel`. Wrap in `relative` container, render `<WallGlowCue>` overlay. On compact: wrap `CrateShelf` in `motion.div` with press-only animation. On non-compact: adjust existing wrapper to remove `rotate`.
+- In `CrateShelfLayout`: support `coverScale` and `gap` props. Add `wallGridColumns` or expose column override.
+- Responsive matrix tests (new in `store_floor.test.tsx`):
+  - `describe.each(['compact', 'comfy', 'wide'])('Wall at %s tier', (tier) => { ... })` — render Wall with 6 records, verify: grid columns (2/3/3), borderless classes present, no "DIG →" label, no description paragraph, `aria-label` on region, press feedback container present.
+  - Sparse grid tests per tier.
+  - Ghost cue visibility test (mock `cue_lesson`).
+- Guard-parity audit (per learning `responsive-branching-guard-condition-drift`):
+  - Walk every responsive branch in `PicksShelf` and `CrateShelfLayout`.
+  - Verify: `records.length > 0` guard (hides Wall when empty) on all branches.
+  - Verify: `crate` prop null/undefined guard on all branches.
+  - Verify: ghost cue only renders when `!isCueLearned` and `!prefersReducedMotion`.
+  - Verify: `coverScale` only applied when defined.
+
+**Test scenarios:**
+- Integration: Full Wall render at compact, comfy, wide — borderless, 6 covers, correct columns
+- Integration: Tapping a cover navigates to correct crate position (mock `onSelectCrate`)
+- Accessibility: `role="region"` with correct `aria-label`
+- Accessibility: Each cover is a `<button>` with `aria-label`
+- Regression: Featured and Genre sections unchanged (existing tests pass)
+- Regression: Existing CrateShelf usage (Featured, Genre via CrateCard) unaffected by new props
+
+**Verification:**
+- All AE1-AE4 acceptance examples pass
+- All three tiers render correctly
+- Existing tests pass with no regressions
+- Guard-parity audit produces no findings
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `StoreFloor` → `PicksShelf` → `CrateShelf` → `RecordTile`. New: `WallGlowCue` overlay in `PicksShelf`. No changes to `CrateCard`, `CrateSectionGrid`, `FeaturedCratesRow`, or `GenreGrid`.
+- **Error propagation:** `cue_lesson.ts` handles `localStorage` unavailability silently (try/catch on getItem/setItem). Ghost cue gracefully degrades — renders but can't persist dismissal. No error propagation to the user.
+- **State lifecycle risks:** Ghost cue timer (3s) must be cleaned up on unmount to prevent `setState` on unmounted component. `useEffect` cleanup handles this.
+- **API surface parity:** No new Inertia props or backend changes. The Wall still consumes the same `Crate` type from `StoreShowProps`.
+- **Integration coverage:** The `CrateShelf` interactive mode's existing event handling (container `motion.div` press + inner `<button>` click) is the key integration seam. Test on real mobile Safari.
+- **Unchanged invariants:** `CrateShelf`'s static variant and Featured/Genre interactive variant are unchanged. `CrateCard` is unchanged. `RecordTile` API is unchanged (scale applied at wrapper level). `CrateView` and the card stack are unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Container press animation conflicts with button clicks on mobile Safari (G2) | Test on real device early in U4. The existing CrateShelf pattern has this same architecture — if it works today for Featured/Genre, it works for the Wall. |
+| 1.5× cover scale overflows grid gap and overlaps adjacent covers (G14) | Increase Wall grid gap from `gap-1.5` to `gap-3` via new `gap` prop. Overflow is contained. |
+| Ghost cue timer fires during active press (G4) | Clear timer on `onPointerDown` in U5. |
+| `localStorage` unavailable (private browsing) | `cue_lesson.ts` wraps getItem/setItem in try/catch. Cue renders on first visit but can't persist — acceptable degradation. |
+| Ghost cue and CrateView ghost finger cue fire back-to-back (G10) | Keep independent per Key Technical Decision. The cues teach different interactions. If user feedback indicates annoyance, address in follow-up. |
+| Guard drift across responsive branches | Guard-parity audit in U6 catches this before merge. |
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-01-wall-editorial-marquee-requirements.md](docs/brainstorms/2026-06-01-wall-editorial-marquee-requirements.md)
+- **Ideation document:** [docs/ideation/2026-06-01-store-page-visual-refresh-ideation.md](docs/ideation/2026-06-01-store-page-visual-refresh-ideation.md)
+- Related code: `app/frontend/components/store_floor.tsx`, `app/frontend/components/crate_shelf.tsx`, `app/frontend/components/record_tile.tsx`, `app/frontend/components/ghost_finger_cue.tsx`, `app/frontend/lib/first_swipe_lesson.ts`, `app/frontend/lib/motion_tokens.ts`, `app/frontend/hooks/use_tactile_hover.ts`
+- Learnings: `docs/solutions/logic-errors/responsive-branching-guard-condition-drift-2026-05-13.md`, `docs/solutions/architecture-patterns/viewport-context-responsive-architecture-2026-05-09.md`, `docs/solutions/architecture-patterns/storefront-animation-token-system-2026-05-08.md`, `docs/solutions/architecture-patterns/vendor-brand-responsive-surface-system-2026-05-14.md`

--- a/docs/plans/2026-06-01-003-feat-wall-editorial-marquee-plan.md
+++ b/docs/plans/2026-06-01-003-feat-wall-editorial-marquee-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Wall as Editorial Marquee — borderless grid with ghost cue and tap feedback"
 type: feat
-status: active
+status: completed
 date: 2026-06-01
 origin: docs/brainstorms/2026-06-01-wall-editorial-marquee-requirements.md
 ---


### PR DESCRIPTION
## Summary

Transforms the Wall from a bordered CrateShelf card into a borderless, full-width 6-record grid (2x3 compact, 3x2 comfy/wide) with 1.5x cover scale, tap-down feedback, and a one-time ghost glow cue — all through prop differentiation on CrateShelf via the existing PicksShelf wrapper.

## What changed

**7 source files, 6 incremental commits:**

- **U1:** Added `SCALE_MARQUEE` (1.5) and `LIFT_MARQUEE` to motion tokens. Extracted shared cue lifecycle from `first_swipe_lesson.ts` into `cue_lesson.ts` with configurable storage backend.
- **U2:** PicksShelf now renders borderless unconditionally on all viewport tiers. `previewCount` changed from 4/8 to 6. Description paragraph and "DIG →" label removed. Desktop wrapper loses rotate animation.
- **U3:** `coverScale` and `gridGap` props added to CrateShelf. Wall uses `SCALE_MARQUEE` (1.5x) with `gap-3` to accommodate cover overflow.
- **U4:** Compact and non-compact both wrap in `motion.div` with `useTactileHover` for press feedback (`SCALE_PRESS` 0.985).
- **U5:** `WallGlowCue` — one-time soft radial glow in accent color, dissolves on pointer-down or after 3s. Uses `localStorage` for permanent dismissal. Respects `prefers-reduced-motion`.
- **U6:** Responsive tests for borderless, grid columns, press wrapper, no-DIG, aria-label.

## Key decisions

- Wall is the only unbordered surface on the store floor — creates a spatial threshold between editorial zone and navigation zone
- Grid-as-entry: tapping any cover enters the crate at that record position
- No persistent CTA label — taught via one-time ghost cue + tap feedback
- 1.5x covers overflow into `gap-3` (12px) to avoid overlapping adjacent covers
- Ghost cue uses `localStorage` (permanent one-shot) — deliberate departure from `GhostFingerCue`'s `sessionStorage`, because the Wall teaches a simpler interaction (tap vs. vertical drag)

## Testing

- 479 tests pass (4 new Wall-specific tests)
- All existing CrateShelf, StoreFloor, Featured, and Genre tests unchanged
- Lint clean

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — frontend-only presentation change with no backend, API, or data modifications.

## Requirements trace

| R-ID | Description | Status |
|------|------------|--------|
| R1 | Wall borderless, full-width | Done |
| R2 | 6-record adaptive grid | Done |
| R3 | 1.5x cover scale | Done |
| R4 | Tap enters crate at position | Done |
| R5 | Tap-down press feedback | Done |
| R6 | One-time ghost glow cue | Done |
| R7 | Header: name + date only | Done |
| R8 | Comfy/wide: 3x2 + hover | Done |
| R9 | Accessibility preserved | Done |
| R10 | No WallMarquee component | Done |

## Origin

- [Requirements](docs/brainstorms/2026-06-01-wall-editorial-marquee-requirements.md)
- [Plan](docs/plans/2026-06-01-003-feat-wall-editorial-marquee-plan.md)
