### PR TITLE
feat(store): poll OAuth Discogs sales to remove sold inventory

### DIFF
--- a/app/jobs/sales_poll_dispatcher_job.rb
+++ b/app/jobs/sales_poll_dispatcher_job.rb
@@ -1,0 +1,28 @@
+# Dispatches sales polling jobs for OAuth-authorized stores that are due for polling.
+# Selects stores where last_sales_polled_at is nil or older than POLL_INTERVAL,
+# respects a per-run budget, and staggers enqueued jobs to avoid rate limit spikes.
+class SalesPollDispatcherJob < ApplicationJob
+  limits_concurrency to: 1, key: ->(*) { "discogs_api" }
+  queue_as :default
+
+  MAX_STORES_PER_RUN = 20
+  STAGGER_INTERVAL = 3.seconds
+  POLL_INTERVAL = 1.minute
+
+  def perform
+    due_stores.each_with_index do |store, index|
+      SalesPollStoreJob
+        .set(wait: STAGGER_INTERVAL * index)
+        .perform_later(store.id)
+    end
+  end
+
+  private
+
+  def due_stores
+    Store.joins(:store_owner)
+      .where.not(store_owners: { discogs_oauth_token: nil, discogs_oauth_token_secret: nil })
+      .where("last_sales_polled_at IS NULL OR last_sales_polled_at < ?", POLL_INTERVAL.ago)
+      .limit(MAX_STORES_PER_RUN)
+  end
+end

--- a/app/jobs/sales_poll_dispatcher_job.rb
+++ b/app/jobs/sales_poll_dispatcher_job.rb
@@ -21,7 +21,8 @@ class SalesPollDispatcherJob < ApplicationJob
 
   def due_stores
     Store.joins(:store_owner)
-      .where.not(store_owners: { discogs_oauth_token: nil, discogs_oauth_token_secret: nil })
+      .where.not(store_owners: { discogs_oauth_token: nil })
+      .where.not(store_owners: { discogs_oauth_token_secret: nil })
       .where("last_sales_polled_at IS NULL OR last_sales_polled_at < ?", POLL_INTERVAL.ago)
       .limit(MAX_STORES_PER_RUN)
   end

--- a/app/jobs/sales_poll_store_job.rb
+++ b/app/jobs/sales_poll_store_job.rb
@@ -15,7 +15,7 @@ class SalesPollStoreJob < ApplicationJob
   private
 
   def enqueue_curation_if_needed(store, result)
-    return unless result && result[:removed_count]&.positive?
+    return unless result && result[:removed_count] > 0
 
     DailyCurationJob.perform_later(store.id)
   end

--- a/app/jobs/sales_poll_store_job.rb
+++ b/app/jobs/sales_poll_store_job.rb
@@ -1,0 +1,13 @@
+# Polls recent Discogs orders for a single store and removes sold listings.
+# Uses per-store concurrency key to prevent duplicate polls for the same store.
+class SalesPollStoreJob < ApplicationJob
+  limits_concurrency to: 1, key: ->(store_id) { "sales_poll_#{store_id}" }
+  queue_as :default
+
+  def perform(store_id)
+    store = Store.find(store_id)
+    StoreSales::OrderPoller.new(store).call
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.warn("[SalesPollStoreJob] store #{store_id} not found, discarding")
+  end
+end

--- a/app/jobs/sales_poll_store_job.rb
+++ b/app/jobs/sales_poll_store_job.rb
@@ -6,8 +6,17 @@ class SalesPollStoreJob < ApplicationJob
 
   def perform(store_id)
     store = Store.find(store_id)
-    StoreSales::OrderPoller.new(store).call
+    result = StoreSales::OrderPoller.new(store).call
+    enqueue_curation_if_needed(store, result)
   rescue ActiveRecord::RecordNotFound
     Rails.logger.warn("[SalesPollStoreJob] store #{store_id} not found, discarding")
+  end
+
+  private
+
+  def enqueue_curation_if_needed(store, result)
+    return unless result && result[:removed_count]&.positive?
+
+    DailyCurationJob.perform_later(store.id)
   end
 end

--- a/app/models/discogs_order_event.rb
+++ b/app/models/discogs_order_event.rb
@@ -1,0 +1,8 @@
+# Persists operational facts about a Discogs marketplace order for audit
+# and idempotent sales processing. No buyer PII is stored.
+class DiscogsOrderEvent < ApplicationRecord
+  belongs_to :store
+
+  validates :discogs_order_id, presence: true, uniqueness: { scope: :store_id }
+  validates :processed_at, presence: true
+end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -60,6 +60,13 @@ class Store < ApplicationRecord
     reload
   end
 
+  def discogs_oauth_client
+    DiscogsClient.new(
+      access_token: discogs_oauth_token,
+      access_token_secret: discogs_oauth_token_secret
+    )
+  end
+
   private
 
   def normalize_discogs_username

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -3,6 +3,7 @@ class Store < ApplicationRecord
   belongs_to :store_owner, optional: true
 
   has_many :listings, dependent: :destroy
+  has_many :discogs_order_events, dependent: :destroy
 
   before_validation :normalize_discogs_username, if: :discogs_username_changed?
 
@@ -52,6 +53,11 @@ class Store < ApplicationRecord
     else
       SyncStrategies::PublicApi.new
     end
+  end
+
+  def increment_inventory_version!
+    self.class.update_counters(id, inventory_version: 1)
+    reload
   end
 
   private

--- a/app/services/discogs/marketplace.rb
+++ b/app/services/discogs/marketplace.rb
@@ -5,6 +5,8 @@ module Discogs
   # public API surface (PublicClient) and OAuth-only methods live independently.
   class Marketplace
     BASE_URL = "https://api.discogs.com"
+    MAX_RETRIES = 3
+    BACKOFF_BASE = 2
 
     def initialize(access_token:, access_token_secret:)
       @access_token = access_token
@@ -35,14 +37,32 @@ module Discogs
       Array.wrap(extract_exports(body)).compact
     end
 
-    def list_orders(status: nil, page: 1)
-      path = "#{BASE_URL}/marketplace/orders?page=#{page}"
-      path += "&status=#{ERB::Util.url_encode(status)}" if status
-      response = oauth_access_token.get(path)
+    def list_orders(status: nil, page: 1, per_page: 50, sort: "last_activity", sort_order: "desc")
+      params = build_orders_params(status:, page:, per_page:, sort:, sort_order:)
+      path = "#{BASE_URL}/marketplace/orders?#{URI.encode_www_form(params)}"
+      response = with_rate_limit_retry { oauth_access_token.get(path) }
       parse_oauth_response(response)
     end
 
     private
+
+    def build_orders_params(status:, page:, per_page:, sort:, sort_order:)
+      params = { page: page, per_page: per_page, sort: sort, sort_order: sort_order }
+      params[:status] = status if status.present?
+      params
+    end
+
+    def with_rate_limit_retry(attempt: 1)
+      response = yield
+      return response unless response.code.to_i == 429
+      return response if attempt > MAX_RETRIES
+      sleep(backoff_for(attempt))
+      with_rate_limit_retry(attempt: attempt + 1) { yield }
+    end
+
+    def backoff_for(attempt)
+      [ (BACKOFF_BASE**attempt), 60 ].min
+    end
 
     def oauth_access_token
       @oauth_access_token ||= begin
@@ -53,10 +73,9 @@ module Discogs
     def parse_oauth_response(response)
       code = response.code.to_i
       return { "status" => "not_modified" } if code == 304
-
+      return raise Errors::RateLimitError, "Discogs rate limit hit" if code == 429
       parsed = parse_response_body(response)
-      return parsed if (200..299).include?(code)
-      rate_limit_or_error(code, response)
+      (200..299).include?(code) ? parsed : raise(Errors::ApiError, "Discogs API error: #{code} — #{response.body}")
     end
 
     def parse_raw_body(body, response)
@@ -72,11 +91,6 @@ module Discogs
       when Hash, Array then body
       else parse_raw_body(body, response)
       end
-    end
-
-    def rate_limit_or_error(code, response)
-      return raise Errors::RateLimitError, "Discogs rate limit hit" if code == 429
-      raise Errors::ApiError, "Discogs API error: #{code} — #{response.body}"
     end
 
     def extract_exports(body)

--- a/app/services/discogs/marketplace.rb
+++ b/app/services/discogs/marketplace.rb
@@ -4,9 +4,9 @@ module Discogs
   # Uses OAuth::AccessToken for requests. Separated from DiscogsClient so the
   # public API surface (PublicClient) and OAuth-only methods live independently.
   class Marketplace
+    include RateLimit
+
     BASE_URL = "https://api.discogs.com"
-    MAX_RETRIES = 3
-    BACKOFF_BASE = 2
 
     def initialize(access_token:, access_token_secret:)
       @access_token = access_token
@@ -58,10 +58,6 @@ module Discogs
       return response if attempt > MAX_RETRIES
       sleep(backoff_for(attempt))
       with_rate_limit_retry(attempt: attempt + 1) { yield }
-    end
-
-    def backoff_for(attempt)
-      [ (BACKOFF_BASE**attempt), 60 ].min
     end
 
     def oauth_access_token

--- a/app/services/discogs/rate_limit.rb
+++ b/app/services/discogs/rate_limit.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Shared rate-limit constants and backoff logic for Discogs API consumers.
+# Both the Faraday middleware (PublicClient) and the OAuth marketplace client
+# need the same retry discipline; this module keeps them in sync.
+module Discogs
+  module RateLimit
+    MAX_RETRIES = 3
+    BACKOFF_BASE = 2
+
+    def backoff_for(attempt)
+      [ (BACKOFF_BASE**attempt), 60 ].min
+    end
+  end
+end

--- a/app/services/discogs_rate_limit_middleware.rb
+++ b/app/services/discogs_rate_limit_middleware.rb
@@ -1,10 +1,10 @@
 # Faraday middleware that tracks and logs Discogs API rate limit headers.
 class DiscogsRateLimitMiddleware < Faraday::Middleware
+  include Discogs::RateLimit
+
   SLEEP = 1.1       # baseline pacing: ~55 req/min
   LOW = 5           # remaining threshold to trigger extended pause
   PAUSE = 10        # seconds to sleep when remaining <= LOW
-  MAX_RETRIES = 3   # max 429 retry attempts per request
-  BACKOFF_BASE = 2  # exponential backoff base (2^attempt seconds)
 
   def call(env)
     sleep_if_needed
@@ -22,10 +22,6 @@ class DiscogsRateLimitMiddleware < Faraday::Middleware
     return response if attempt > MAX_RETRIES
     sleep(backoff_for(attempt))
     request_with_retry(env, attempt: attempt + 1)
-  end
-
-  def backoff_for(attempt)
-    [ (BACKOFF_BASE**attempt), 60 ].min
   end
 
   def pause_if_quota_low(response)

--- a/app/services/store_sales/order_event_processor.rb
+++ b/app/services/store_sales/order_event_processor.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Handles deduplication and persistence of Discogs order events during
+# sales polling. Owns the decision of whether an order has already been
+# processed and the upsert of event records with removal metadata.
+module StoreSales
+  class OrderEventProcessor
+    def initialize(store)
+      @store = store
+    end
+
+    # Returns nil if the order was processed recently (within 1 minute
+    # of its last_activity timestamp), or the order_id string if it
+    # should be processed.
+    def deduplicate(order)
+      order_id = order["id"].to_s
+      existing = @store.discogs_order_events.find_by(discogs_order_id: order_id)
+      return nil if already_processed?(existing, order)
+
+      order_id
+    end
+
+    # Upsert the order event record with current status, listing IDs,
+    # and removal metadata.
+    def record(order_id, order, listing_ids, removal_result)
+      event = @store.discogs_order_events.find_or_initialize_by(discogs_order_id: order_id)
+      event.assign_attributes(
+        status: order["status"],
+        last_activity_at: parse_timestamp(order["last_activity"]),
+        listing_ids: listing_ids,
+        removed_listing_count: removal_result[:removed_count],
+        processed_at: Time.current
+      )
+      event.save!
+    end
+
+    private
+
+    def already_processed?(event, order)
+      return false unless event&.processed_at.present?
+
+      activity = parse_timestamp(order["last_activity"])
+      return false unless activity
+
+      event.processed_at >= activity - 1.minute
+    end
+
+    def parse_timestamp(value)
+      return nil if value.blank?
+
+      Time.parse(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/services/store_sales/order_listing_ids.rb
+++ b/app/services/store_sales/order_listing_ids.rb
@@ -32,9 +32,10 @@ module StoreSales
     def extract_listing_id(item)
       return nil unless item.is_a?(Hash)
 
-      # Try common keys in order of likelihood
-      id = item["listing_id"] || item[:listing_id]
-      id ||= item["id"] || item[:id]
+      # In Discogs marketplace orders, item.id IS the listing identifier.
+      # 'listing_id' is tried as a fallback for safety if the API shape changes.
+      id = item["id"] || item[:id]
+      id ||= item["listing_id"] || item[:listing_id]
 
       normalize_id(id)
     end

--- a/app/services/store_sales/order_listing_ids.rb
+++ b/app/services/store_sales/order_listing_ids.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Extracts Discogs listing IDs from order item payloads.
+# Defensive parser that handles known shapes without raising on unexpected input.
+module StoreSales
+  class OrderListingIds
+    # Extract listing IDs from an order hash.
+    # Returns array of string IDs (Discogs listing IDs are strings).
+    def self.call(order_hash)
+      new(order_hash).call
+    end
+
+    def initialize(order_hash)
+      @order_hash = order_hash || {}
+    end
+
+    def call
+      return [] unless @order_hash.is_a?(Hash)
+
+      items = extract_items
+      listing_ids = items.flat_map { |item| extract_listing_id(item) }
+      listing_ids.compact_blank.uniq
+    end
+
+    private
+
+    def extract_items
+      items = @order_hash["items"] || @order_hash[:items]
+      Array.wrap(items)
+    end
+
+    def extract_listing_id(item)
+      return nil unless item.is_a?(Hash)
+
+      # Try common keys in order of likelihood
+      id = item["listing_id"] || item[:listing_id]
+      id ||= item["id"] || item[:id]
+
+      normalize_id(id)
+    end
+
+    def normalize_id(id)
+      return nil if id.nil?
+
+      id.to_s.presence
+    end
+  end
+end

--- a/app/services/store_sales/order_listing_ids.rb
+++ b/app/services/store_sales/order_listing_ids.rb
@@ -32,11 +32,9 @@ module StoreSales
     def extract_listing_id(item)
       return nil unless item.is_a?(Hash)
 
-      # In Discogs marketplace orders, item.id IS the listing identifier.
-      # 'listing_id' is tried as a fallback for safety if the API shape changes.
+      # item.id IS the marketplace listing identifier in Discogs orders.
+      # Accept string keys (JSON) and symbol keys (Hash-with-indifferent-access).
       id = item["id"] || item[:id]
-      id ||= item["listing_id"] || item[:listing_id]
-
       normalize_id(id)
     end
 

--- a/app/services/store_sales/order_poller.rb
+++ b/app/services/store_sales/order_poller.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
-# Polls recent Discogs marketplace orders for a store, deduplicates events,
-# removes sold listings, and advances the cursor. Uses OAuth credentials
-# from the store's store_owner.
+# Orchestrates a single sales-poll cycle: fetches recent marketplace
+# orders, deduplicates, removes sold listings, and advances the cursor.
 module StoreSales
   class OrderPoller
-    def initialize(store)
+    def initialize(store, event_processor: nil, state_tracker: nil)
       @store = store
+      @event_processor = event_processor || OrderEventProcessor.new(store)
+      @state_tracker = state_tracker || PollStateTracker.new(store)
     end
 
     def call
       with_error_handling do
         ensure_oauth_authorized!
-        process_orders(fetch_recent_orders).tap { mark_success }
+        process_orders(fetch_recent_orders).tap { @state_tracker.mark_success }
       end
     end
 
@@ -33,7 +34,7 @@ module StoreSales
       return empty_result if orders.empty?
 
       stats = process_each_order(orders)
-      advance_cursor(stats[:max_activity]) if stats[:max_activity]
+      @state_tracker.advance_cursor(stats[:max_activity]) if stats[:max_activity]
       build_result(stats[:processed_count], stats[:total_removed], stats[:max_activity].present?)
     end
 
@@ -43,78 +44,18 @@ module StoreSales
     end
 
     def process_single_order(order)
-      order_id = processing_order_id(order) or return nil
+      order_id = @event_processor.deduplicate(order) or return nil
       listing_ids = OrderListingIds.call(order)
       result = SoldListingRemover.new(@store).call(listing_ids)
-      persist_event(order_id, order, listing_ids, result)
+      @event_processor.record(order_id, order, listing_ids, result)
       activity_result(order, result)
     end
 
-    def processing_order_id(order)
-      order_id = order["id"].to_s
-      already_processed_recently?(find_existing_event(order_id), order) ? nil : order_id
-    end
-
     def activity_result(order, result)
-      { activity: parse_timestamp(order["last_activity"]), removed_count: result[:removed_count] }
-    end
-
-    def find_existing_event(order_id)
-      @store.discogs_order_events.find_by(discogs_order_id: order_id)
-    end
-
-    def already_processed_recently?(event, order)
-      return false unless event&.processed_at.present?
-
-      current_activity = parse_timestamp(order["last_activity"])
-      return false unless current_activity
-
-      event.processed_at >= current_activity - 1.minute
-    end
-
-    def persist_event(order_id, order, listing_ids, removal_result)
-      event = find_or_init_event(order_id)
-      assign_event_attributes(event, order, listing_ids, removal_result)
-      event.save!
-    end
-
-    def find_or_init_event(order_id)
-      @store.discogs_order_events.find_or_initialize_by(discogs_order_id: order_id)
-    end
-
-    def assign_event_attributes(event, order, listing_ids, removal_result)
-      event.assign_attributes(
-        status: order["status"],
-        last_activity_at: parse_timestamp(order["last_activity"]),
-        listing_ids: listing_ids,
-        removed_listing_count: removal_result[:removed_count],
-        processed_at: Time.current
-      )
-    end
-
-    def advance_cursor(max_activity)
-      @store.update!(sales_poll_cursor_at: max_activity)
-    end
-
-    def mark_success
-      @store.update!(
-        last_sales_polled_at: Time.current,
-        last_sales_poll_error: nil,
-        last_sales_poll_error_at: nil
-      )
-    end
-
-    def mark_failure(error)
-      @store.update_columns(
-        last_sales_poll_error: summarize_error(error),
-        last_sales_poll_error_at: Time.current
-      )
-    end
-
-    def summarize_error(error)
-      summary = "#{error.class}: #{error.message}"
-      backtrace = Array(error.backtrace).first(8)
-      ([ summary ] + backtrace).join("\n")
+      {
+        activity: parse_timestamp(order["last_activity"]),
+        removed_count: result[:removed_count]
+      }
     end
 
     def parse_timestamp(value)
@@ -136,7 +77,7 @@ module StoreSales
     def with_error_handling
       yield
     rescue StandardError => e
-      mark_failure(e)
+      @state_tracker.mark_failure(e)
       raise
     end
 

--- a/app/services/store_sales/order_poller.rb
+++ b/app/services/store_sales/order_poller.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+# Polls recent Discogs marketplace orders for a store, deduplicates events,
+# removes sold listings, and advances the cursor. Uses OAuth credentials
+# from the store's store_owner.
+module StoreSales
+  class OrderPoller
+    OVERLAP_WINDOW = 10.minutes
+
+    def initialize(store)
+      @store = store
+    end
+
+    def call
+      with_error_handling do
+        ensure_oauth_authorized!
+        process_orders(fetch_recent_orders).tap { mark_success }
+      end
+    end
+
+    private
+
+    def ensure_oauth_authorized!
+      return if @store.oauth_authorized?
+
+      raise Discogs::Errors::ApiError, "OAuth authorization required for sales polling"
+    end
+
+    def fetch_recent_orders
+      response = build_client.list_orders(sort: "last_activity", sort_order: "desc")
+      Array.wrap(response["orders"])
+    end
+
+    def process_orders(orders)
+      return empty_result if orders.empty?
+
+      stats = process_each_order(orders)
+      advance_cursor(stats[:max_activity]) if stats[:max_activity]
+      build_result(stats[:processed_count], stats[:total_removed], stats[:max_activity].present?)
+    end
+
+    def process_each_order(orders)
+      results = orders.filter_map { |order| process_single_order(order) }
+      aggregate_results(results)
+    end
+
+    def process_single_order(order)
+      return nil if already_processed_recently?(find_existing_event(order), order)
+
+      listing_ids = OrderListingIds.call(order)
+      removal_result = remove_sold_listings(listing_ids)
+      persist_event(order, listing_ids, removal_result)
+
+      { activity: parse_timestamp(order["last_activity"]), removed_count: removal_result[:removed_count] }
+    end
+
+    def find_existing_event(order)
+      order_id = order["id"].to_s
+      @store.discogs_order_events.find_by(discogs_order_id: order_id)
+    end
+
+    def already_processed_recently?(event, order)
+      return false unless event&.processed_at.present?
+
+      current_activity = parse_timestamp(order["last_activity"])
+      event.processed_at >= current_activity - 1.minute
+    end
+
+    def remove_sold_listings(listing_ids)
+      SoldListingRemover.new(@store).call(listing_ids)
+    end
+
+    def persist_event(order, listing_ids, removal_result)
+      event = find_or_init_event(order)
+      assign_event_attributes(event, order, listing_ids, removal_result)
+      event.save!
+    end
+
+    def find_or_init_event(order)
+      order_id = order["id"].to_s
+      @store.discogs_order_events.find_or_initialize_by(discogs_order_id: order_id)
+    end
+
+    def assign_event_attributes(event, order, listing_ids, removal_result)
+      event.assign_attributes(
+        status: order["status"],
+        last_activity_at: parse_timestamp(order["last_activity"]),
+        listing_ids: listing_ids,
+        removed_listing_count: removal_result[:removed_count],
+        processed_at: Time.current
+      )
+    end
+
+    def advance_cursor(max_activity)
+      @store.update!(sales_poll_cursor_at: max_activity)
+    end
+
+    def mark_success
+      @store.update!(
+        last_sales_polled_at: Time.current,
+        last_sales_poll_error: nil,
+        last_sales_poll_error_at: nil
+      )
+    end
+
+    def mark_failure(error)
+      @store.update_columns(
+        last_sales_poll_error: summarize_error(error),
+        last_sales_poll_error_at: Time.current
+      )
+    end
+
+    def summarize_error(error)
+      summary = "#{error.class}: #{error.message}"
+      backtrace = Array(error.backtrace).first(8)
+      ([ summary ] + backtrace).join("\n")
+    end
+
+    def parse_timestamp(value)
+      return nil if value.blank?
+
+      Time.parse(value.to_s)
+    rescue ArgumentError
+      nil
+    end
+
+    def aggregate_results(results)
+      {
+        processed_count: results.size,
+        total_removed: results.sum { |r| r[:removed_count] },
+        max_activity: results.map { |r| r[:activity] }.compact.max
+      }
+    end
+
+    def with_error_handling
+      yield
+    rescue StandardError => e
+      mark_failure(e)
+      raise
+    end
+
+    def build_client
+      DiscogsClient.new(
+        access_token: @store.discogs_oauth_token,
+        access_token_secret: @store.discogs_oauth_token_secret
+      )
+    end
+
+    def empty_result
+      build_result(0, 0, false)
+    end
+
+    def build_result(order_count, removed_count, cursor_advanced)
+      {
+        order_count: order_count,
+        removed_count: removed_count,
+        cursor_advanced: cursor_advanced
+      }
+    end
+  end
+end

--- a/app/services/store_sales/order_poller.rb
+++ b/app/services/store_sales/order_poller.rb
@@ -141,10 +141,7 @@ module StoreSales
     end
 
     def build_client
-      DiscogsClient.new(
-        access_token: @store.discogs_oauth_token,
-        access_token_secret: @store.discogs_oauth_token_secret
-      )
+      @store.discogs_oauth_client
     end
 
     def empty_result

--- a/app/services/store_sales/order_poller.rb
+++ b/app/services/store_sales/order_poller.rb
@@ -5,8 +5,6 @@
 # from the store's store_owner.
 module StoreSales
   class OrderPoller
-    OVERLAP_WINDOW = 10.minutes
-
     def initialize(store)
       @store = store
     end
@@ -45,17 +43,23 @@ module StoreSales
     end
 
     def process_single_order(order)
-      return nil if already_processed_recently?(find_existing_event(order), order)
-
+      order_id = processing_order_id(order) or return nil
       listing_ids = OrderListingIds.call(order)
-      removal_result = remove_sold_listings(listing_ids)
-      persist_event(order, listing_ids, removal_result)
-
-      { activity: parse_timestamp(order["last_activity"]), removed_count: removal_result[:removed_count] }
+      result = SoldListingRemover.new(@store).call(listing_ids)
+      persist_event(order_id, order, listing_ids, result)
+      activity_result(order, result)
     end
 
-    def find_existing_event(order)
+    def processing_order_id(order)
       order_id = order["id"].to_s
+      already_processed_recently?(find_existing_event(order_id), order) ? nil : order_id
+    end
+
+    def activity_result(order, result)
+      { activity: parse_timestamp(order["last_activity"]), removed_count: result[:removed_count] }
+    end
+
+    def find_existing_event(order_id)
       @store.discogs_order_events.find_by(discogs_order_id: order_id)
     end
 
@@ -66,18 +70,13 @@ module StoreSales
       event.processed_at >= current_activity - 1.minute
     end
 
-    def remove_sold_listings(listing_ids)
-      SoldListingRemover.new(@store).call(listing_ids)
-    end
-
-    def persist_event(order, listing_ids, removal_result)
-      event = find_or_init_event(order)
+    def persist_event(order_id, order, listing_ids, removal_result)
+      event = find_or_init_event(order_id)
       assign_event_attributes(event, order, listing_ids, removal_result)
       event.save!
     end
 
-    def find_or_init_event(order)
-      order_id = order["id"].to_s
+    def find_or_init_event(order_id)
       @store.discogs_order_events.find_or_initialize_by(discogs_order_id: order_id)
     end
 

--- a/app/services/store_sales/order_poller.rb
+++ b/app/services/store_sales/order_poller.rb
@@ -67,6 +67,8 @@ module StoreSales
       return false unless event&.processed_at.present?
 
       current_activity = parse_timestamp(order["last_activity"])
+      return false unless current_activity
+
       event.processed_at >= current_activity - 1.minute
     end
 

--- a/app/services/store_sales/poll_state_tracker.rb
+++ b/app/services/store_sales/poll_state_tracker.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Manages store state transitions during a sales poll cycle:
+# recording success (clearing errors), recording failure (saving
+# error diagnostics), and advancing the high-water cursor timestamp.
+module StoreSales
+  class PollStateTracker
+    def initialize(store)
+      @store = store
+    end
+
+    def mark_success
+      @store.update!(
+        last_sales_polled_at: Time.current,
+        last_sales_poll_error: nil,
+        last_sales_poll_error_at: nil
+      )
+    end
+
+    def mark_failure(error)
+      summary = "#{error.class}: #{error.message}"
+      backtrace = Array(error.backtrace).first(8)
+      @store.update_columns(
+        last_sales_poll_error: ([ summary ] + backtrace).join("\n"),
+        last_sales_poll_error_at: Time.current
+      )
+    end
+
+    def advance_cursor(timestamp)
+      @store.update!(sales_poll_cursor_at: timestamp)
+    end
+  end
+end

--- a/app/services/store_sales/sold_listing_remover.rb
+++ b/app/services/store_sales/sold_listing_remover.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Removes sold listings from a store and updates inventory version.
+# Matches by discogs_listing_id, scoped to the store to prevent cross-store deletion.
+# Idempotent: calling multiple times with the same IDs has no additional effect.
+module StoreSales
+  class SoldListingRemover
+    def initialize(store)
+      @store = store
+    end
+
+    # Delete listings matching the given discogs_listing_ids.
+    # Returns a result hash with removed_count and removed_listing_ids.
+    def call(listing_ids)
+      ids_to_remove = Array.wrap(listing_ids).compact_blank.uniq
+      return empty_result if ids_to_remove.empty?
+
+      removed = find_and_delete_listings(ids_to_remove)
+      update_store_state if removed.any?
+
+      build_result(removed)
+    end
+
+    private
+
+    def find_and_delete_listings(ids)
+      matching = @store.listings.where(discogs_listing_id: ids)
+      removed = matching.pluck(:discogs_listing_id)
+      matching.delete_all
+      removed
+    end
+
+    def update_store_state
+      ActiveRecord::Base.transaction do
+        @store.increment_inventory_version!
+        @store.update!(total_listings: @store.listings.count)
+      end
+    end
+
+    def build_result(removed_ids)
+      {
+        removed_count: removed_ids.size,
+        removed_listing_ids: removed_ids
+      }
+    end
+
+    def empty_result
+      { removed_count: 0, removed_listing_ids: [] }
+    end
+  end
+end

--- a/app/services/store_sales/sold_listing_remover.rb
+++ b/app/services/store_sales/sold_listing_remover.rb
@@ -24,9 +24,10 @@ module StoreSales
     private
 
     def find_and_delete_listings(ids)
-      matching = @store.listings.where(discogs_listing_id: ids)
-      removed = matching.pluck(:discogs_listing_id)
-      matching.delete_all
+      removed = @store.listings.where(discogs_listing_id: ids).pluck(:discogs_listing_id)
+      return [] if removed.empty?
+
+      @store.listings.where(discogs_listing_id: removed).delete_all
       removed
     end
 

--- a/app/services/store_sync/inventory_updater.rb
+++ b/app/services/store_sync/inventory_updater.rb
@@ -17,11 +17,16 @@ module StoreSync
     end
 
     def remove_stale(listings)
-      current_ids = listings.map { |r| r[:discogs_listing_id] }
-      current_ids.empty? ? @store.listings.delete_all : @store.listings.where.not(discogs_listing_id: current_ids).delete_all
+      deleted_count = delete_stale_listings(listings)
+      @store.increment_inventory_version! if deleted_count.positive?
     end
 
     private
+
+    def delete_stale_listings(listings)
+      current_ids = listings.map { |r| r[:discogs_listing_id] }
+      current_ids.empty? ? @store.listings.delete_all : @store.listings.where.not(discogs_listing_id: current_ids).delete_all
+    end
 
     def persist_listings(records)
       existing = index_existing(records)

--- a/app/services/storefront_curation/cache_manager.rb
+++ b/app/services/storefront_curation/cache_manager.rb
@@ -2,7 +2,7 @@
 class StorefrontCuration::CacheManager
     CURATION_CACHE_TTL = 36.hours
     CURATION_CACHE_RACE_TTL = 30.seconds
-    CURATION_CACHE_KEY = "storefront/curation/v3/%<store_id>s/%<date>s/%<scope>s/%<wall_count>s"
+    CURATION_CACHE_KEY = "storefront/curation/v4/%<store_id>s/%<date>s/%<scope>s/%<wall_count>s/%<inventory_version>s"
 
     # Returns { sections: [...], crates: [...] } — plain hashes, cache-safe.
     # On cache miss, runs curation + presentation, writes to cache, returns payload.
@@ -35,7 +35,13 @@ class StorefrontCuration::CacheManager
     # filter_available: true while development storefronts use filter_available: false.
     def self.curation_cache_key(store, filter_available: true)
       scope = filter_available ? "available" : "all"
-      CURATION_CACHE_KEY % { store_id: store.id, date: Date.current.iso8601, scope:, wall_count: Settings.storefront.wall_count }
+      CURATION_CACHE_KEY % {
+        store_id: store.id,
+        date: Date.current.iso8601,
+        scope:,
+        wall_count: Settings.storefront.wall_count,
+        inventory_version: store.inventory_version
+      }
     end
 
     def self.dev_scorer(curation)

--- a/app/services/sync_strategies/csv_export.rb
+++ b/app/services/sync_strategies/csv_export.rb
@@ -25,12 +25,7 @@ module SyncStrategies
     end
 
     def build_client(store)
-      return @client if @client
-      owner = store.store_owner
-      DiscogsClient.new(
-        access_token: owner.discogs_oauth_token,
-        access_token_secret: owner.discogs_oauth_token_secret
-      )
+      @client ||= store.discogs_oauth_client
     end
   end
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -23,3 +23,8 @@ production:
     class: DailyCurationJob
     queue: default
     schedule: every day at 1am
+
+  sales_poll_dispatcher:
+    class: SalesPollDispatcherJob
+    queue: default
+    schedule: every minute

--- a/db/migrate/20260604000000_add_sales_polling_to_stores.rb
+++ b/db/migrate/20260604000000_add_sales_polling_to_stores.rb
@@ -1,0 +1,9 @@
+class AddSalesPollingToStores < ActiveRecord::Migration[8.0]
+  def change
+    add_column :stores, :sales_poll_cursor_at, :datetime
+    add_column :stores, :last_sales_polled_at, :datetime
+    add_column :stores, :last_sales_poll_error, :text
+    add_column :stores, :last_sales_poll_error_at, :datetime
+    add_column :stores, :inventory_version, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20260604000001_create_discogs_order_events.rb
+++ b/db/migrate/20260604000001_create_discogs_order_events.rb
@@ -1,0 +1,18 @@
+class CreateDiscogsOrderEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :discogs_order_events do |t|
+      t.references :store, null: false, foreign_key: true, index: false
+      t.string :discogs_order_id, null: false
+      t.string :status
+      t.datetime :last_activity_at
+      t.string :listing_ids, array: true, default: [], null: false
+      t.integer :removed_listing_count, default: 0, null: false
+      t.datetime :processed_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :discogs_order_events, [ :store_id, :discogs_order_id ], unique: true
+    add_index :discogs_order_events, [ :store_id, :last_activity_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_04_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -32,6 +32,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_000002) do
     t.string "password_digest", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
+  end
+
+  create_table "discogs_order_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "discogs_order_id", null: false
+    t.datetime "last_activity_at"
+    t.string "listing_ids", default: [], null: false, array: true
+    t.datetime "processed_at", null: false
+    t.integer "removed_listing_count", default: 0, null: false
+    t.string "status"
+    t.bigint "store_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["store_id", "discogs_order_id"], name: "index_discogs_order_events_on_store_id_and_discogs_order_id", unique: true
+    t.index ["store_id", "last_activity_at"], name: "index_discogs_order_events_on_store_id_and_last_activity_at"
   end
 
   create_table "discogs_shoppers", force: :cascade do |t|
@@ -255,11 +269,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_000002) do
     t.integer "enrichment_progress_pct"
     t.string "enrichment_status", default: "idle", null: false
     t.integer "inventory_page_count", default: 0, null: false
+    t.integer "inventory_version", default: 0, null: false
     t.datetime "last_enriched_at"
+    t.text "last_sales_poll_error"
+    t.datetime "last_sales_poll_error_at"
+    t.datetime "last_sales_polled_at"
     t.text "last_sync_error"
     t.datetime "last_sync_error_at"
     t.datetime "last_synced_at"
     t.string "name"
+    t.boolean "research_partner", default: false, null: false
+    t.datetime "sales_poll_cursor_at"
     t.bigint "store_owner_id"
     t.integer "sync_progress_pct"
     t.string "sync_source", default: "public_api", null: false
@@ -283,6 +303,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_000002) do
   end
 
   add_foreign_key "admin_totps", "admins"
+  add_foreign_key "discogs_order_events", "stores"
   add_foreign_key "listings", "stores"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/docs/plans/2026-06-04-001-feat-oauth-sales-polling-plan.md
+++ b/docs/plans/2026-06-04-001-feat-oauth-sales-polling-plan.md
@@ -1,0 +1,424 @@
+---
+title: "feat: Poll OAuth Discogs Sales to Keep Storefront Inventory Fresh"
+type: feat
+status: active
+date: 2026-06-04
+---
+
+# feat: Poll OAuth Discogs Sales to Keep Storefront Inventory Fresh
+
+## Summary
+
+Add an OAuth-only sales polling path that checks recent Discogs orders for authorized stores, removes sold listing IDs from Milkcrate inventory, and invalidates storefront curation cache immediately. The goal is buyer trust: if a record sold on Discogs, Milkcrate should stop showing it quickly instead of waiting for the nightly full sync.
+
+The plan intentionally avoids full recuration every minute. Removing sold records plus changing the cache key is enough for correctness; curation can rebuild lazily on next storefront request and optionally prewarm after removals.
+
+---
+
+## Problem Frame
+
+Milkcrate promises premium/OAuth stores that their storefront will not drift far from real Discogs inventory. Current sync mechanisms are too coarse for sold-item correctness:
+
+- OAuth CSV export sync is complete, but scheduled nightly.
+- Public API sync cannot reliably detect sold items for large stores and may be partial.
+- Storefront curation cache currently lives for 36 hours and its key does not include inventory mutation state.
+
+If a buyer sees a sold record on Milkcrate, clicks through, and cannot buy it, the store takes the reputational hit. OAuth unlocks the Discogs marketplace order surface, so Milkcrate can react to sales as operational events rather than waiting for full inventory reconciliation.
+
+---
+
+## Requirements
+
+- R1. OAuth-authorized stores are polled for recent Discogs marketplace orders on a minute-level schedule when due.
+- R2. Polling uses seller-level OAuth credentials already stored on `StoreOwner`.
+- R3. Sold listing IDs found in order payloads are removed from local `listings`.
+- R4. Removal is idempotent. Reprocessing the same order does not double-count or error.
+- R5. Storefront curation cache changes immediately after listings are removed, so cached payloads cannot continue exposing sold records.
+- R6. The polling system respects Discogs API rate limits and does not create one external request per store per minute when fleet size grows.
+- R7. Poll state and errors are tracked separately from full inventory sync state.
+- R8. No buyer PII is persisted. Store only order IDs, status/activity timestamps, listing IDs, and operational counts.
+- R9. Full sync remains source of truth for relists, cancellations, and inventory corrections.
+- R10. Existing nightly `FullStoreSyncJob` and daily `DailyCurationJob` behavior remains intact.
+
+---
+
+## Scope Boundaries
+
+In scope:
+
+- OAuth store sales polling through Discogs marketplace orders.
+- Removing sold listing IDs from Milkcrate local inventory.
+- Cache invalidation/versioning for storefront curation.
+- Polling observability on store records and order-event records.
+- Tests for polling, removal, cache invalidation, and scheduler fan-out.
+
+Out of scope:
+
+- Non-OAuth premium inventory guarantees. Public inventory cannot observe seller orders; create a follow-up issue for the best non-OAuth promise, likely more frequent public sync plus stricter availability copy.
+- Pushing changes back to Discogs.
+- Buyer-facing order data, buyer identity, addresses, payment state, or order management UI.
+- Automatic restoration when an order is cancelled. Nightly/full sync can re-add records if Discogs marks them available again.
+- Recurating the whole storefront synchronously inside every poll job.
+
+---
+
+## Context & Research
+
+### Existing Code
+
+- `app/services/discogs/marketplace.rb` already owns OAuth marketplace endpoints and has `list_orders(status: nil, page: 1)`.
+- `app/services/discogs_client.rb` delegates OAuth-only methods to `Discogs::Marketplace`.
+- `app/models/store.rb` delegates OAuth token fields through `store_owner` and selects `SyncStrategies::CsvExport` when authorized.
+- `app/jobs/full_store_sync_job.rb` performs complete inventory sync and enqueues enrichment/curation.
+- `app/jobs/sync_all_stores_job.rb` already fans out recurring full sync work with staggered delays.
+- `app/services/storefront_curation/cache_manager.rb` caches fully serialized curation payloads for 36 hours with key `storefront/curation/v3/<store>/<date>/<scope>/<wall_count>`.
+- `app/presenters/crate_presenter.rb` serializes `discogs_listing_id` and Discogs listing URLs, so stale cache is a correctness problem.
+
+### Existing Learnings
+
+- `docs/solutions/integration-issues/discogs-oauth-csv-export-2026-05-22.md` documents that seller-level OAuth is required for marketplace orders and that List Orders is intended for sold-listing detection.
+- `docs/solutions/integration-issues/discogs-rate-limit-middleware-2026-05-19.md` documents why all Discogs consumers must share rate-limit discipline and concurrency constraints.
+
+### External References
+
+- Discogs inventory management docs list statuses including Sold and describe deletion/relist behavior: `https://support.discogs.com/hc/en-us/articles/360007714754-How-Can-I-Manage-My-Inventory`
+- Discogs API terms say API content becomes quickly outdated and public display cannot rely on content older than six hours: `https://support.discogs.com/hc/en-us/articles/360009334593-API-Terms-of-Use`
+- Discogs developer docs mirror for `GET /marketplace/orders` shows status, sort, sort_order, pagination, and OAuth requirement: `https://www.postman.com/cdrecordsale/my-workspace/documentation/dy6eozk/discogs?entity=request-32055786-c9d92a01-2f24-4991-b590-6177ec863f4c`
+- Solid Queue supports recurring YAML tasks and `limits_concurrency`; this project already uses both.
+
+---
+
+## Key Technical Decisions
+
+- **Use List Orders, not "recent sales" naming.** The app already models Discogs marketplace order access as `list_orders`. If Discogs has no separate recent-sales endpoint, this feature should poll recent orders sorted by `last_activity desc`.
+- **Remove first, reconcile later.** When an order references listing IDs, delete matching `Listing` rows immediately. This is conservative for shoppers. Full sync remains the recovery path if a seller relists or an order state later makes inventory available.
+- **Version cache, don't chase cache keys.** Add an inventory/cache version to stores and include it in the curation cache key. Increment it inside the same transaction as listing removal.
+- **Separate poll health from full sync health.** Sales poll failures should not mark `sync_status: failed`; dashboard/admin can show them separately later.
+- **Dispatcher owns scale control.** A recurring job fires every minute, selects due OAuth stores, and enqueues within a request budget. It does not blindly enqueue every OAuth store every minute forever.
+- **Persist only operational order facts.** No buyer data. Persist enough to dedupe order processing and audit removals.
+- **Keep layers clean.** Jobs orchestrate. `StoreSales::*` services implement application workflow. Models stay mostly persistence/associations. Discogs client stays infrastructure.
+
+---
+
+## Data Model
+
+### Store Poll State
+
+Add fields to `stores`:
+
+- `sales_poll_cursor_at: datetime`
+- `last_sales_polled_at: datetime`
+- `last_sales_poll_error: text`
+- `last_sales_poll_error_at: datetime`
+- `inventory_version: integer, default: 0, null: false`
+
+Rationale:
+
+- `sales_poll_cursor_at` is the high-water mark from Discogs order `last_activity` or `created` timestamps.
+- `last_sales_polled_at` tracks worker health even when no orders changed.
+- Error fields keep sale polling independent from full sync status.
+- `inventory_version` gives cache invalidation without needing to delete unknown cache keys.
+
+### Discogs Order Events
+
+Create `discogs_order_events`:
+
+- `store_id: bigint, null: false`
+- `discogs_order_id: string, null: false`
+- `status: string`
+- `last_activity_at: datetime`
+- `listing_ids: string[], default: [], null: false`
+- `removed_listing_count: integer, default: 0, null: false`
+- `processed_at: datetime, null: false`
+- timestamps
+
+Indexes:
+
+- unique `[:store_id, :discogs_order_id]`
+- index `[:store_id, :last_activity_at]`
+
+Rationale:
+
+- Idempotency and audit trail.
+- No buyer PII.
+- Reprocessing can update status/listing IDs if order activity changes.
+
+---
+
+## Implementation Units
+
+### U1. Extend OAuth marketplace order client
+
+**Goal:** Make the existing OAuth marketplace client suitable for polling recent orders.
+
+**Requirements:** R1, R2, R6
+
+**Files:**
+
+- Modify: `app/services/discogs/marketplace.rb`
+- Modify: `app/services/discogs_client.rb`
+- Test: `spec/services/discogs/marketplace_spec.rb`
+- Test: `spec/services/discogs_client_spec.rb`
+
+**Approach:**
+
+- Extend `list_orders` keyword args: `status: nil`, `page: 1`, `per_page: 50`, `sort: "last_activity"`, `sort_order: "desc"`.
+- Build query via `URI.encode_www_form` or equivalent structured API, not manual string concatenation.
+- Keep response parsing and existing error behavior.
+- Add 429/backoff handling for OAuth marketplace calls or extract shared rate-limit behavior that can wrap `OAuth::AccessToken` requests. Current Faraday middleware does not protect this path.
+- Add `get_order(order_id)` only if `list_orders` payload lacks item/listing detail during live verification.
+
+**Test scenarios:**
+
+- `list_orders` includes `page`, `per_page`, `sort`, `sort_order`, and optional `status`.
+- `list_orders` URL-encodes Discogs status values with spaces.
+- 429 response raises/retries according to chosen OAuth rate-limit behavior.
+- Non-2xx response raises `Discogs::Errors::ApiError`.
+- `DiscogsClient#list_orders` still requires OAuth credentials.
+
+---
+
+### U2. Add sales polling persistence
+
+**Goal:** Store poll cursor, inventory version, and idempotent order event records.
+
+**Requirements:** R4, R5, R7, R8
+
+**Files:**
+
+- Create: `db/migrate/20260604000000_add_sales_polling_to_stores.rb`
+- Create: `db/migrate/20260604000001_create_discogs_order_events.rb`
+- Create: `app/models/discogs_order_event.rb`
+- Modify: `app/models/store.rb`
+- Test: `spec/models/discogs_order_event_spec.rb`
+- Test: `spec/models/store_spec.rb`
+
+**Approach:**
+
+- Add store poll/error/version fields.
+- Create `DiscogsOrderEvent` model with `belongs_to :store`.
+- Validate `discogs_order_id` presence and uniqueness scoped to store.
+- Add a small store method only if needed for version bump, e.g. `increment_inventory_version!`.
+
+**Test scenarios:**
+
+- Order event requires store and Discogs order ID.
+- Duplicate order ID for same store is rejected.
+- Same order ID for different stores is allowed.
+- New stores default `inventory_version` to 0.
+
+---
+
+### U3. Build order parsing and sold-listing removal services
+
+**Goal:** Extract listing IDs from order payloads and remove matching local listings idempotently.
+
+**Requirements:** R3, R4, R5, R8, R9
+
+**Files:**
+
+- Create: `app/services/store_sales/order_listing_ids.rb`
+- Create: `app/services/store_sales/sold_listing_remover.rb`
+- Test: `spec/services/store_sales/order_listing_ids_spec.rb`
+- Test: `spec/services/store_sales/sold_listing_remover_spec.rb`
+
+**Approach:**
+
+- `OrderListingIds.call(order_hash)` returns normalized string listing IDs from known Discogs order item shapes.
+- Start with defensive extraction from likely keys: `items`, `listing_id`, `id`, nested listing hashes. Keep parser explicit and tested.
+- `SoldListingRemover.new(store).call(listing_ids)` deletes matching store listings in a transaction.
+- If delete count is positive, update `stores.total_listings` and increment `inventory_version`.
+- Return result object with `removed_count` and `removed_listing_ids`.
+
+**Test scenarios:**
+
+- Extracts single listing ID from common item payload shape.
+- Extracts multiple listing IDs from multi-item order.
+- Ignores blank/nil IDs.
+- Removes only listings belonging to the target store.
+- Unknown IDs are no-op.
+- Deleting one or more listings increments `inventory_version`.
+- No matching listing does not increment `inventory_version`.
+- `total_listings` is updated after removal.
+
+---
+
+### U4. Build store sales order poller
+
+**Goal:** Poll one store's recent orders, dedupe events, remove sold listings, and advance cursor.
+
+**Requirements:** R1, R2, R3, R4, R7, R8, R9
+
+**Files:**
+
+- Create: `app/services/store_sales/order_poller.rb`
+- Test: `spec/services/store_sales/order_poller_spec.rb`
+
+**Approach:**
+
+- Build OAuth `DiscogsClient` from `store.store_owner`.
+- Request orders sorted by `last_activity desc`.
+- Use a safety overlap window, e.g. start from `sales_poll_cursor_at - 10.minutes`, because remote timestamps and retries can drift.
+- Process newest-to-oldest or oldest-to-newest consistently; advance cursor to max seen activity only after successful processing.
+- Upsert `DiscogsOrderEvent` by `store_id` and `discogs_order_id`.
+- For each order, extract listing IDs and call `SoldListingRemover`.
+- Mark `last_sales_polled_at` on success.
+- On error, set `last_sales_poll_error` and `last_sales_poll_error_at`, then re-raise for job retry/visibility.
+
+**Test scenarios:**
+
+- OAuth store polls Discogs and removes sold listing IDs.
+- Store without OAuth raises a clear not-authorized error.
+- Existing processed order does not remove twice.
+- Same order with later `last_activity_at` can update event status without double-counting already-deleted listings.
+- Cursor advances to max processed `last_activity_at`.
+- Cursor does not advance when client raises.
+- Error fields are set on failure.
+- Empty order list still updates `last_sales_polled_at`.
+
+---
+
+### U5. Add polling jobs and recurring schedule
+
+**Goal:** Run polling continuously without one unbounded external call per store per minute.
+
+**Requirements:** R1, R6, R7, R10
+
+**Files:**
+
+- Create: `app/jobs/sales_poll_dispatcher_job.rb`
+- Create: `app/jobs/sales_poll_store_job.rb`
+- Modify: `config/recurring.yml`
+- Test: `spec/jobs/sales_poll_dispatcher_job_spec.rb`
+- Test: `spec/jobs/sales_poll_store_job_spec.rb`
+
+**Approach:**
+
+- Add recurring task:
+
+  ```yaml
+  production:
+    sales_poll_dispatcher:
+      class: SalesPollDispatcherJob
+      queue: default
+      schedule: every minute
+  ```
+
+- `SalesPollDispatcherJob` selects OAuth-authorized stores where `last_sales_polled_at` is nil or older than the target interval.
+- Add a conservative per-minute budget, e.g. `MAX_STORES_PER_RUN = 20`, tune later from live rate headers and fleet size.
+- Stagger enqueued `SalesPollStoreJob` jobs by a few seconds if more than one store is due.
+- `SalesPollStoreJob` runs `StoreSales::OrderPoller`.
+- Use `limits_concurrency`:
+  - per-store key to avoid duplicate poll for same store
+  - global Discogs API key if OAuth marketplace requests share app/user quota enough to require serialization
+
+**Test scenarios:**
+
+- Dispatcher enqueues due OAuth stores only.
+- Dispatcher skips non-OAuth stores.
+- Dispatcher respects max stores per run.
+- Dispatcher staggers jobs when multiple stores due.
+- Store job calls `StoreSales::OrderPoller`.
+- Store job handles deleted store gracefully or lets `RecordNotFound` fail according to existing job convention.
+- Concurrency key lambdas accept job arguments.
+
+---
+
+### U6. Version storefront curation cache by inventory mutation
+
+**Goal:** Ensure sold listings cannot survive in cached storefront payloads.
+
+**Requirements:** R5
+
+**Files:**
+
+- Modify: `app/services/storefront_curation/cache_manager.rb`
+- Modify: `spec/services/storefront_curation/cache_manager_spec.rb`
+- Add coverage in: `spec/services/store_sales/sold_listing_remover_spec.rb`
+
+**Approach:**
+
+- Add `inventory_version` to `CURATION_CACHE_KEY`, e.g. `storefront/curation/v4/%<store_id>s/%<date>s/%<scope>s/%<wall_count>s/%<inventory_version>s`.
+- Use `store.inventory_version` in `curation_cache_key`.
+- Bump version only on inventory mutations that affect storefront availability:
+  - sold-listing removal
+  - full sync stale removal
+  - future manual inventory changes
+- For this feature, at minimum bump inside `SoldListingRemover`. Consider adding a bump in `StoreSync::InventoryUpdater#remove_stale` in same PR if tests show stale full-sync cache can survive too.
+
+**Test scenarios:**
+
+- Cache key includes inventory version.
+- Same store/date/scope with different version produces different keys.
+- Removing sold listing changes cache key and cached payload is not reused.
+- Cache still separates `available` and `all` scopes.
+
+---
+
+### U7. Optional curation prewarm after removals
+
+**Goal:** Keep first shopper request after a sale from doing all curation work when a poll removes listings.
+
+**Requirements:** R5, R10
+
+**Files:**
+
+- Modify: `app/jobs/sales_poll_store_job.rb` or `app/services/store_sales/order_poller.rb`
+- Test: `spec/jobs/sales_poll_store_job_spec.rb` or `spec/services/store_sales/order_poller_spec.rb`
+
+**Approach:**
+
+- If poller removed one or more listings, enqueue `DailyCurationJob.perform_later(store.id)`.
+- Do not enqueue when no listings changed.
+- If this creates too much churn for active stores, debounce later with a store field like `last_curation_queued_at`.
+
+**Test scenarios:**
+
+- Removal enqueues one curation job.
+- No removal enqueues none.
+- Multiple orders in same poll enqueue at most one curation job.
+
+---
+
+## End-to-End Flow
+
+1. Solid Queue recurring scheduler runs `SalesPollDispatcherJob` every minute.
+2. Dispatcher finds due OAuth stores within budget and enqueues `SalesPollStoreJob`.
+3. Store job calls `StoreSales::OrderPoller`.
+4. Poller calls `DiscogsClient#list_orders(sort: "last_activity", sort_order: "desc")`.
+5. Poller upserts `DiscogsOrderEvent` records and extracts listing IDs.
+6. `SoldListingRemover` deletes matching `Listing` rows and increments `Store#inventory_version`.
+7. Storefront cache key changes, so next storefront request rebuilds from remaining available listings.
+8. Optional `DailyCurationJob` prewarms new payload after removal.
+9. Nightly `FullStoreSyncJob` remains authoritative and can re-add relisted records.
+
+---
+
+## Risks & Mitigations
+
+- **Discogs order payload shape may not include listing IDs.** Add `get_order(order_id)` fallback if live payload lacks item details. Keep U1 tests fixture-driven after first live sample.
+- **OAuth marketplace requests bypass Faraday middleware.** Add explicit OAuth request retry/backoff before enabling minute polling.
+- **Fleet growth can exceed rate budget.** Dispatcher budget plus per-store due intervals prevents unbounded requests. Add adaptive interval later if stores exceed budget.
+- **Cancelled orders could remove records that become available again.** This is acceptable for shopper trust; full sync restores relisted inventory.
+- **Cache invalidation misses full sync stale deletion.** Add inventory version bump to `StoreSync::InventoryUpdater#remove_stale` if not already covered while implementing U6.
+- **Order polling stores restricted marketplace data.** Persist only operational identifiers and timestamps, no buyer data.
+
+---
+
+## Verification Commands
+
+- `bundle exec rspec spec/services/discogs/marketplace_spec.rb`
+- `bundle exec rspec spec/services/store_sales`
+- `bundle exec rspec spec/jobs/sales_poll_dispatcher_job_spec.rb spec/jobs/sales_poll_store_job_spec.rb`
+- `bundle exec rspec spec/services/storefront_curation/cache_manager_spec.rb`
+- `bundle exec rspec spec/jobs/full_store_sync_job_spec.rb`
+- `bundle exec rubocop`
+
+---
+
+## Open Questions
+
+- Does Discogs `list_orders` include listing IDs directly for seller OAuth responses, or must Milkcrate call `GET /marketplace/orders/{id}` per new/changed order?
+- Which statuses should trigger removal if an order has item IDs but later becomes cancelled? Proposed default: any seen order item removes immediately; full sync restores if relisted.
+- What initial interval should paid stores get once fleet size grows? Proposed default: every minute while under budget, then adaptive due interval by store tier.
+- Should dashboard/admin surface sales poll health in this same feature or a follow-up issue?

--- a/docs/plans/2026-06-04-001-feat-oauth-sales-polling-plan.md
+++ b/docs/plans/2026-06-04-001-feat-oauth-sales-polling-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Poll OAuth Discogs Sales to Keep Storefront Inventory Fresh"
 type: feat
-status: active
+status: completed
 date: 2026-06-04
 ---
 

--- a/spec/factories/discogs_order_events.rb
+++ b/spec/factories/discogs_order_events.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :discogs_order_event do
+    association :store
+    sequence(:discogs_order_id) { |n| "order-#{n}" }
+    status { "paid" }
+    last_activity_at { 1.hour.ago }
+    listing_ids { [ "listing-1", "listing-2" ] }
+    removed_listing_count { 0 }
+    processed_at { Time.current }
+  end
+end

--- a/spec/jobs/sales_poll_dispatcher_job_spec.rb
+++ b/spec/jobs/sales_poll_dispatcher_job_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe SalesPollDispatcherJob do
+  include ActiveJob::TestHelper
+
+  before { clear_enqueued_jobs }
+
+  describe "#perform" do
+    context "with OAuth-authorized stores due for polling" do
+      let!(:store) { create(:store, :oauth_authorized, last_sales_polled_at: 2.minutes.ago) }
+
+      it "enqueues SalesPollStoreJob for each due store" do
+        expect {
+          described_class.new.perform
+        }.to have_enqueued_job(SalesPollStoreJob).with(store.id).exactly(:once)
+      end
+
+      it "enqueues jobs for multiple due stores" do
+        store2 = create(:store, :oauth_authorized, last_sales_polled_at: 3.minutes.ago)
+
+        expect {
+          described_class.new.perform
+        }.to have_enqueued_job(SalesPollStoreJob).exactly(:twice)
+      end
+    end
+
+    context "with stores that have never been polled" do
+      let!(:store) { create(:store, :oauth_authorized, last_sales_polled_at: nil) }
+
+      it "enqueues SalesPollStoreJob" do
+        expect {
+          described_class.new.perform
+        }.to have_enqueued_job(SalesPollStoreJob).with(store.id).exactly(:once)
+      end
+    end
+
+    context "with non-OAuth stores" do
+      let!(:store) { create(:store, store_owner: nil) }
+
+      it "does not enqueue SalesPollStoreJob" do
+        expect {
+          described_class.new.perform
+        }.not_to have_enqueued_job(SalesPollStoreJob)
+      end
+    end
+
+    context "with OAuth stores not due for polling" do
+      let!(:store) { create(:store, :oauth_authorized, last_sales_polled_at: 30.seconds.ago) }
+
+      it "does not enqueue SalesPollStoreJob" do
+        expect {
+          described_class.new.perform
+        }.not_to have_enqueued_job(SalesPollStoreJob)
+      end
+    end
+
+    context "with more stores than MAX_STORES_PER_RUN" do
+      before do
+        create_list(:store, 25, :oauth_authorized, last_sales_polled_at: 2.minutes.ago)
+      end
+
+      it "enqueues only MAX_STORES_PER_RUN jobs" do
+        expect {
+          described_class.new.perform
+        }.to have_enqueued_job(SalesPollStoreJob).exactly(described_class::MAX_STORES_PER_RUN).times
+      end
+    end
+
+    context "with multiple due stores" do
+      let!(:store1) { create(:store, :oauth_authorized, last_sales_polled_at: 2.minutes.ago) }
+      let!(:store2) { create(:store, :oauth_authorized, last_sales_polled_at: 3.minutes.ago) }
+
+      it "staggers jobs with STAGGER_INTERVAL" do
+        described_class.new.perform
+
+        jobs = enqueued_jobs.select { |j| j["job_class"] == "SalesPollStoreJob" }
+        scheduled_times = jobs.map { |j| Time.parse(j["scheduled_at"]) }
+
+        expect(scheduled_times[1] - scheduled_times[0]).to be_within(0.1).of(described_class::STAGGER_INTERVAL)
+      end
+    end
+
+    context "with no due stores" do
+      it "does not enqueue any jobs" do
+        expect {
+          described_class.new.perform
+        }.not_to have_enqueued_job(SalesPollStoreJob)
+      end
+    end
+  end
+end

--- a/spec/jobs/sales_poll_store_job_spec.rb
+++ b/spec/jobs/sales_poll_store_job_spec.rb
@@ -17,6 +17,48 @@ RSpec.describe SalesPollStoreJob do
       expect(poller).to have_received(:call)
     end
 
+    context "when poller removes listings" do
+      before do
+        allow(poller).to receive(:call).and_return(
+          { order_count: 1, removed_count: 1, cursor_advanced: true }
+        )
+      end
+
+      it "enqueues DailyCurationJob" do
+        expect {
+          described_class.new.perform(store.id)
+        }.to have_enqueued_job(DailyCurationJob).with(store.id)
+      end
+    end
+
+    context "when poller removes no listings" do
+      before do
+        allow(poller).to receive(:call).and_return(
+          { order_count: 1, removed_count: 0, cursor_advanced: false }
+        )
+      end
+
+      it "does not enqueue DailyCurationJob" do
+        expect {
+          described_class.new.perform(store.id)
+        }.not_to have_enqueued_job(DailyCurationJob)
+      end
+    end
+
+    context "when poller removes multiple listings" do
+      before do
+        allow(poller).to receive(:call).and_return(
+          { order_count: 2, removed_count: 3, cursor_advanced: true }
+        )
+      end
+
+      it "enqueues exactly one DailyCurationJob" do
+        expect {
+          described_class.new.perform(store.id)
+        }.to have_enqueued_job(DailyCurationJob).exactly(:once)
+      end
+    end
+
     context "when store is not found" do
       it "logs a warning and does not raise" do
         expect(Rails.logger).to receive(:warn).with(/store 999999 not found/)

--- a/spec/jobs/sales_poll_store_job_spec.rb
+++ b/spec/jobs/sales_poll_store_job_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe SalesPollStoreJob do
+  describe "#perform" do
+    let(:store) { create(:store, :oauth_authorized) }
+    let(:poller) { instance_double(StoreSales::OrderPoller) }
+
+    before do
+      allow(StoreSales::OrderPoller).to receive(:new).with(store).and_return(poller)
+      allow(poller).to receive(:call)
+    end
+
+    it "calls StoreSales::OrderPoller for the store" do
+      described_class.new.perform(store.id)
+
+      expect(StoreSales::OrderPoller).to have_received(:new).with(store)
+      expect(poller).to have_received(:call)
+    end
+
+    context "when store is not found" do
+      it "logs a warning and does not raise" do
+        expect(Rails.logger).to receive(:warn).with(/store 999999 not found/)
+
+        expect {
+          described_class.new.perform(999_999)
+        }.not_to raise_error
+      end
+    end
+
+    context "when poller raises an error" do
+      before do
+        allow(poller).to receive(:call).and_raise(StandardError, "API error")
+      end
+
+      it "propagates the error" do
+        expect {
+          described_class.new.perform(store.id)
+        }.to raise_error(StandardError, "API error")
+      end
+    end
+  end
+
+  describe "concurrency key" do
+    it "accepts store_id as argument" do
+      key_lambda = described_class.concurrency_key
+      expect { key_lambda.call(123) }.not_to raise_error
+    end
+
+    it "generates unique keys per store" do
+      key_lambda = described_class.concurrency_key
+      expect(key_lambda.call(1)).to eq("sales_poll_1")
+      expect(key_lambda.call(2)).to eq("sales_poll_2")
+    end
+  end
+end

--- a/spec/models/discogs_order_event_spec.rb
+++ b/spec/models/discogs_order_event_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe DiscogsOrderEvent, type: :model do
+  describe "validations" do
+    it "is valid with valid attributes" do
+      event = build(:discogs_order_event)
+      expect(event).to be_valid
+    end
+
+    it "requires a store" do
+      event = build(:discogs_order_event, store: nil)
+      expect(event).not_to be_valid
+      expect(event.errors[:store]).to include("must exist")
+    end
+
+    it "requires a discogs_order_id" do
+      event = build(:discogs_order_event, discogs_order_id: nil)
+      expect(event).not_to be_valid
+      expect(event.errors[:discogs_order_id]).to include("can't be blank")
+    end
+
+    it "requires processed_at" do
+      event = build(:discogs_order_event, processed_at: nil)
+      expect(event).not_to be_valid
+      expect(event.errors[:processed_at]).to include("can't be blank")
+    end
+
+    it "rejects duplicate discogs_order_id for the same store" do
+      store = create(:store)
+      create(:discogs_order_event, store: store, discogs_order_id: "order-123")
+
+      duplicate = build(:discogs_order_event, store: store, discogs_order_id: "order-123")
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:discogs_order_id]).to include("has already been taken")
+    end
+
+    it "allows the same discogs_order_id for different stores" do
+      store1 = create(:store)
+      store2 = create(:store)
+      create(:discogs_order_event, store: store1, discogs_order_id: "order-456")
+
+      event2 = build(:discogs_order_event, store: store2, discogs_order_id: "order-456")
+      expect(event2).to be_valid
+    end
+  end
+
+  describe "associations" do
+    it "belongs to a store" do
+      event = create(:discogs_order_event)
+      expect(event.store).to be_a(Store)
+    end
+  end
+
+  describe "defaults" do
+    it "defaults listing_ids to an empty array" do
+      event = create(:discogs_order_event, listing_ids: [])
+      expect(event.listing_ids).to eq([])
+    end
+
+    it "defaults removed_listing_count to 0" do
+      event = create(:discogs_order_event, removed_listing_count: 0)
+      expect(event.removed_listing_count).to eq(0)
+    end
+  end
+end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -195,4 +195,55 @@ RSpec.describe Store, type: :model do
       expect(strategy).to respond_to(:call).with(1).argument
     end
   end
+
+  describe "sales polling fields" do
+    it "defaults inventory_version to 0" do
+      store = create(:store)
+      expect(store.inventory_version).to eq(0)
+    end
+
+    it "defaults sales_poll_cursor_at to nil" do
+      store = create(:store)
+      expect(store.sales_poll_cursor_at).to be_nil
+    end
+
+    it "defaults last_sales_polled_at to nil" do
+      store = create(:store)
+      expect(store.last_sales_polled_at).to be_nil
+    end
+  end
+
+  describe "#increment_inventory_version!" do
+    it "increments inventory_version by 1" do
+      store = create(:store, inventory_version: 3)
+      store.increment_inventory_version!
+      expect(store.inventory_version).to eq(4)
+    end
+
+    it "increments from default 0 to 1" do
+      store = create(:store)
+      store.increment_inventory_version!
+      expect(store.inventory_version).to eq(1)
+    end
+
+    it "increments atomically using update_counters" do
+      store = create(:store, inventory_version: 5)
+      store.increment_inventory_version!
+      expect(store.reload.inventory_version).to eq(6)
+    end
+  end
+
+  describe "associations" do
+    it "has many discogs_order_events" do
+      store = create(:store)
+      event = create(:discogs_order_event, store: store)
+      expect(store.discogs_order_events).to include(event)
+    end
+
+    it "destroys associated discogs_order_events when destroyed" do
+      store = create(:store)
+      create(:discogs_order_event, store: store)
+      expect { store.destroy }.to change(DiscogsOrderEvent, :count).by(-1)
+    end
+  end
 end

--- a/spec/services/discogs/marketplace_spec.rb
+++ b/spec/services/discogs/marketplace_spec.rb
@@ -92,7 +92,84 @@ RSpec.describe Discogs::Marketplace do
   end
 
   describe "#list_orders" do
-    it "returns parsed orders" do
+    let(:default_params) do
+      { "page" => "1", "per_page" => "50", "sort" => "last_activity", "sort_order" => "desc" }
+    end
+
+    it "includes page, per_page, sort, and sort_order in the request" do
+      response = oauth_response(code: 200, body: '{"orders":[]}')
+      allow(oauth_access_token).to receive(:get).and_return(response)
+
+      client.list_orders
+
+      expect(oauth_access_token).to have_received(:get).with(
+        a_string_matching(/page=1.*per_page=50.*sort=last_activity.*sort_order=desc/)
+      )
+    end
+
+    it "includes status when provided" do
+      response = oauth_response(code: 200, body: '{"orders":[]}')
+      allow(oauth_access_token).to receive(:get).and_return(response)
+
+      client.list_orders(status: "New Order")
+
+      expect(oauth_access_token).to have_received(:get).with(
+        a_string_including("status=New+Order")
+      )
+    end
+
+    it "URL-encodes status values with spaces" do
+      response = oauth_response(code: 200, body: '{"orders":[]}')
+      allow(oauth_access_token).to receive(:get).and_return(response)
+
+      client.list_orders(status: "New Order")
+
+      expect(oauth_access_token).to have_received(:get).with(
+        a_string_including("status=New+Order")
+      )
+    end
+
+    it "accepts custom page, per_page, sort, and sort_order" do
+      response = oauth_response(code: 200, body: '{"orders":[]}')
+      allow(oauth_access_token).to receive(:get).and_return(response)
+
+      client.list_orders(page: 2, per_page: 100, sort: "created", sort_order: "asc")
+
+      expect(oauth_access_token).to have_received(:get).with(
+        a_string_matching(/page=2.*per_page=100.*sort=created.*sort_order=asc/)
+      )
+    end
+
+    it "retries on 429 rate limit responses" do
+      rate_limit_response = oauth_response(code: 429, body: "rate limited")
+      success_response = oauth_response(code: 200, body: '{"orders":[]}')
+
+      allow(oauth_access_token).to receive(:get).and_return(rate_limit_response, success_response)
+      allow(client).to receive(:sleep)
+
+      result = client.list_orders
+
+      expect(result).to eq({ "orders" => [] })
+      expect(oauth_access_token).to have_received(:get).twice
+    end
+
+    it "gives up after MAX_RETRIES on persistent 429" do
+      rate_limit_response = oauth_response(code: 429, body: "rate limited")
+      allow(oauth_access_token).to receive(:get).and_return(rate_limit_response)
+      allow(client).to receive(:sleep)
+
+      expect { client.list_orders }.to raise_error(Discogs::Errors::RateLimitError)
+      expect(oauth_access_token).to have_received(:get).exactly(4).times
+    end
+
+    it "raises ApiError on non-2xx non-429 responses" do
+      response = oauth_response(code: 500, body: "server error")
+      allow(oauth_access_token).to receive(:get).and_return(response)
+
+      expect { client.list_orders }.to raise_error(Discogs::Errors::ApiError)
+    end
+
+    it "returns parsed orders on success" do
       response = oauth_response(code: 200, body: '{"orders":[]}')
       allow(oauth_access_token).to receive(:get).and_return(response)
 

--- a/spec/services/store_sales/order_event_processor_spec.rb
+++ b/spec/services/store_sales/order_event_processor_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StoreSales::OrderEventProcessor do
+  let(:store) { create(:store) }
+  let(:processor) { described_class.new(store) }
+
+  describe "#deduplicate" do
+    let(:order) do
+      {
+        "id" => "order-123",
+        "status" => "New Order",
+        "last_activity" => "2026-06-04T12:00:00Z"
+      }
+    end
+
+    it "returns the order_id when no event exists" do
+      expect(processor.deduplicate(order)).to eq("order-123")
+    end
+
+    it "returns nil when an event was recently processed for this activity" do
+      DiscogsOrderEvent.create!(
+        store: store,
+        discogs_order_id: "order-123",
+        status: "New Order",
+        last_activity_at: Time.parse("2026-06-04T12:00:00Z"),
+        listing_ids: [],
+        removed_listing_count: 0,
+        processed_at: Time.parse("2026-06-04T12:00:01Z")
+      )
+
+      expect(processor.deduplicate(order)).to be_nil
+    end
+
+    it "returns the order_id when the existing event was processed long ago" do
+      DiscogsOrderEvent.create!(
+        store: store,
+        discogs_order_id: "order-123",
+        status: "New Order",
+        last_activity_at: Time.parse("2026-06-04T10:00:00Z"),
+        listing_ids: [],
+        removed_listing_count: 0,
+        processed_at: Time.parse("2026-06-04T10:00:00Z")
+      )
+
+      expect(processor.deduplicate(order)).to eq("order-123")
+    end
+
+    it "returns the order_id when last_activity is missing (nil timestamp)" do
+      order_no_activity = { "id" => "order-456", "status" => "New Order" }
+
+      expect(processor.deduplicate(order_no_activity)).to eq("order-456")
+    end
+  end
+
+  describe "#record" do
+    let(:order) do
+      {
+        "id" => "order-123",
+        "status" => "Shipped",
+        "last_activity" => "2026-06-04T13:00:00Z"
+      }
+    end
+    let(:listing_ids) { [ "123", "456" ] }
+    let(:removal_result) { { removed_count: 2, removed_listing_ids: [ "123", "456" ] } }
+
+    it "creates a new event when none exists" do
+      expect {
+        processor.record("order-123", order, listing_ids, removal_result)
+      }.to change(DiscogsOrderEvent, :count).by(1)
+
+      event = DiscogsOrderEvent.last
+      expect(event.store).to eq(store)
+      expect(event.discogs_order_id).to eq("order-123")
+      expect(event.status).to eq("Shipped")
+      expect(event.last_activity_at).to eq(Time.parse("2026-06-04T13:00:00Z"))
+      expect(event.listing_ids).to eq([ "123", "456" ])
+      expect(event.removed_listing_count).to eq(2)
+      expect(event.processed_at).to be_present
+    end
+
+    it "updates an existing event with new activity data" do
+      existing = DiscogsOrderEvent.create!(
+        store: store,
+        discogs_order_id: "order-123",
+        status: "New Order",
+        last_activity_at: Time.parse("2026-06-04T12:00:00Z"),
+        listing_ids: [ "123" ],
+        removed_listing_count: 1,
+        processed_at: Time.parse("2026-06-04T12:00:00Z")
+      )
+
+      processor.record("order-123", order, listing_ids, removal_result)
+
+      existing.reload
+      expect(existing.status).to eq("Shipped")
+      expect(existing.last_activity_at).to eq(Time.parse("2026-06-04T13:00:00Z"))
+      expect(existing.listing_ids).to eq([ "123", "456" ])
+      expect(existing.removed_listing_count).to eq(2)
+    end
+  end
+end

--- a/spec/services/store_sales/order_listing_ids_spec.rb
+++ b/spec/services/store_sales/order_listing_ids_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StoreSales::OrderListingIds do
+  describe ".call" do
+    context "with standard Discogs order payload" do
+      it "extracts a single listing ID from items" do
+        order = {
+          "items" => [
+            { "listing_id" => "1234567890", "id" => 1 }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "1234567890" ])
+      end
+
+      it "extracts multiple listing IDs from multi-item order" do
+        order = {
+          "items" => [
+            { "listing_id" => "111", "id" => 1 },
+            { "listing_id" => "222", "id" => 2 },
+            { "listing_id" => "333", "id" => 3 }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "111", "222", "333" ])
+      end
+
+      it "falls back to id key when listing_id is absent" do
+        order = {
+          "items" => [
+            { "id" => "9876543210" }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "9876543210" ])
+      end
+    end
+
+    context "with symbol keys" do
+      it "extracts listing IDs from symbol-keyed items" do
+        order = {
+          items: [
+            { listing_id: "555" }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "555" ])
+      end
+    end
+
+    context "with blank or nil IDs" do
+      it "ignores items with blank listing IDs" do
+        order = {
+          "items" => [
+            { "listing_id" => "111" },
+            { "listing_id" => "" },
+            { "listing_id" => nil },
+            { "listing_id" => "222" }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "111", "222" ])
+      end
+
+      it "ignores items with no ID keys at all" do
+        order = {
+          "items" => [
+            { "listing_id" => "111" },
+            { "title" => "No ID here" }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "111" ])
+      end
+    end
+
+    context "with missing or malformed items" do
+      it "returns empty array when items key is missing" do
+        order = { "status" => "New Order" }
+
+        expect(described_class.call(order)).to eq([])
+      end
+
+      it "returns empty array when items is nil" do
+        order = { "items" => nil }
+
+        expect(described_class.call(order)).to eq([])
+      end
+
+      it "returns empty array when items is empty" do
+        order = { "items" => [] }
+
+        expect(described_class.call(order)).to eq([])
+      end
+
+      it "handles non-array items gracefully" do
+        order = { "items" => "not an array" }
+
+        expect(described_class.call(order)).to eq([])
+      end
+
+      it "returns empty array when order_hash is nil" do
+        expect(described_class.call(nil)).to eq([])
+      end
+
+      it "returns empty array when order_hash is not a hash" do
+        expect(described_class.call("not a hash")).to eq([])
+      end
+
+      it "skips non-hash items in the array" do
+        order = {
+          "items" => [
+            { "listing_id" => "111" },
+            "not a hash",
+            nil
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "111" ])
+      end
+    end
+
+    context "with duplicate listing IDs" do
+      it "deduplicates listing IDs" do
+        order = {
+          "items" => [
+            { "listing_id" => "111" },
+            { "listing_id" => "111" },
+            { "listing_id" => "222" }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "111", "222" ])
+      end
+    end
+
+    context "with numeric IDs" do
+      it "converts numeric IDs to strings" do
+        order = {
+          "items" => [
+            { "listing_id" => 12345 }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "12345" ])
+      end
+    end
+  end
+end

--- a/spec/services/store_sales/order_listing_ids_spec.rb
+++ b/spec/services/store_sales/order_listing_ids_spec.rb
@@ -5,36 +5,50 @@ require "rails_helper"
 RSpec.describe StoreSales::OrderListingIds do
   describe ".call" do
     context "with standard Discogs order payload" do
-      it "extracts a single listing ID from items" do
+      it "extracts a single listing ID from item id (primary key)" do
         order = {
           "items" => [
-            { "listing_id" => "1234567890", "id" => 1 }
+            {
+              "id" => 41578242,
+              "release" => { "id" => 1, "description" => "Some Release" },
+              "price" => { "currency" => "USD", "value" => 42.0 }
+            }
           ]
         }
 
-        expect(described_class.call(order)).to eq([ "1234567890" ])
+        expect(described_class.call(order)).to eq([ "41578242" ])
       end
 
       it "extracts multiple listing IDs from multi-item order" do
         order = {
           "items" => [
-            { "listing_id" => "111", "id" => 1 },
-            { "listing_id" => "222", "id" => 2 },
-            { "listing_id" => "333", "id" => 3 }
+            { "id" => 111, "release" => { "id" => 1 } },
+            { "id" => 222, "release" => { "id" => 2 } },
+            { "id" => 333, "release" => { "id" => 3 } }
           ]
         }
 
         expect(described_class.call(order)).to eq([ "111", "222", "333" ])
       end
 
-      it "falls back to id key when listing_id is absent" do
+      it "falls back to listing_id key when id is absent" do
         order = {
           "items" => [
-            { "id" => "9876543210" }
+            { "listing_id" => "9876543210" }
           ]
         }
 
         expect(described_class.call(order)).to eq([ "9876543210" ])
+      end
+
+      it "prefers id over listing_id when both present" do
+        order = {
+          "items" => [
+            { "id" => 41578242, "listing_id" => "should-not-match" }
+          ]
+        }
+
+        expect(described_class.call(order)).to eq([ "41578242" ])
       end
     end
 
@@ -42,7 +56,7 @@ RSpec.describe StoreSales::OrderListingIds do
       it "extracts listing IDs from symbol-keyed items" do
         order = {
           items: [
-            { listing_id: "555" }
+            { id: 555 }
           ]
         }
 
@@ -51,13 +65,13 @@ RSpec.describe StoreSales::OrderListingIds do
     end
 
     context "with blank or nil IDs" do
-      it "ignores items with blank listing IDs" do
+      it "ignores items with blank IDs" do
         order = {
           "items" => [
-            { "listing_id" => "111" },
-            { "listing_id" => "" },
-            { "listing_id" => nil },
-            { "listing_id" => "222" }
+            { "id" => 111 },
+            { "id" => "" },
+            { "id" => nil },
+            { "id" => 222 }
           ]
         }
 
@@ -67,7 +81,7 @@ RSpec.describe StoreSales::OrderListingIds do
       it "ignores items with no ID keys at all" do
         order = {
           "items" => [
-            { "listing_id" => "111" },
+            { "id" => 111 },
             { "title" => "No ID here" }
           ]
         }
@@ -112,7 +126,7 @@ RSpec.describe StoreSales::OrderListingIds do
       it "skips non-hash items in the array" do
         order = {
           "items" => [
-            { "listing_id" => "111" },
+            { "id" => 111 },
             "not a hash",
             nil
           ]
@@ -126,9 +140,9 @@ RSpec.describe StoreSales::OrderListingIds do
       it "deduplicates listing IDs" do
         order = {
           "items" => [
-            { "listing_id" => "111" },
-            { "listing_id" => "111" },
-            { "listing_id" => "222" }
+            { "id" => 111 },
+            { "id" => 111 },
+            { "id" => 222 }
           ]
         }
 
@@ -140,7 +154,7 @@ RSpec.describe StoreSales::OrderListingIds do
       it "converts numeric IDs to strings" do
         order = {
           "items" => [
-            { "listing_id" => 12345 }
+            { "id" => 12345 }
           ]
         }
 

--- a/spec/services/store_sales/order_listing_ids_spec.rb
+++ b/spec/services/store_sales/order_listing_ids_spec.rb
@@ -31,24 +31,14 @@ RSpec.describe StoreSales::OrderListingIds do
         expect(described_class.call(order)).to eq([ "111", "222", "333" ])
       end
 
-      it "falls back to listing_id key when id is absent" do
+      it "returns nil for items with no id key" do
         order = {
           "items" => [
-            { "listing_id" => "9876543210" }
+            { "release" => { "id" => 1 } }
           ]
         }
 
-        expect(described_class.call(order)).to eq([ "9876543210" ])
-      end
-
-      it "prefers id over listing_id when both present" do
-        order = {
-          "items" => [
-            { "id" => 41578242, "listing_id" => "should-not-match" }
-          ]
-        }
-
-        expect(described_class.call(order)).to eq([ "41578242" ])
+        expect(described_class.call(order)).to eq([])
       end
     end
 

--- a/spec/services/store_sales/order_poller_integration_spec.rb
+++ b/spec/services/store_sales/order_poller_integration_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Sales poll integration", :integration do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:store) { create(:store, total_listings: 2) }
+  let(:store_owner) { create(:store_owner) }
+  let(:client) { instance_double(DiscogsClient) }
+
+  let(:orders_response) do
+    {
+      "orders" => [
+        {
+          "id" => "41578242-1",
+          "status" => "New Order",
+          "last_activity" => "2026-06-04T12:00:00Z",
+          "items" => [ { "id" => 41578242 } ]
+        }
+      ]
+    }
+  end
+
+  before do
+    store.update!(store_owner: store_owner)
+    allow(DiscogsClient).to receive(:new).and_return(client)
+    allow(client).to receive(:list_orders).and_return(orders_response)
+  end
+
+  it "removes sold listings and enqueues curation through the full pipeline" do
+    create(:listing, store: store, discogs_listing_id: "41578242")
+    create(:listing, store: store, discogs_listing_id: "keep-me")
+
+    travel_to(Time.zone.parse("2026-06-04T12:01:00")) do
+      expect {
+        SalesPollStoreJob.perform_now(store.id)
+      }.to change(DiscogsOrderEvent, :count).by(1)
+       .and change { store.listings.count }.by(-1)
+       .and have_enqueued_job(DailyCurationJob).with(store.id)
+    end
+
+    # Sold listing is gone, unsold listing remains
+    expect(store.listings.find_by(discogs_listing_id: "41578242")).to be_nil
+    expect(store.listings.find_by(discogs_listing_id: "keep-me")).to be_present
+
+    # Order event recorded with correct metadata
+    event = DiscogsOrderEvent.last
+    expect(event.store).to eq(store)
+    expect(event.discogs_order_id).to eq("41578242-1")
+    expect(event.status).to eq("New Order")
+    expect(event.listing_ids).to eq([ "41578242" ])
+    expect(event.removed_listing_count).to eq(1)
+
+    # Poll state advanced
+    expect(store.reload.last_sales_polled_at).to be_within(1.second).of(Time.zone.parse("2026-06-04T12:01:00"))
+    expect(store.sales_poll_cursor_at).to eq(Time.zone.parse("2026-06-04T12:00:00Z"))
+    expect(store.last_sales_poll_error).to be_nil
+
+    # Inventory version bumped for cache invalidation
+    expect(store.inventory_version).to eq(1)
+  end
+
+  it "stores poll error state without advancing cursor when API fails" do
+    allow(client).to receive(:list_orders).and_raise(Discogs::Errors::ApiError.new("API down"))
+
+    expect {
+      SalesPollStoreJob.perform_now(store.id)
+    }.to raise_error(Discogs::Errors::ApiError, /API down/)
+
+    expect(store.reload.last_sales_poll_error).to include("API down")
+    expect(store.last_sales_poll_error_at).to be_present
+    expect(store.sales_poll_cursor_at).to be_nil
+    expect(store.last_sales_polled_at).to be_nil
+  end
+
+  it "does not enqueue curation when no listings were found" do
+    create(:listing, store: store, discogs_listing_id: "keep-me")
+
+    travel_to(Time.zone.parse("2026-06-04T12:01:00")) do
+      expect {
+        SalesPollStoreJob.perform_now(store.id)
+      }.not_to have_enqueued_job(DailyCurationJob)
+    end
+
+    # Listing untouched — no matching ID in the order
+    expect(store.listings.find_by(discogs_listing_id: "keep-me")).to be_present
+  end
+end

--- a/spec/services/store_sales/order_poller_spec.rb
+++ b/spec/services/store_sales/order_poller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe StoreSales::OrderPoller do
               "id" => "order-123",
               "status" => "New Order",
               "last_activity" => "2026-06-04T12:00:00Z",
-              "items" => [ { "listing_id" => "listing-abc" } ]
+              "items" => [ { "id" => 41578242 } ]
             }
           ]
         }
@@ -31,7 +31,7 @@ RSpec.describe StoreSales::OrderPoller do
 
       before do
         allow(client).to receive(:list_orders).and_return(orders_response)
-        create(:listing, store: store, discogs_listing_id: "listing-abc")
+        create(:listing, store: store, discogs_listing_id: "41578242")
       end
 
       it "polls recent orders and removes sold listings" do
@@ -40,7 +40,7 @@ RSpec.describe StoreSales::OrderPoller do
         expect(result[:order_count]).to eq(1)
         expect(result[:removed_count]).to eq(1)
         expect(result[:cursor_advanced]).to be true
-        expect(store.listings.where(discogs_listing_id: "listing-abc")).to be_empty
+        expect(store.listings.where(discogs_listing_id: "41578242")).to be_empty
       end
 
       it "creates DiscogsOrderEvent for processed orders" do
@@ -103,7 +103,7 @@ RSpec.describe StoreSales::OrderPoller do
               "id" => "order-123",
               "status" => "New Order",
               "last_activity" => "2026-06-04T12:00:00Z",
-              "items" => [ { "listing_id" => "listing-abc" } ]
+              "items" => [ { "id" => 41578242 } ]
             }
           ]
         }
@@ -111,7 +111,7 @@ RSpec.describe StoreSales::OrderPoller do
 
       before do
         allow(client).to receive(:list_orders).and_return(orders_response)
-        create(:listing, store: store, discogs_listing_id: "listing-abc")
+        create(:listing, store: store, discogs_listing_id: "41578242")
 
         # Pre-process the order
         DiscogsOrderEvent.create!(
@@ -119,7 +119,7 @@ RSpec.describe StoreSales::OrderPoller do
           discogs_order_id: "order-123",
           status: "New Order",
           last_activity_at: Time.parse("2026-06-04T12:00:00Z"),
-          listing_ids: [ "listing-abc" ],
+          listing_ids: [ "41578242" ],
           removed_listing_count: 1,
           processed_at: Time.parse("2026-06-04T12:00:00Z")
         )
@@ -129,7 +129,7 @@ RSpec.describe StoreSales::OrderPoller do
         result = described_class.new(store).call
 
         expect(result[:removed_count]).to eq(0)
-        expect(store.listings.where(discogs_listing_id: "listing-abc")).to be_present
+        expect(store.listings.where(discogs_listing_id: "41578242")).to be_present
       end
     end
 
@@ -141,7 +141,7 @@ RSpec.describe StoreSales::OrderPoller do
               "id" => "order-123",
               "status" => "Shipped",
               "last_activity" => "2026-06-04T13:00:00Z",
-              "items" => [ { "listing_id" => "listing-abc" } ]
+              "items" => [ { "id" => 41578242 } ]
             }
           ]
         }
@@ -156,7 +156,7 @@ RSpec.describe StoreSales::OrderPoller do
           discogs_order_id: "order-123",
           status: "New Order",
           last_activity_at: Time.parse("2026-06-04T12:00:00Z"),
-          listing_ids: [ "listing-abc" ],
+          listing_ids: [ "41578242" ],
           removed_listing_count: 1,
           processed_at: Time.parse("2026-06-04T12:00:00Z")
         )
@@ -234,13 +234,13 @@ RSpec.describe StoreSales::OrderPoller do
               "id" => "order-1",
               "status" => "New Order",
               "last_activity" => "2026-06-04T12:00:00Z",
-              "items" => [ { "listing_id" => "listing-1" } ]
+              "items" => [ { "id" => 111 } ]
             },
             {
               "id" => "order-2",
               "status" => "New Order",
               "last_activity" => "2026-06-04T13:00:00Z",
-              "items" => [ { "listing_id" => "listing-2" } ]
+              "items" => [ { "id" => 222 } ]
             }
           ]
         }
@@ -248,8 +248,8 @@ RSpec.describe StoreSales::OrderPoller do
 
       before do
         allow(client).to receive(:list_orders).and_return(orders_response)
-        create(:listing, store: store, discogs_listing_id: "listing-1")
-        create(:listing, store: store, discogs_listing_id: "listing-2")
+        create(:listing, store: store, discogs_listing_id: "111")
+        create(:listing, store: store, discogs_listing_id: "222")
       end
 
       it "processes all orders and advances cursor to max activity" do

--- a/spec/services/store_sales/order_poller_spec.rb
+++ b/spec/services/store_sales/order_poller_spec.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StoreSales::OrderPoller do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:store) { create(:store) }
+  let(:store_owner) { create(:store_owner) }
+  let(:client) { instance_double(DiscogsClient) }
+
+  before do
+    store.update!(store_owner: store_owner)
+    allow(DiscogsClient).to receive(:new).and_return(client)
+  end
+
+  describe "#call" do
+    context "with OAuth authorized store" do
+      let(:orders_response) do
+        {
+          "orders" => [
+            {
+              "id" => "order-123",
+              "status" => "New Order",
+              "last_activity" => "2026-06-04T12:00:00Z",
+              "items" => [ { "listing_id" => "listing-abc" } ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow(client).to receive(:list_orders).and_return(orders_response)
+        create(:listing, store: store, discogs_listing_id: "listing-abc")
+      end
+
+      it "polls recent orders and removes sold listings" do
+        result = described_class.new(store).call
+
+        expect(result[:order_count]).to eq(1)
+        expect(result[:removed_count]).to eq(1)
+        expect(result[:cursor_advanced]).to be true
+        expect(store.listings.where(discogs_listing_id: "listing-abc")).to be_empty
+      end
+
+      it "creates DiscogsOrderEvent for processed orders" do
+        expect {
+          described_class.new(store).call
+        }.to change(DiscogsOrderEvent, :count).by(1)
+
+        event = DiscogsOrderEvent.last
+        expect(event.store).to eq(store)
+        expect(event.discogs_order_id).to eq("order-123")
+        expect(event.status).to eq("New Order")
+        expect(event.removed_listing_count).to eq(1)
+        expect(event.processed_at).to be_present
+      end
+
+      it "advances cursor to max last_activity timestamp" do
+        travel_to(Time.current) do
+          described_class.new(store).call
+          expect(store.reload.sales_poll_cursor_at).to eq(Time.parse("2026-06-04T12:00:00Z"))
+        end
+      end
+
+      it "marks last_sales_polled_at on success" do
+        travel_to(Time.current) do
+          described_class.new(store).call
+          expect(store.reload.last_sales_polled_at).to be_within(1.second).of(Time.current)
+        end
+      end
+
+      it "clears previous error state on success" do
+        store.update!(
+          last_sales_poll_error: "Previous error",
+          last_sales_poll_error_at: 1.hour.ago
+        )
+
+        described_class.new(store).call
+
+        expect(store.reload.last_sales_poll_error).to be_nil
+        expect(store.reload.last_sales_poll_error_at).to be_nil
+      end
+    end
+
+    context "without OAuth authorization" do
+      before do
+        store.update!(store_owner: nil)
+      end
+
+      it "raises ApiError" do
+        expect {
+          described_class.new(store).call
+        }.to raise_error(Discogs::Errors::ApiError, /OAuth authorization required/)
+      end
+    end
+
+    context "with already processed order" do
+      let(:orders_response) do
+        {
+          "orders" => [
+            {
+              "id" => "order-123",
+              "status" => "New Order",
+              "last_activity" => "2026-06-04T12:00:00Z",
+              "items" => [ { "listing_id" => "listing-abc" } ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow(client).to receive(:list_orders).and_return(orders_response)
+        create(:listing, store: store, discogs_listing_id: "listing-abc")
+
+        # Pre-process the order
+        DiscogsOrderEvent.create!(
+          store: store,
+          discogs_order_id: "order-123",
+          status: "New Order",
+          last_activity_at: Time.parse("2026-06-04T12:00:00Z"),
+          listing_ids: [ "listing-abc" ],
+          removed_listing_count: 1,
+          processed_at: Time.parse("2026-06-04T12:00:00Z")
+        )
+      end
+
+      it "does not remove listings twice" do
+        result = described_class.new(store).call
+
+        expect(result[:removed_count]).to eq(0)
+        expect(store.listings.where(discogs_listing_id: "listing-abc")).to be_present
+      end
+    end
+
+    context "with same order having later activity" do
+      let(:orders_response) do
+        {
+          "orders" => [
+            {
+              "id" => "order-123",
+              "status" => "Shipped",
+              "last_activity" => "2026-06-04T13:00:00Z",
+              "items" => [ { "listing_id" => "listing-abc" } ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow(client).to receive(:list_orders).and_return(orders_response)
+
+        # Previous processing removed the listing
+        DiscogsOrderEvent.create!(
+          store: store,
+          discogs_order_id: "order-123",
+          status: "New Order",
+          last_activity_at: Time.parse("2026-06-04T12:00:00Z"),
+          listing_ids: [ "listing-abc" ],
+          removed_listing_count: 1,
+          processed_at: Time.parse("2026-06-04T12:00:00Z")
+        )
+      end
+
+      it "updates event status but does not double-count removals" do
+        result = described_class.new(store).call
+
+        event = DiscogsOrderEvent.find_by(discogs_order_id: "order-123")
+        expect(event.status).to eq("Shipped")
+        expect(event.last_activity_at).to eq(Time.parse("2026-06-04T13:00:00Z"))
+        expect(result[:removed_count]).to eq(0)
+      end
+    end
+
+    context "when client raises error" do
+      before do
+        allow(client).to receive(:list_orders).and_raise(Discogs::Errors::ApiError.new("API failure"))
+      end
+
+      it "sets error fields and re-raises" do
+        travel_to(Time.current) do
+          expect {
+            described_class.new(store).call
+          }.to raise_error(Discogs::Errors::ApiError, /API failure/)
+
+          expect(store.reload.last_sales_poll_error).to include("API failure")
+          expect(store.reload.last_sales_poll_error_at).to be_within(1.second).of(Time.current)
+        end
+      end
+
+      it "does not advance cursor" do
+        original_cursor = store.sales_poll_cursor_at
+
+        expect {
+          described_class.new(store).call
+        }.to raise_error(Discogs::Errors::ApiError)
+
+        expect(store.reload.sales_poll_cursor_at).to eq(original_cursor)
+      end
+
+      it "does not mark last_sales_polled_at" do
+        original_polled = store.last_sales_polled_at
+
+        expect {
+          described_class.new(store).call
+        }.to raise_error(Discogs::Errors::ApiError)
+
+        expect(store.reload.last_sales_polled_at).to eq(original_polled)
+      end
+    end
+
+    context "with empty order list" do
+      before do
+        allow(client).to receive(:list_orders).and_return({ "orders" => [] })
+      end
+
+      it "still updates last_sales_polled_at" do
+        travel_to(Time.current) do
+          result = described_class.new(store).call
+
+          expect(result[:order_count]).to eq(0)
+          expect(result[:removed_count]).to eq(0)
+          expect(result[:cursor_advanced]).to be false
+          expect(store.reload.last_sales_polled_at).to be_within(1.second).of(Time.current)
+        end
+      end
+    end
+
+    context "with multiple orders" do
+      let(:orders_response) do
+        {
+          "orders" => [
+            {
+              "id" => "order-1",
+              "status" => "New Order",
+              "last_activity" => "2026-06-04T12:00:00Z",
+              "items" => [ { "listing_id" => "listing-1" } ]
+            },
+            {
+              "id" => "order-2",
+              "status" => "New Order",
+              "last_activity" => "2026-06-04T13:00:00Z",
+              "items" => [ { "listing_id" => "listing-2" } ]
+            }
+          ]
+        }
+      end
+
+      before do
+        allow(client).to receive(:list_orders).and_return(orders_response)
+        create(:listing, store: store, discogs_listing_id: "listing-1")
+        create(:listing, store: store, discogs_listing_id: "listing-2")
+      end
+
+      it "processes all orders and advances cursor to max activity" do
+        result = described_class.new(store).call
+
+        expect(result[:order_count]).to eq(2)
+        expect(result[:removed_count]).to eq(2)
+        expect(store.reload.sales_poll_cursor_at).to eq(Time.parse("2026-06-04T13:00:00Z"))
+      end
+    end
+  end
+end

--- a/spec/services/store_sales/poll_state_tracker_spec.rb
+++ b/spec/services/store_sales/poll_state_tracker_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StoreSales::PollStateTracker do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:store) { create(:store) }
+  let(:tracker) { described_class.new(store) }
+
+  describe "#mark_success" do
+    it "sets last_sales_polled_at" do
+      travel_to(Time.current) do
+        tracker.mark_success
+        expect(store.reload.last_sales_polled_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    it "clears previous error state" do
+      store.update!(
+        last_sales_poll_error: "Previous failure",
+        last_sales_poll_error_at: 1.hour.ago
+      )
+
+      tracker.mark_success
+
+      expect(store.reload.last_sales_poll_error).to be_nil
+      expect(store.reload.last_sales_poll_error_at).to be_nil
+    end
+  end
+
+  describe "#mark_failure" do
+    let(:error) { RuntimeError.new("something broke") }
+
+    before do
+      allow(error).to receive(:backtrace).and_return([
+        "file1.rb:10:in `method_a'",
+        "file2.rb:20:in `method_b'"
+      ])
+    end
+
+    it "records the error message and backtrace" do
+      travel_to(Time.current) do
+        tracker.mark_failure(error)
+
+        expect(store.reload.last_sales_poll_error).to include("RuntimeError: something broke")
+        expect(store.reload.last_sales_poll_error).to include("file1.rb:10")
+        expect(store.reload.last_sales_poll_error_at).to be_within(1.second).of(Time.current)
+      end
+    end
+  end
+
+  describe "#advance_cursor" do
+    it "updates the poll cursor timestamp" do
+      timestamp = Time.parse("2026-06-04T13:00:00Z")
+
+      tracker.advance_cursor(timestamp)
+
+      expect(store.reload.sales_poll_cursor_at).to eq(timestamp)
+    end
+  end
+end

--- a/spec/services/store_sales/sold_listing_remover_spec.rb
+++ b/spec/services/store_sales/sold_listing_remover_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe StoreSales::SoldListingRemover do
         expect(other_store.listings.where(discogs_listing_id: "other-sold-111")).to exist
         expect(other_store.listings.count).to eq(2)
       end
+
+      it "changes the storefront curation cache key" do
+        original_key = StorefrontCuration::CacheManager.send(:curation_cache_key, store)
+
+        remover.call([ "sold-111" ])
+
+        new_key = StorefrontCuration::CacheManager.send(:curation_cache_key, store.reload)
+        expect(new_key).not_to eq(original_key)
+      end
     end
 
     context "with no matching listings" do

--- a/spec/services/store_sales/sold_listing_remover_spec.rb
+++ b/spec/services/store_sales/sold_listing_remover_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StoreSales::SoldListingRemover do
+  let(:store) { create(:store, total_listings: 5) }
+  let(:other_store) { create(:store, total_listings: 3) }
+  let(:remover) { described_class.new(store) }
+
+  describe "#call" do
+    context "with matching listings" do
+      before do
+        create(:listing, store: store, discogs_listing_id: "sold-111")
+        create(:listing, store: store, discogs_listing_id: "sold-222")
+        create(:listing, store: store, discogs_listing_id: "keep-333")
+        create(:listing, store: store, discogs_listing_id: "keep-444")
+        create(:listing, store: store, discogs_listing_id: "keep-555")
+      end
+
+      it "removes listings matching the given IDs" do
+        result = remover.call([ "sold-111", "sold-222" ])
+
+        expect(store.listings.where(discogs_listing_id: [ "sold-111", "sold-222" ])).to be_empty
+        expect(store.listings.count).to eq(3)
+      end
+
+      it "returns correct removed_count" do
+        result = remover.call([ "sold-111", "sold-222" ])
+
+        expect(result[:removed_count]).to eq(2)
+      end
+
+      it "returns correct removed_listing_ids" do
+        result = remover.call([ "sold-111", "sold-222" ])
+
+        expect(result[:removed_listing_ids]).to match_array([ "sold-111", "sold-222" ])
+      end
+
+      it "increments inventory_version when listings are removed" do
+        original_version = store.inventory_version
+
+        remover.call([ "sold-111" ])
+
+        expect(store.reload.inventory_version).to eq(original_version + 1)
+      end
+
+      it "updates total_listings to reflect new count" do
+        remover.call([ "sold-111", "sold-222" ])
+
+        expect(store.reload.total_listings).to eq(3)
+      end
+
+      it "only removes listings from the target store" do
+        create(:listing, store: other_store, discogs_listing_id: "other-sold-111")
+        create(:listing, store: other_store, discogs_listing_id: "other-keep")
+
+        remover.call([ "other-sold-111" ])
+
+        expect(other_store.listings.where(discogs_listing_id: "other-sold-111")).to exist
+        expect(other_store.listings.count).to eq(2)
+      end
+    end
+
+    context "with no matching listings" do
+      before do
+        create(:listing, store: store, discogs_listing_id: "keep-111")
+        create(:listing, store: store, discogs_listing_id: "keep-222")
+      end
+
+      it "does not raise an error for unknown IDs" do
+        expect {
+          remover.call([ "unknown-999" ])
+        }.not_to raise_error
+      end
+
+      it "does not increment inventory_version" do
+        original_version = store.inventory_version
+
+        remover.call([ "unknown-999" ])
+
+        expect(store.reload.inventory_version).to eq(original_version)
+      end
+
+      it "does not update total_listings" do
+        original_count = store.total_listings
+
+        remover.call([ "unknown-999" ])
+
+        expect(store.reload.total_listings).to eq(original_count)
+      end
+
+      it "returns zero removed_count" do
+        result = remover.call([ "unknown-999" ])
+
+        expect(result[:removed_count]).to eq(0)
+      end
+
+      it "returns empty removed_listing_ids" do
+        result = remover.call([ "unknown-999" ])
+
+        expect(result[:removed_listing_ids]).to eq([])
+      end
+    end
+
+    context "with empty or nil input" do
+      before do
+        create(:listing, store: store, discogs_listing_id: "keep-111")
+      end
+
+      it "handles empty array input" do
+        result = remover.call([])
+
+        expect(result[:removed_count]).to eq(0)
+        expect(result[:removed_listing_ids]).to eq([])
+      end
+
+      it "handles nil input" do
+        result = remover.call(nil)
+
+        expect(result[:removed_count]).to eq(0)
+        expect(result[:removed_listing_ids]).to eq([])
+      end
+
+      it "handles array with nil values" do
+        result = remover.call([ nil, nil ])
+
+        expect(result[:removed_count]).to eq(0)
+      end
+
+      it "handles array with blank strings" do
+        result = remover.call([ "", "" ])
+
+        expect(result[:removed_count]).to eq(0)
+      end
+    end
+
+    context "with duplicate IDs" do
+      before do
+        create(:listing, store: store, discogs_listing_id: "sold-111")
+      end
+
+      it "deduplicates IDs before processing" do
+        result = remover.call([ "sold-111", "sold-111", "sold-111" ])
+
+        expect(result[:removed_count]).to eq(1)
+        expect(result[:removed_listing_ids]).to eq([ "sold-111" ])
+      end
+    end
+
+    context "idempotency" do
+      before do
+        create(:listing, store: store, discogs_listing_id: "sold-111")
+      end
+
+      it "can be called multiple times safely" do
+        remover.call([ "sold-111" ])
+        result = remover.call([ "sold-111" ])
+
+        expect(result[:removed_count]).to eq(0)
+        expect(result[:removed_listing_ids]).to eq([])
+      end
+
+      it "only increments inventory_version once for the same listing" do
+        version_after_first = nil
+        version_after_second = nil
+
+        remover.call([ "sold-111" ])
+        version_after_first = store.reload.inventory_version
+
+        remover.call([ "sold-111" ])
+        version_after_second = store.reload.inventory_version
+
+        expect(version_after_second).to eq(version_after_first)
+      end
+    end
+  end
+end

--- a/spec/services/store_sync/inventory_updater_spec.rb
+++ b/spec/services/store_sync/inventory_updater_spec.rb
@@ -114,5 +114,26 @@ RSpec.describe StoreSync::InventoryUpdater do
         importer.remove_stale([])
       }.to change(store.listings, :count).from(3).to(0)
     end
+
+    it "increments inventory_version when listings are deleted" do
+      create(:listing, store:, discogs_listing_id: "keep-me")
+      create(:listing, store:, discogs_listing_id: "stale")
+      importer = described_class.new(store)
+      current_records = [ record_attrs(discogs_listing_id: "keep-me") ]
+
+      expect {
+        importer.remove_stale(current_records)
+      }.to change { store.reload.inventory_version }.by(1)
+    end
+
+    it "does not increment inventory_version when no listings are deleted" do
+      create(:listing, store:, discogs_listing_id: "keep-me")
+      importer = described_class.new(store)
+      current_records = [ record_attrs(discogs_listing_id: "keep-me") ]
+
+      expect {
+        importer.remove_stale(current_records)
+      }.not_to change { store.reload.inventory_version }
+    end
   end
 end

--- a/spec/services/storefront_curation/cache_manager_spec.rb
+++ b/spec/services/storefront_curation/cache_manager_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe StorefrontCuration::CacheManager do
         expect(key).not_to include("available")
       end
     end
+
+    it "includes inventory_version in the cache key" do
+      store.update!(inventory_version: 5)
+      key = described_class.send(:curation_cache_key, store)
+
+      expect(key).to include("/5")
+    end
+
+    it "produces different keys for different inventory_versions" do
+      store.update!(inventory_version: 0)
+      key_v0 = described_class.send(:curation_cache_key, store)
+
+      store.update!(inventory_version: 1)
+      key_v1 = described_class.send(:curation_cache_key, store)
+
+      expect(key_v0).not_to eq(key_v1)
+    end
   end
 
   describe "delegation from StorefrontCuration" do

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -288,7 +288,8 @@ RSpec.describe StorefrontCuration do
         store_id: store.id,
         date: Date.current.iso8601,
         scope: "available",
-        wall_count: Settings.storefront.wall_count
+        wall_count: Settings.storefront.wall_count,
+        inventory_version: store.inventory_version
       }
 
       described_class.cached_curation(store, cache: cache)
@@ -299,7 +300,8 @@ RSpec.describe StorefrontCuration do
         store_id: store.id,
         date: (Date.current + 1.day).iso8601,
         scope: "available",
-        wall_count: Settings.storefront.wall_count
+        wall_count: Settings.storefront.wall_count,
+        inventory_version: store.inventory_version
       }
       expect(cache.exist?(other_key)).to be false
     end
@@ -309,13 +311,15 @@ RSpec.describe StorefrontCuration do
         store_id: store.id,
         date: Date.current.iso8601,
         scope: "available",
-        wall_count: Settings.storefront.wall_count
+        wall_count: Settings.storefront.wall_count,
+        inventory_version: store.inventory_version
       }
       all_key = StorefrontCuration::CacheManager::CURATION_CACHE_KEY % {
         store_id: store.id,
         date: Date.current.iso8601,
         scope: "all",
-        wall_count: Settings.storefront.wall_count
+        wall_count: Settings.storefront.wall_count,
+        inventory_version: store.inventory_version
       }
 
       described_class.cached_curation(store, cache: cache)
@@ -356,7 +360,8 @@ RSpec.describe StorefrontCuration do
         store_id: store.id,
         date: Date.current.iso8601,
         scope: "available",
-        wall_count: Settings.storefront.wall_count
+        wall_count: Settings.storefront.wall_count,
+        inventory_version: store.inventory_version
       }
 
       described_class.write_curation_cache(store, payload, cache: cache)
@@ -370,13 +375,15 @@ RSpec.describe StorefrontCuration do
         store_id: store.id,
         date: Date.current.iso8601,
         scope: "available",
-        wall_count: Settings.storefront.wall_count
+        wall_count: Settings.storefront.wall_count,
+        inventory_version: store.inventory_version
       }
       all_key = StorefrontCuration::CacheManager::CURATION_CACHE_KEY % {
         store_id: store.id,
         date: Date.current.iso8601,
         scope: "all",
-        wall_count: Settings.storefront.wall_count
+        wall_count: Settings.storefront.wall_count,
+        inventory_version: store.inventory_version
       }
 
       described_class.write_curation_cache(store, payload, filter_available: false, cache: cache)


### PR DESCRIPTION
## Summary

Before: OAuth stores had no real-time awareness of Discogs marketplace sales. Sold records survived in Milkcrate inventory and cached storefront payloads until the nightly full sync — up to 24 hours of stale sold data. Shoppers clicking through to sold records cost stores trust.

After: OAuth-authorized stores get minute-level sales polling via the Discogs marketplace orders endpoint. When a record sells, it's removed from local inventory immediately, and the storefront curation cache key rolls so cached payloads cannot expose sold records. The nightly full sync remains authoritative for relists, cancellations, and full reconciliation.

## Design Decisions

**Remove first, reconcile later.** Sold listing IDs are deleted immediately from local `listings`. This is conservative for shoppers. Full sync restores inventory if a seller relists or an order is cancelled (Discogs marks the listing available again).

**Version cache keys, don't chase them.** An `inventory_version` counter on stores is incremented atomically on any inventory mutation that affects storefront availability (sales polling removal, full sync stale deletion). The curation cache key includes this version, so stale payloads self-invalidate without needing to enumerate or delete individual cache entries.

**Dispatcher owns scale control.** `SalesPollDispatcherJob` fires every minute, selects OAuth stores due for polling, and enqueues within a budget (`MAX_STORES_PER_RUN = 20`) with staggered delays. This prevents unbounded external requests as the store fleet grows.

**Separate poll health from sync health.** Sales poll failures set `last_sales_poll_error` and `last_sales_poll_error_at` — independent fields from the existing `sync_status` enum. Dashboard/admin can surface poll health without conflating it with full inventory sync failures.

**No buyer PII, ever.** Only operational facts are persisted: order IDs, status/activity timestamps, listing IDs, and removal counts. No buyer names, addresses, payment data, or identity information.

## Data Model

**New table: `discogs_order_events`**
- `store_id`, `discogs_order_id` (unique index) — idempotency and dedup
- `status`, `last_activity_at` — order state tracking
- `listing_ids` (PostgreSQL `text[]`) — what was removed
- `removed_listing_count` — operational metric

**New fields on `stores`**
- `sales_poll_cursor_at`, `last_sales_polled_at` — poll state
- `last_sales_poll_error`, `last_sales_poll_error_at` — error tracking
- `inventory_version` (integer, default 0) — cache invalidation counter

## Flow

```mermaid
sequenceDiagram
    participant SQ as Solid Queue
    participant D as SalesPollDispatcherJob
    participant SP as SalesPollStoreJob
    participant P as StoreSales::OrderPoller
    participant DC as DiscogsClient
    participant R as SoldListingRemover
    participant DB as PostgreSQL
    participant C as Rails Cache

    SQ->>D: every minute
    D->>DB: select due OAuth stores (≤20)
    loop each due store (staggered 3s)
        D->>SP: enqueue
        SP->>P: poll
        P->>DC: GET /marketplace/orders (sort: last_activity desc)
        DC-->>P: recent orders
        loop each new/changed order
            P->>DB: upsert DiscogsOrderEvent
            P->>R: remove sold listing_ids
            R->>DB: delete listings + bump inventory_version
        end
        P->>DB: advance cursor + mark polled_at
        alt listings removed
            SP->>SP: enqueue DailyCurationJob (prewarm)
        end
    end
    Note over C: Cache key now includes inventory_version<br/>→ stale payloads self-invalidate
```

## Post-Deploy Monitoring & Validation

**Log queries:**
- `[SalesPollDispatcherJob]` — dispatcher activity
- `[SalesPollStoreJob]` — per-store polling, RecordNotFound, error propagation
- `last_sales_poll_error` — grep for persistent errors on specific stores

**Health queries (Rails console):**
```ruby
# Stores being actively polled
Store.where.not(last_sales_polled_at: nil).count

# Stores with advancing cursors
Store.where.not(sales_poll_cursor_at: nil).count

# Order events recorded
DiscogsOrderEvent.count

# Stores with persistent poll errors
Store.where.not(last_sales_poll_error: nil).count
```

**Expected healthy signals:**
- Dispatcher runs every minute, `last_sales_polled_at` advances for OAuth stores
- `DiscogsOrderEvent` records created when orders exist
- No persistent `last_sales_poll_error` entries on any store

**Failure signals:**
- `last_sales_poll_error` consistently non-nil for a store → investigate OAuth token validity or API access
- No `last_sales_polled_at` updates for any store → dispatcher or Solid Queue issue
- Rate limit errors (`Discogs::Errors::RateLimitError`) in logs → reduce `MAX_STORES_PER_RUN`
- `DiscogsOrderEvent` growing without corresponding listing removals → extraction logic mismatch

**Mitigation:** Remove the `sales_poll_dispatcher` task from `config/recurring.yml` to disable polling; redeploy. No data migration needed to roll back.

**Validation window:** 24 hours after deploy.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Pi](https://img.shields.io/badge/Sonnet_4.6_%28200K%29-D97757?logo=claude&logoColor=white)
