### PR TITLE
feat: Switch curation axis to styles for narrow-catalog stores

### DIFF
--- a/app/models/wall.rb
+++ b/app/models/wall.rb
@@ -3,9 +3,10 @@
 class Wall
   attr_reader :crate
 
-  def initialize(eligible_listings:, genre_counts:)
+  def initialize(eligible_listings:, genre_counts:, curation_axis: :genres)
     @eligible_listings = eligible_listings
     @genre_counts = genre_counts
+    @curation_axis = curation_axis
     @crate = CuratedCrate.new(
       slug: "wall",
       name: "The Wall",
@@ -29,6 +30,6 @@ class Wall
   end
 
   def strategy
-    @strategy ||= CrateStrategies::Wall.new(genre_counts: @genre_counts, today: Date.today)
+    @strategy ||= CrateStrategies::Wall.new(genre_counts: @genre_counts, curation_axis: @curation_axis, today: Date.today)
   end
 end

--- a/app/models/wall.rb
+++ b/app/models/wall.rb
@@ -3,7 +3,7 @@
 class Wall
   attr_reader :crate
 
-  def initialize(eligible_listings:, genre_counts:, curation_axis: :genres)
+  def initialize(eligible_listings:, genre_counts:, curation_axis: GenresAxis.new)
     @eligible_listings = eligible_listings
     @genre_counts = genre_counts
     @curation_axis = curation_axis

--- a/app/services/crate_strategies/genre.rb
+++ b/app/services/crate_strategies/genre.rb
@@ -8,14 +8,19 @@ module CrateStrategies
 
     MIN_RECORDS = 4
 
-    def initialize(genre:, genre_counts:, today: Date.today)
+    def initialize(genre:, genre_counts:, curation_axis: :genres, today: Date.today)
       @scorer = RecordScorer.new(genre_counts:, today:)
       @genre  = genre
+      @curation_axis = curation_axis
     end
 
     def select(pool, excluded_ids:)
       candidates = score_and_sort(pool, excluded_ids:, scorer: @scorer) do |candidates|
-        candidates.select { |l| l.primary_genre == @genre }
+        if @curation_axis == :styles
+          candidates.select { |l| Array(l.styles).include?(@genre) }
+        else
+          candidates.select { |l| l.primary_genre == @genre }
+        end
       end
 
       return [] if candidates.size < MIN_RECORDS

--- a/app/services/crate_strategies/genre.rb
+++ b/app/services/crate_strategies/genre.rb
@@ -8,7 +8,7 @@ module CrateStrategies
 
     MIN_RECORDS = 4
 
-    def initialize(genre:, genre_counts:, curation_axis: :genres, today: Date.today)
+    def initialize(genre:, genre_counts:, curation_axis: GenresAxis.new, today: Date.today)
       @scorer = RecordScorer.new(genre_counts:, today:)
       @genre  = genre
       @curation_axis = curation_axis
@@ -16,22 +16,12 @@ module CrateStrategies
 
     def select(pool, excluded_ids:)
       candidates = score_and_sort(pool, excluded_ids:, scorer: @scorer) do |candidates|
-        candidates.select { |l| matches_axis?(l) }
+        candidates.select { |l| @curation_axis.matches?(l, @genre) }
       end
 
       return [] if candidates.size < MIN_RECORDS
 
       candidates.first(CuratedCrate::CRATE_SIZE)
-    end
-
-    private
-
-    def matches_axis?(listing)
-      if @curation_axis == :styles
-        Array(listing.styles).include?(@genre)
-      else
-        listing.primary_genre == @genre
-      end
     end
   end
 end

--- a/app/services/crate_strategies/genre.rb
+++ b/app/services/crate_strategies/genre.rb
@@ -16,16 +16,22 @@ module CrateStrategies
 
     def select(pool, excluded_ids:)
       candidates = score_and_sort(pool, excluded_ids:, scorer: @scorer) do |candidates|
-        if @curation_axis == :styles
-          candidates.select { |l| Array(l.styles).include?(@genre) }
-        else
-          candidates.select { |l| l.primary_genre == @genre }
-        end
+        candidates.select { |l| matches_axis?(l) }
       end
 
       return [] if candidates.size < MIN_RECORDS
 
       candidates.first(CuratedCrate::CRATE_SIZE)
+    end
+
+    private
+
+    def matches_axis?(listing)
+      if @curation_axis == :styles
+        Array(listing.styles).include?(@genre)
+      else
+        listing.primary_genre == @genre
+      end
     end
   end
 end

--- a/app/services/crate_strategies/hidden_gems.rb
+++ b/app/services/crate_strategies/hidden_gems.rb
@@ -8,9 +8,10 @@ module CrateStrategies
     MAX_ENGAGEMENT  = 100
     MIN_WANTS       = 10
 
-    def initialize(genre_counts:, today: Date.today)
+    def initialize(genre_counts:, curation_axis: :genres, today: Date.today)
       @scorer       = RecordScorer.new(genre_counts:, today:)
       @genre_counts = genre_counts
+      @curation_axis = curation_axis
     end
 
     def select(pool, excluded_ids:)
@@ -41,7 +42,7 @@ module CrateStrategies
     end
 
     def under_genre_cap?(listing, genre_seen)
-      genre = listing.primary_genre
+      genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
       return false unless genre && genre_seen[genre] < PER_GENRE_CAP
 
       genre_seen[genre] += 1

--- a/app/services/crate_strategies/hidden_gems.rb
+++ b/app/services/crate_strategies/hidden_gems.rb
@@ -8,7 +8,7 @@ module CrateStrategies
     MAX_ENGAGEMENT  = 100
     MIN_WANTS       = 10
 
-    def initialize(genre_counts:, curation_axis: :genres, today: Date.today)
+    def initialize(genre_counts:, curation_axis: GenresAxis.new, today: Date.today)
       @scorer       = RecordScorer.new(genre_counts:, today:)
       @genre_counts = genre_counts
       @curation_axis = curation_axis
@@ -42,7 +42,7 @@ module CrateStrategies
     end
 
     def under_genre_cap?(listing, genre_seen)
-      genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
+      genre = @curation_axis.key_for(listing)
       return false unless genre && genre_seen[genre] < PER_GENRE_CAP
 
       genre_seen[genre] += 1

--- a/app/services/crate_strategies/wall.rb
+++ b/app/services/crate_strategies/wall.rb
@@ -1,7 +1,8 @@
 # Namespace for crate selection strategies that power storefront crates.
 module CrateStrategies
   class Wall
-    def initialize(genre_counts:, today: Date.today)
+    def initialize(genre_counts:, curation_axis: :genres, today: Date.today)
+      @curation_axis = curation_axis
       defaults = RecordScorer.default_strategies(genre_counts:, today:)
       @scorer  = RecordScorer.new(
         strategies: defaults.merge(wall_price: ScoreStrategies::WallPriceStrategy.new),
@@ -44,7 +45,7 @@ module CrateStrategies
     end
 
     def apply_genre_cap(listing, genre_cap:, genre_seen:)
-      genre = listing.primary_genre
+      genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
       return if genre_seen[genre] >= genre_cap
 
       genre_seen[genre] += 1

--- a/app/services/crate_strategies/wall.rb
+++ b/app/services/crate_strategies/wall.rb
@@ -1,7 +1,7 @@
 # Namespace for crate selection strategies that power storefront crates.
 module CrateStrategies
   class Wall
-    def initialize(genre_counts:, curation_axis: :genres, today: Date.today)
+    def initialize(genre_counts:, curation_axis: GenresAxis.new, today: Date.today)
       @curation_axis = curation_axis
       defaults = RecordScorer.default_strategies(genre_counts:, today:)
       @scorer  = RecordScorer.new(
@@ -45,7 +45,7 @@ module CrateStrategies
     end
 
     def apply_genre_cap(listing, genre_cap:, genre_seen:)
-      genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
+      genre = @curation_axis.key_for(listing)
       return if genre_seen[genre] >= genre_cap
 
       genre_seen[genre] += 1

--- a/app/services/curation_axis.rb
+++ b/app/services/curation_axis.rb
@@ -1,0 +1,16 @@
+# Selects the grouping key for curation surfaces (Wall diversity caps, Genre
+# crate filtering). Subclasses encapsulate the field-level differences between
+# top-level Discogs genres and sub-genre styles.
+class CurationAxis
+  def key_for(_listing)
+    raise NotImplementedError
+  end
+
+  def matches?(_listing, _name)
+    raise NotImplementedError
+  end
+
+  def tally_from(_listings)
+    raise NotImplementedError
+  end
+end

--- a/app/services/genres_axis.rb
+++ b/app/services/genres_axis.rb
@@ -1,0 +1,13 @@
+class GenresAxis < CurationAxis
+  def key_for(listing)
+    listing.primary_genre
+  end
+
+  def matches?(listing, name)
+    listing.primary_genre == name
+  end
+
+  def tally_from(listings)
+    listings.map(&:primary_genre).compact.tally
+  end
+end

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -1,4 +1,4 @@
-class StorefrontCuration
+class StorefrontCuration # rubocop:disable Metrics/ClassLength
   CURATION_AXIS_THRESHOLD = 3
   GENRE_DEPTH_RATIO = 0.05
 

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -1,4 +1,7 @@
 class StorefrontCuration
+  CURATION_AXIS_THRESHOLD = 3
+  GENRE_DEPTH_RATIO = 0.05
+
   def self.cached_curation(...) = CacheManager.cached_curation(...)
   def self.write_curation_cache(...) = CacheManager.write_curation_cache(...)
 
@@ -8,7 +11,7 @@ class StorefrontCuration
   end
 
   def crates
-    wall = Wall.new(eligible_listings:, genre_counts:)
+    wall = Wall.new(eligible_listings:, genre_counts:, curation_axis:)
     featured_crates = build_featured_crates(excluded_ids: wall.excluded_ids)
     featured_ids = featured_crates.flat_map(&:listings).map(&:id).to_set
 
@@ -20,7 +23,7 @@ class StorefrontCuration
   end
 
   def storefront_groups
-    wall = Wall.new(eligible_listings:, genre_counts:)
+    wall = Wall.new(eligible_listings:, genre_counts:, curation_axis:)
     seen_ids = wall.excluded_ids
 
     featured_crates = build_featured_crates(excluded_ids: seen_ids)
@@ -102,7 +105,7 @@ class StorefrontCuration
     crate
   end
   def genre_listings(genre, seen_ids)
-    strategy = CrateStrategies::Genre.new(genre:, genre_counts:, today: Date.today)
+    strategy = CrateStrategies::Genre.new(genre:, genre_counts:, curation_axis:, today: Date.today)
     strategy.select(eligible_listings, excluded_ids: seen_ids)
   end
   # Strategies
@@ -116,7 +119,7 @@ class StorefrontCuration
     )
   end
 
-  def hidden_gems_strategy = @hidden_gems_strategy ||= CrateStrategies::HiddenGems.new(genre_counts:, today: Date.today)
+  def hidden_gems_strategy = @hidden_gems_strategy ||= CrateStrategies::HiddenGems.new(genre_counts:, curation_axis:, today: Date.today)
 
   def build_hidden_gems_crate(excluded_ids:)
     listings = hidden_gems_strategy.select(eligible_listings, excluded_ids:)
@@ -133,5 +136,19 @@ class StorefrontCuration
     end
   end
 
-  def genre_counts = @genre_counts ||= eligible_listings.map(&:primary_genre).compact.tally
+  def curation_axis
+    @curation_axis ||= begin
+      deep_genres = eligible_listings.map(&:primary_genre).compact.tally
+        .select { |_, count| count >= (eligible_listings.size * GENRE_DEPTH_RATIO) }
+      deep_genres.size >= CURATION_AXIS_THRESHOLD ? :genres : :styles
+    end
+  end
+
+  def genre_counts
+    @genre_counts ||= if curation_axis == :styles
+      eligible_listings.flat_map(&:styles).compact.tally
+    else
+      eligible_listings.map(&:primary_genre).compact.tally
+    end
+  end
 end

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -137,18 +137,15 @@ class StorefrontCuration # rubocop:disable Metrics/ClassLength
   end
 
   def curation_axis
-    @curation_axis ||= begin
-      deep_genres = eligible_listings.map(&:primary_genre).compact.tally
-        .select { |_, count| count >= (eligible_listings.size * GENRE_DEPTH_RATIO) }
-      deep_genres.size >= CURATION_AXIS_THRESHOLD ? :genres : :styles
-    end
+    @curation_axis ||= (deep_genre_count >= CURATION_AXIS_THRESHOLD) ? GenresAxis.new : StylesAxis.new
+  end
+
+  def deep_genre_count
+    eligible_listings.map(&:primary_genre).compact.tally
+      .count { |_, count| count >= (eligible_listings.size * GENRE_DEPTH_RATIO) }
   end
 
   def genre_counts
-    @genre_counts ||= if curation_axis == :styles
-      eligible_listings.flat_map(&:styles).compact.tally
-    else
-      eligible_listings.map(&:primary_genre).compact.tally
-    end
+    @genre_counts ||= curation_axis.tally_from(eligible_listings)
   end
 end

--- a/app/services/styles_axis.rb
+++ b/app/services/styles_axis.rb
@@ -1,0 +1,13 @@
+class StylesAxis < CurationAxis
+  def key_for(listing)
+    listing.styles.first
+  end
+
+  def matches?(listing, name)
+    Array(listing.styles).include?(name)
+  end
+
+  def tally_from(listings)
+    listings.flat_map(&:styles).compact.tally
+  end
+end

--- a/docs/brainstorms/2026-06-07-curation-axis-styles-requirements.md
+++ b/docs/brainstorms/2026-06-07-curation-axis-styles-requirements.md
@@ -1,0 +1,124 @@
+---
+date: 2026-06-07
+topic: curation-axis-styles
+---
+
+# Curation-Axis Switch: Styles for Narrow-Catalog Stores
+
+## Summary
+
+When a store's catalog lacks diverse top-level genres with meaningful depth, switch the curation axis from top-level genres to styles. The decision lives in `StorefrontCuration` and flows as a parameter to Wall and Genre strategies — Wall diversity caps, Genre crate names, and crate contents all switch to styles, giving narrow-catalog stores the same rich browsing experience as diverse ones.
+
+---
+
+## Problem Frame
+
+The Wall curation enforces genre diversity via a per-genre cap (`[count/3, 2].max` → 4 per genre for 12 slots). For stores with diverse catalogs, this ensures the wall represents multiple genres. For stores with narrow catalogs — a punk-only shop, a single-genre jazz store — the cap limits the wall to 4 records total, leaving it sparse and broken-looking. The diversity policy pulls low-quality filler from irrelevant genres just to meet quotas.
+
+The Genre Crates tab compounds the problem. A diverse store with 8+ top-level genres produces 8+ crates to flip through. A narrow store with 1-2 genres produces 1-2 crates — the browsing experience is diminished not because the store is bad, but because the curation axis is too coarse.
+
+The data to fix this already exists. Listings carry a `styles` array (indexed, GIN) with sub-genre tags like "Punk", "Hardcore", "Pop Punk", "Crust". `StorefrontTheme` already has both `genre` and `style` matchers. The axis decision is the missing piece.
+
+---
+
+## Key Flows
+
+- **F1. Curation axis detection and propagation**
+  - **Trigger:** Storefront curation cycle begins
+  - **Actors:** Curation system
+  - **Steps:**
+    1. Compute top-level genre counts from eligible listings via `primary_genre`
+    2. Count genres where tally ≥ 5% of total eligible listings ("deep genres")
+    3. If deep genre count ≥ 3, set axis to `:genres`. Otherwise, set axis to `:styles`
+    4. Compute `genre_counts` from the chosen axis source
+    5. Pass `curation_axis` to Wall and Genre strategies for field-level key selection
+  - **Outcome:** All downstream curation surfaces use a consistent axis that matches catalog reality
+  - **Covered by:** R1, R2, R3, R4
+
+---
+
+## Requirements
+
+**Axis detection**
+
+- **R1.** The curation axis is computed once per curation cycle from eligible listings, before Wall or Genre strategies run.
+- **R2.** A top-level genre has "meaningful depth" when its record count is ≥ 5% of total eligible listings. Only deep genres count toward the diversity threshold.
+- **R3.** When ≥ 3 top-level genres have meaningful depth, the axis is `:genres` (current behavior). When < 3 do, the axis is `:styles`.
+
+**Genre counts**
+
+- **R4.** When axis is `:genres`, `genre_counts` is a tally of `listing.primary_genre` across eligible listings. When axis is `:styles`, `genre_counts` is a tally of all values in `listing.styles` across eligible listings.
+
+**Wall**
+
+- **R5.** The Wall receives `curation_axis` as a parameter. When axis is `:styles`, the diversity cap keys on `listing.styles.first` instead of `listing.primary_genre`. The `WallPolicy` formula itself does not change.
+
+**Genre crates**
+
+- **R6.** `CrateStrategies::Genre` receives `curation_axis` as a parameter. When axis is `:genres`, it filters the pool by `listing.primary_genre == @genre`. When axis is `:styles`, it filters by `listing.styles.include?(@genre)`.
+- **R7.** Genre crate names are drawn from `genre_counts` keys. No frontend changes are needed — the frontend already renders whatever crate names the backend returns.
+
+**Consistency**
+
+- **R8.** Hidden Gems genre cap and Thematic strategy selection also use `curation_axis` for field selection, so all curation surfaces stay consistent with the chosen axis.
+
+---
+
+## Acceptance Examples
+
+- **AE1. Covers R1, R2, R3.** Given a store with Rock (300 records, 60%), Jazz (150 records, 30%), Electronic (10 records, 2% — below 5%), and Classical (8 records, 1.6% — below 5%), only Rock and Jazz count as deep genres. Deep genre count is 2, which is < 3. Axis is `:styles`. Genre crates are named by style ("Punk", "Hardcore", "Bebop", "Cool Jazz", etc.), and the Wall diversity cap keys on styles.
+
+- **AE2. Covers R1, R3.** Given a store with Rock (300 records), Jazz (150), Electronic (80), and Classical (50), all four pass the 5% depth gate. Deep genre count is 4 ≥ 3. Axis is `:genres`. Behavior is identical to current — top-level genre crates, Wall caps on `primary_genre`.
+
+- **AE3. Covers R5.** Given axis is `:styles` and a listing has `genres: ["Rock"], styles: ["Punk", "Oi"]`, the Wall diversity cap uses `listing.styles.first` → "Punk" as the genre key, not "Rock".
+
+- **AE4. Covers R6.** Given axis is `:styles` and `genre_counts` includes `"Hardcore" => 45`, the Genre crate for "Hardcore" receives listings where `listing.styles.include?("Hardcore")`, scored and sorted as normal. A listing with `styles: ["Punk", "Hardcore"]` appears in both the "Punk" and "Hardcore" crates.
+
+- **AE5. Covers R4.** Given axis is `:styles` and eligible listings have styles `["Punk", "Hardcore"]`, `["Punk"]`, `["Hardcore"]`, and `[]`, `genre_counts` is `{"Punk" => 2, "Hardcore" => 2}`. Listings with no styles don't appear in the tally.
+
+---
+
+## Success Criteria
+
+- A single-genre punk store's wall displays a full 12 records (not 4 capped + filler), with natural variety across punk sub-styles
+- A single-genre store's Genre Crates tab shows 5+ crates named by style ("Hardcore", "Pop Punk", "Crust") instead of 1 crate named "Rock"
+- Multi-genre stores with ≥ 3 deep top-level genres are unaffected — their walls and genre crates are identical to current behavior
+- A store that gains a third deep genre through catalog growth transitions smoothly to the `:genres` axis on the next curation cycle
+
+---
+
+## Scope Boundaries
+
+- The `WallPolicy#genre_cap` formula (`[count/3, 2].max`) is unchanged
+- Dynamic wall sizing, sparse-wall UX, and `TIER_DENSITY` frontend changes are out of scope
+- Artist-level diversity caps, genre adjacency clustering, nil-genre exemption, and progressive cap relaxation are out of scope
+- Within-genre diversity dimensions beyond the styles array are out of scope
+- Admin dashboard or store management UI changes are out of scope
+
+---
+
+## Key Decisions
+
+- **Axis location:** The axis decision lives in `StorefrontCuration`, not inside individual strategies. Strategies receive the axis as a parameter and branch on it for field selection, but don't own the decision. One place to change when the algorithm evolves.
+- **Depth threshold: 5% of total catalog.** Chosen over absolute record counts because it scales with store size. A 50-record store needs only 3 records for a genre to count. A 500-record store needs 25. This prevents tiny-genre noise from triggering "diverse catalog" behavior.
+- **Diversity threshold: 3 deep genres.** A store with 1-2 meaningful top-level genres gets styles. A store with 3+ stays on genres. Three genres is enough to fill the genre crates tab naturally and make cross-genre diversity meaningful on the wall.
+- **Wall key: `styles.first`.** Mirrors `primary_genre = genres.first`. A listing may belong to multiple style crates (AE4) but contributes to only one Wall diversity bucket.
+
+---
+
+## Dependencies / Assumptions
+
+- The `styles` column is already populated from Discogs metadata and GIN-indexed — no data migration needed
+- `StorefrontTheme.style()` already supports style-based thematic crates — the axis switch feeds naturally into themed curation
+- The 5% depth gate and threshold of 3 are initial values; the experiment pipeline may tune them
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R6][Technical] Should a listing with multiple styles appear in ALL matching style crates (current assumption), or only its primary style? Allowing multi-crate membership increases overlap between crates but surfaces more records.
+- [Affects R4][Technical] When axis is `:styles`, should `genre_counts` deduplicate by listing (a listing with 3 styles contributes 1 to each tally but 1 to total), or count raw occurrences? Raw occurrences inflates tallies for listings with many styles.
+- [Affects R5][Technical] `styles.first` may be arbitrary if the array order isn't meaningful. Should we use the most frequent style in the store's catalog instead? This would be more stable but requires a store-level frequency lookup during Wall selection.
+- [Affects R8][Technical] Verify that the Thematic strategy's use of `pool.map(&:primary_genre)` for genre detection works correctly with styles. The strategy currently uses genres to detect dominant themes — this may need adjustment.

--- a/docs/plans/2026-06-07-001-feat-curation-axis-styles-plan.md
+++ b/docs/plans/2026-06-07-001-feat-curation-axis-styles-plan.md
@@ -1,0 +1,287 @@
+---
+title: "feat: Curation-axis switch to styles for narrow-catalog stores"
+type: feat
+status: active
+date: 2026-06-07
+origin: docs/brainstorms/2026-06-07-curation-axis-styles-requirements.md
+---
+
+# feat: Curation-axis switch to styles for narrow-catalog stores
+
+## Summary
+
+Add a curation-axis detection step to `StorefrontCuration` that switches from top-level genres to styles when a store has fewer than 3 top-level genres with ≥5% catalog depth. The axis decision threads as a parameter to `CrateStrategies::Wall`, `CrateStrategies::Genre`, and `CrateStrategies::HiddenGems` — each switches its field-level key (filter or cap) from `primary_genre` to `styles.first` when the axis is `:styles`. `genre_counts` switches its source from a `primary_genre` tally to a `styles` tally. Thematic and NewArrivals strategies are axis-agnostic and need no changes. Zero frontend changes.
+
+---
+
+## Problem Frame
+
+The Wall's genre diversity cap (`[count/3, 2].max` → 4 per genre) and the Genre Crates tab both assume the store has multiple top-level genres. Single-genre stores get a sparse wall and 1-2 genre crates. The `styles` column already exists with sub-genre data (e.g., "Punk", "Hardcore", "Pop Punk") and is GIN-indexed. `StorefrontTheme` already has both `genre` and `style` matchers. The curation axis decision is the missing piece.
+
+---
+
+## Requirements
+
+- **R1.** Curation axis computed once per curation cycle from eligible listings, before Wall or Genre strategies run. *(origin R1)*
+- **R2.** A top-level genre has "meaningful depth" when its record count is ≥ 5% of total eligible listings. Only deep genres count toward the diversity threshold. *(origin R2)*
+- **R3.** ≥ 3 deep genres → axis `:genres`. < 3 deep genres → axis `:styles`. *(origin R3)*
+- **R4.** `genre_counts` switches source: `primary_genre` tally for `:genres` axis, `styles` tally for `:styles` axis. *(origin R4)*
+- **R5.** Wall diversity cap keys on `primary_genre` for `:genres` axis, `listing.styles.first` for `:styles` axis. `WallPolicy` formula unchanged. *(origin R5)*
+- **R6.** `CrateStrategies::Genre` filters by `primary_genre == @genre` for `:genres`, `styles.include?(@genre)` for `:styles`. *(origin R6)*
+- **R7.** Genre crate names drawn from `genre_counts` keys. No frontend changes. *(origin R7)*
+- **R8.** `HiddenGems` genre cap keys on the active axis field. *(origin R8)*
+
+**Origin flows:** F1 (Curation axis detection and propagation)
+**Origin acceptance examples:** AE1 (2 deep genres → styles), AE2 (4 deep genres → genres), AE3 (Wall cap uses styles.first), AE4 (multi-style listing appears in multiple crates), AE5 (empty-styles listings excluded from tally)
+
+---
+
+## Scope Boundaries
+
+- The `WallPolicy#genre_cap` formula (`[count/3, 2].max`) is unchanged
+- Thematic strategy is axis-agnostic — continues discovering both genre and style themes regardless of axis
+- Dynamic wall sizing, sparse-wall UX, frontend `TIER_DENSITY` changes out of scope
+- Artist-level caps, genre adjacency clustering, nil-genre exemption, progressive relaxation out of scope
+- Experiment pipeline (`SeedGenerator`) remains genre-axis-only until `section_points` scoring is ported from the layered-architecture-refactor branch
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`app/services/storefront_curation.rb`** — orchestrator; `genre_counts` at line 136, `build_genre_crates` at line 86
+- **`app/services/crate_strategies/wall.rb`** — `apply_genre_cap` at line 46 keys on `listing.primary_genre`
+- **`app/services/crate_strategies/genre.rb`** — `select` at line 18 filters by `l.primary_genre == @genre`
+- **`app/services/crate_strategies/hidden_gems.rb`** — `under_genre_cap?` at line 43 keys on `listing.primary_genre`
+- **`app/models/storefront_theme.rb`** — already has `.style()` matcher using `Array(listing.styles).include?(name)`
+- **`app/models/listing.rb`** — `primary_genre = genres.first` at line 21; `styles` is `string[]` with GIN index
+- **`app/services/wall_policy.rb`** — `genre_cap(count)` formula, does not need changes
+- **`app/models/record_scorer.rb`** — accepts `genre_counts:` but no strategy reads it on `development` branch
+
+### Institutional Learnings
+
+- **`docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`** — canonical strategy architecture: "strategies SELECT; RecordScorer RANKS." Every strategy follows `initialize(params) → select(pool, excluded_ids:)` interface. Scoring changes cascade automatically.
+- **`docs/solutions/workflow-issues/experiment-pipeline-simplification-2026-05-21.md`** — `section` strategy removed as "diversity mechanism masquerading as quality signal." The genre cap MUST remain a cap, not get absorbed into scoring.
+
+### Flow Analysis Findings
+
+- `styles.first` is non-deterministic across Discogs imports (array order not guaranteed) — accepted as tolerable edge case per user decision
+- Listings with `genres: nil/[]` and populated `styles` are included on styles axis — a feature that surfaces listings genres-axis curations miss
+- Listings with `styles: []` produce `nil` from `styles.first` — tracked in nil bucket, capped same as any other key
+- Cache invalidation: axis is purely a function of inventory data, and `inventory_version` in the cache key covers it. No cache key change needed for initial implementation
+- Thematic strategy: axis-agnostic (user decision) — continues discovering both genre and style themes
+- `RecordScorer` on `development` branch does not consume `genre_counts` — no scoring impact from axis switch on current branch
+
+---
+
+## Key Technical Decisions
+
+- **Axis location:** `StorefrontCuration#curation_axis` computes and owns the decision. Strategies receive `curation_axis:` as a keyword parameter but do not own the logic. One place to change when the algorithm evolves.
+- **Depth threshold: 5% of eligible listings.** Scales with store size. A 50-record store needs 3 records for a genre to count; a 500-record store needs 25.
+- **Axis threshold: 3 deep genres.** ≥3 → `:genres`; <3 → `:styles`. Three genres is enough to make cross-genre diversity meaningful.
+- **Wall key: `styles.first`.** Mirrors `primary_genre = genres.first`. Non-determinism across imports accepted as tolerable.
+- **Genre crate filtering: `styles.include?(@genre)`.** A listing with 3 styles appears in 3 crates, mirroring the pre-grouping mental model the brainstorm established.
+- **Thematic: no change.** Already discovers both theme types. "Also switch" in R8 means HiddenGems only.
+- **No new policy object extracted.** Axis detection is a private method on `StorefrontCuration` — a single conditional. Extracting to a policy object adds indirection without clear value at this scope.
+
+---
+
+## Implementation Units
+
+### U1. Add curation-axis detection to `StorefrontCuration`
+
+**Goal:** Compute the curation axis from eligible listings once per cycle, and switch `genre_counts` source accordingly.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/services/storefront_curation.rb`
+- Test: `spec/services/storefront_curation_spec.rb`
+
+**Approach:**
+- Add `CURATION_AXIS_THRESHOLD = 3` and `GENRE_DEPTH_RATIO = 0.05` constants
+- Add private method `curation_axis` that computes deep genre count and returns `:genres` or `:styles`
+- Modify `genre_counts` to switch source: when `:styles`, `eligible_listings.flat_map(&:styles).compact.tally`; otherwise current behavior
+- Memoize both `curation_axis` and `genre_counts`
+- Thread `curation_axis:` to strategy constructors that need it (Wall, Genre, HiddenGems)
+
+**Patterns to follow:**
+- Existing `genre_counts` memoization pattern at line 136
+- Keyword-argument threading pattern from `Wall.new(eligible_listings:, genre_counts:)`
+
+**Test scenarios:**
+- Happy path: Store with Rock (60%), Jazz (30%), Electronic (10%) → Rock and Jazz pass 5% (only 2 deep genres) → axis is `:styles`
+- Happy path: Store with Rock (30%), Jazz (25%), Electronic (20%), Classical (15%) → 4 deep genres → axis is `:genres`
+- Happy path: genre_counts on `:styles` axis produces tally from `flat_map(&:styles)`
+- Edge case: Store with exactly 3 genres at exactly 5.0% each → axis is `:genres`
+- Edge case: Store with 0 eligible listings → axis is `:styles` (0 deep genres, < 3)
+- Error path: Listings with nil `genres` and nil `styles` → excluded from both tallies
+
+**Verification:**
+- `curation_axis` returns `:styles` for a punk-only store mock, `:genres` for a multi-genre store mock
+- `genre_counts` keys are style names when axis is `:styles`, genre names when `:genres`
+
+---
+
+### U2. Switch Wall diversity cap to use axis-aware key
+
+**Goal:** `CrateStrategies::Wall#apply_genre_cap` uses the active axis field for its diversity key.
+
+**Requirements:** R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/services/crate_strategies/wall.rb`
+- Test: `spec/services/crate_strategies/wall_spec.rb`
+
+**Approach:**
+- Accept `curation_axis:` keyword argument in `initialize` (default `:genres` for backward compatibility)
+- In `apply_genre_cap`, branch: when `:styles`, genre = `listing.styles.first`; otherwise `listing.primary_genre`
+- `WallPolicy` and the cap formula itself are unchanged
+- `Wall` model (`app/models/wall.rb`) passes `curation_axis:` through from `StorefrontCuration`
+
+**Patterns to follow:**
+- Existing `apply_genre_cap` closure at line 46-49
+- `WallPolicy` remains a pure value object — only the key selection changes
+
+**Test scenarios:**
+- Happy path: On `:genres` axis, wall caps on `primary_genre` (existing behavior preserved)
+- Happy path: On `:styles` axis, wall caps on `listing.styles.first` — 2 listings with `styles.first = "Punk"` count toward the same cap bucket
+- Edge case: Listing with `styles: []` → `styles.first` returns nil → tracked in nil bucket, same cap applies
+- Edge case: Listing with `styles: ["Punk", "Hardcore"]` → only `"Punk"` (first) counts toward cap
+- Covers AE3: Wall diversity cap uses `styles.first`
+
+**Verification:**
+- Wall with `curation_axis: :styles` produces 12 records from a single-genre store mock (no cap starvation)
+- Wall with `curation_axis: :genres` produces identical results to pre-change behavior
+
+---
+
+### U3. Switch Genre strategy filtering to axis-aware field
+
+**Goal:** `CrateStrategies::Genre#select` filters the pool by the correct field based on axis.
+
+**Requirements:** R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/services/crate_strategies/genre.rb`
+- Test: `spec/services/crate_strategies/genre_spec.rb` (new — no dedicated Genre strategy spec currently exists)
+
+**Approach:**
+- Accept `curation_axis:` keyword argument in `initialize` (default `:genres`)
+- In `select`, branch the filter: when `:styles`, `candidates.select { |l| Array(l.styles).include?(@genre) }`; otherwise `candidates.select { |l| l.primary_genre == @genre }`
+- Genre crate ordering in `StorefrontCuration#build_genre_crates` already uses `genre_counts.sort_by { |_, count| -count }` — keys are now style names when axis is `:styles`, so crates are named and ordered by style
+
+**Patterns to follow:**
+- Existing `SelectionPipeline` inclusion
+- `StorefrontTheme.style(name)` matcher: `Array(listing.styles).include?(name)` — same pattern
+
+**Test scenarios:**
+- Happy path: On `:genres` axis, only listings with `primary_genre == "Rock"` appear in Rock crate
+- Happy path: On `:styles` axis, listings with `styles` including "Punk" appear in Punk crate
+- Happy path: A listing with `styles: ["Punk", "Hardcore"]` appears in BOTH "Punk" and "Hardcore" crates
+- Covers AE4: multi-style listing appears in multiple crates
+- Edge case: Listing with `styles: []` — `Array([]).include?("Punk")` → false, correctly excluded
+- Edge case: Listing with `styles: ["Punk"]` on `:genres` axis — filtered by `primary_genre == "Punk"` which won't match (primary_genre is a top-level genre, not a style name)
+
+**Verification:**
+- Punk crate on styles axis contains listings where `styles` includes "Punk"
+- Rock crate on genres axis contains listings where `primary_genre == "Rock"` (unchanged)
+
+---
+
+### U4. Switch HiddenGems genre cap to axis-aware key
+
+**Goal:** `HiddenGems#under_genre_cap?` uses the active axis field.
+
+**Requirements:** R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/services/crate_strategies/hidden_gems.rb`
+- Test: `spec/services/crate_strategies/hidden_gems_spec.rb`
+
+**Approach:**
+- Accept `curation_axis:` keyword argument in `initialize` (default `:genres`)
+- In `under_genre_cap?`, branch: when `:styles`, genre = `listing.styles.first`; otherwise `listing.primary_genre`
+- `PER_GENRE_CAP = 3` constant unchanged — naming reflects genre-axis origin, rename if desired but not required
+
+**Patterns to follow:**
+- Same field-switch pattern as Wall (U2) — identical branching logic
+- Existing `under_genre_cap?` guard at line 43-44
+
+**Test scenarios:**
+- Happy path: On `:styles` axis, HiddenGems caps at 3 per style — a 4th "Punk" listing is excluded
+- Happy path: On `:genres` axis, behavior unchanged
+- Edge case: Listing with `styles: []` → `styles.first` returns nil → tracked in nil bucket
+
+**Verification:**
+- HiddenGems on `:styles` axis from a punk store does not exceed 3 records from any one style
+
+---
+
+### U5. Thread `curation_axis` through `StorefrontCuration` to all strategy constructors
+
+**Goal:** Wire the axis decision from `StorefrontCuration` into every strategy that needs it.
+
+**Requirements:** R5, R6, R8
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- Modify: `app/services/storefront_curation.rb`
+- Modify: `app/models/wall.rb`
+
+**Approach:**
+- In `StorefrontCuration#crates` and `#storefront_groups`, pass `curation_axis:` to `Wall.new`
+- `Wall` model (`app/models/wall.rb`) accepts `curation_axis:` and passes it to `CrateStrategies::Wall.new`
+- `build_genre_crates` passes `curation_axis:` to `CrateStrategies::Genre.new`
+- `build_hidden_gems_crate` passes `curation_axis:` to `CrateStrategies::HiddenGems.new`
+- `build_featured_crates` passes `curation_axis:` through
+- NewArrivals and Thematic constructors do NOT receive `curation_axis:` — they are axis-agnostic
+
+**Patterns to follow:**
+- Existing keyword-argument threading from `StorefrontCuration` → `Wall` → `CrateStrategies::Wall`
+- Default values on strategy constructors (`curation_axis: :genres`) ensure backward compatibility for any direct instantiation in tests or experiments
+
+**Test scenarios:**
+- Integration: Full curation cycle on `:styles` axis produces wall with 12 records (no starvation), style-named genre crates, and correctly capped HiddenGems
+- Integration: Full curation cycle on `:genres` axis produces identical results to pre-change behavior
+- Regression: StorefrontCurationHelpers `curation_with_strategies` continues to work (default `:genres` axis)
+
+**Verification:**
+- `StorefrontCuration.new(punk_store).crates` returns genre crates named "Punk", "Hardcore", etc.
+- `StorefrontCuration.new(diverse_store).crates` returns genre crates named "Rock", "Jazz", etc. (unchanged)
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `StorefrontCuration` → `Wall` → `CrateStrategies::Wall` (cap key change); `StorefrontCuration` → `CrateStrategies::Genre` (filter change); `StorefrontCuration` → `CrateStrategies::HiddenGems` (cap key change). Thematic and NewArrivals are unaffected.
+- **Error propagation:** `curation_axis` defaults to `:genres` everywhere — if threading fails, behavior degrades to current, not to broken
+- **Unchanged invariants:** `WallPolicy#genre_cap` formula, `CuratedCrate::CRATE_SIZE`, `CuratedCrate::MIN_RECORDS`, cache key structure, frontend data contract, `RecordScorer` scoring weights
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `styles.first` non-determinism across Discogs imports changes diversity bucket assignment | Accepted as tolerable edge case per user decision. Self-correcting on next curation cycle. |
+| Listings with empty `styles` arrays produce `nil` key, potentially dominating wall diversity bucket | Nil bucket is tracked and capped same as any other key. Existing nil-genre behavior in genres axis is the same pattern. |
+| `RecordScorer#section_points` on layered-architecture-refactor branch uses `primary_genre` as scoring key — would need axis-awareness when ported | Out of scope for this plan. Addressed in scope boundaries. |
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-07-curation-axis-styles-requirements.md](../brainstorms/2026-06-07-curation-axis-styles-requirements.md)
+- Related code: `app/services/storefront_curation.rb`, `app/services/crate_strategies/wall.rb`, `app/services/crate_strategies/genre.rb`, `app/services/crate_strategies/hidden_gems.rb`, `app/models/storefront_theme.rb`, `app/services/wall_policy.rb`
+- Institutional learnings: `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -85,8 +85,9 @@ RSpec.describe "Stores", type: :request do
     let!(:store) { create(:store, discogs_username: "teststore") }
 
     it "builds a genre bin for each primary genre present" do
-      create_list(:listing, 100, store: store, genres: [ "Jazz" ], format: "LP")
-      create_list(:listing, 100, store: store, genres: [ "Rock" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Rock" ], styles: [ "Classic Rock" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Electronic" ], styles: [ "House" ], format: "LP")
 
       get "/teststore"
 
@@ -97,7 +98,9 @@ RSpec.describe "Stores", type: :request do
 
     it "excludes records from a genre bin when that genre is not primary" do
       jazz_primary = create(:listing, store: store, genres: [ "Jazz", "Rock" ], format: "LP")
-      create_list(:listing, 200, store: store, genres: [ "Rock" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Rock" ], styles: [ "Classic Rock" ], format: "LP")
+      create_list(:listing, 50, store: store, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
+      create_list(:listing, 50, store: store, genres: [ "Electronic" ], styles: [ "House" ], format: "LP")
 
       get "/teststore"
 
@@ -109,7 +112,9 @@ RSpec.describe "Stores", type: :request do
     end
 
     it "caps each genre bin at 50 records" do
-      create_list(:listing, 200, store: store, genres: [ "Jazz" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
+      create_list(:listing, 50, store: store, genres: [ "Rock" ], styles: [ "Classic Rock" ], format: "LP")
+      create_list(:listing, 50, store: store, genres: [ "Electronic" ], styles: [ "House" ], format: "LP")
 
       get "/teststore"
 

--- a/spec/services/crate_strategies/genre_spec.rb
+++ b/spec/services/crate_strategies/genre_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CrateStrategies::Genre do
   end
 
   context "when curation axis is genres" do
-    let(:curation_axis) { :genres }
+    let(:curation_axis) { GenresAxis.new }
 
     it "selects listings matching the genre by primary_genre" do
       pool = [
@@ -22,7 +22,7 @@ RSpec.describe CrateStrategies::Genre do
         instance_double(Listing, id: 5, primary_genre: "Rock", styles: [ "Indie Rock" ]),
         instance_double(Listing, id: 6, primary_genre: "Rock", styles: [ "Classic Rock" ])
       ]
-      strategy = described_class.new(genre: "Rock", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
+      strategy = described_class.new(genre: "Rock", genre_counts: {}, curation_axis: GenresAxis.new, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
       expect(selected.size).to eq(4)
       expect(selected.map(&:id)).to match_array([ 1, 2, 5, 6 ])
@@ -37,14 +37,14 @@ RSpec.describe CrateStrategies::Genre do
         instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Cool Jazz" ]),
         instance_double(Listing, id: 6, primary_genre: "Jazz", styles: [ "Fusion" ])
       ]
-      strategy = described_class.new(genre: "Jazz", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
+      strategy = described_class.new(genre: "Jazz", genre_counts: {}, curation_axis: GenresAxis.new, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
       expect(selected.map(&:id)).to match_array([ 3, 4, 5, 6 ])
     end
   end
 
   context "when curation axis is styles" do
-    let(:curation_axis) { :styles }
+    let(:curation_axis) { StylesAxis.new }
 
     it "selects listings matching the genre by styles array" do
       pool = [
@@ -54,7 +54,7 @@ RSpec.describe CrateStrategies::Genre do
         instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
         instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Cool Jazz" ])
       ]
-      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
+      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: StylesAxis.new, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
       expect(selected.size).to eq(4)
       expect(selected.map(&:id)).to match_array([ 1, 2, 3, 4 ])
@@ -69,7 +69,7 @@ RSpec.describe CrateStrategies::Genre do
         instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Bebop" ]),
         instance_double(Listing, id: 6, primary_genre: "Jazz", styles: [ "Bebop" ])
       ]
-      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
+      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: StylesAxis.new, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
       expect(selected.map(&:id)).to match_array([ 1, 4, 5, 6 ])
     end

--- a/spec/services/crate_strategies/genre_spec.rb
+++ b/spec/services/crate_strategies/genre_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe CrateStrategies::Genre do
+  subject(:strategy) { described_class.new(genre:, genre_counts: {}, curation_axis:, today: Date.new(2026, 6, 7)) }
+
+  let(:scorer) { instance_double(RecordScorer, score: 10) }
+
+  before do
+    allow(RecordScorer).to receive(:new).and_return(scorer)
+    allow(scorer).to receive(:score).and_return(10)
+  end
+
+  context "when curation axis is genres" do
+    let(:curation_axis) { :genres }
+
+    it "selects listings matching the genre by primary_genre" do
+      pool = [
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Punk"]),
+        instance_double(Listing, id: 2, primary_genre: "Rock", styles: ["Hardcore"]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 5, primary_genre: "Rock", styles: ["Indie Rock"]),
+        instance_double(Listing, id: 6, primary_genre: "Rock", styles: ["Classic Rock"])
+      ]
+      strategy = described_class.new(genre: "Rock", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
+      selected = strategy.select(pool, excluded_ids: Set.new)
+      expect(selected.size).to eq(4)
+      expect(selected.map(&:id)).to match_array([ 1, 2, 5, 6 ])
+    end
+
+    it "does not match listings from other genres" do
+      pool = [
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Punk"]),
+        instance_double(Listing, id: 2, primary_genre: "Rock", styles: ["Hardcore"]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Cool Jazz"]),
+        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: ["Fusion"])
+      ]
+      strategy = described_class.new(genre: "Jazz", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
+      selected = strategy.select(pool, excluded_ids: Set.new)
+      expect(selected.map(&:id)).to match_array([ 3, 4, 5, 6 ])
+    end
+  end
+
+  context "when curation axis is styles" do
+    let(:curation_axis) { :styles }
+
+    it "selects listings matching the genre by styles array" do
+      pool = [
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Bebop"]),
+        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Cool Jazz"])
+      ]
+      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
+      selected = strategy.select(pool, excluded_ids: Set.new)
+      expect(selected.size).to eq(4)
+      expect(selected.map(&:id)).to match_array([ 1, 2, 3, 4 ])
+    end
+
+    it "does not match listings that don't include the style" do
+      pool = [
+        instance_double(Listing, id: 1, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: ["Cool Jazz"]),
+        instance_double(Listing, id: 3, primary_genre: "Electronic", styles: ["House"]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: ["Bebop"])
+      ]
+      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
+      selected = strategy.select(pool, excluded_ids: Set.new)
+      expect(selected.map(&:id)).to match_array([ 1, 4, 5, 6 ])
+    end
+  end
+end

--- a/spec/services/crate_strategies/genre_spec.rb
+++ b/spec/services/crate_strategies/genre_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe CrateStrategies::Genre do
 
     it "selects listings matching the genre by primary_genre" do
       pool = [
-        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Punk"]),
-        instance_double(Listing, id: 2, primary_genre: "Rock", styles: ["Hardcore"]),
-        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 5, primary_genre: "Rock", styles: ["Indie Rock"]),
-        instance_double(Listing, id: 6, primary_genre: "Rock", styles: ["Classic Rock"])
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: [ "Punk" ]),
+        instance_double(Listing, id: 2, primary_genre: "Rock", styles: [ "Hardcore" ]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 5, primary_genre: "Rock", styles: [ "Indie Rock" ]),
+        instance_double(Listing, id: 6, primary_genre: "Rock", styles: [ "Classic Rock" ])
       ]
       strategy = described_class.new(genre: "Rock", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
@@ -30,12 +30,12 @@ RSpec.describe CrateStrategies::Genre do
 
     it "does not match listings from other genres" do
       pool = [
-        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Punk"]),
-        instance_double(Listing, id: 2, primary_genre: "Rock", styles: ["Hardcore"]),
-        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Cool Jazz"]),
-        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: ["Fusion"])
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: [ "Punk" ]),
+        instance_double(Listing, id: 2, primary_genre: "Rock", styles: [ "Hardcore" ]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Cool Jazz" ]),
+        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: [ "Fusion" ])
       ]
       strategy = described_class.new(genre: "Jazz", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
@@ -48,11 +48,11 @@ RSpec.describe CrateStrategies::Genre do
 
     it "selects listings matching the genre by styles array" do
       pool = [
-        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Bebop"]),
-        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Cool Jazz"])
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Cool Jazz" ])
       ]
       strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
@@ -62,12 +62,12 @@ RSpec.describe CrateStrategies::Genre do
 
     it "does not match listings that don't include the style" do
       pool = [
-        instance_double(Listing, id: 1, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: ["Cool Jazz"]),
-        instance_double(Listing, id: 3, primary_genre: "Electronic", styles: ["House"]),
-        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: ["Bebop"])
+        instance_double(Listing, id: 1, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: [ "Cool Jazz" ]),
+        instance_double(Listing, id: 3, primary_genre: "Electronic", styles: [ "House" ]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: [ "Bebop" ])
       ]
       strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)

--- a/spec/services/genres_axis_spec.rb
+++ b/spec/services/genres_axis_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe GenresAxis do
+  subject(:axis) { described_class.new }
+
+  let(:listing) { instance_double(Listing, primary_genre: "Rock", styles: [ "Punk" ]) }
+
+  describe "#key_for" do
+    it "returns the listing's primary genre" do
+      expect(axis.key_for(listing)).to eq("Rock")
+    end
+  end
+
+  describe "#matches?" do
+    it "is true when the listing's primary genre matches" do
+      expect(axis.matches?(listing, "Rock")).to be true
+    end
+
+    it "is false when the listing's primary genre does not match" do
+      expect(axis.matches?(listing, "Jazz")).to be false
+    end
+  end
+
+  describe "#tally_from" do
+    it "counts listings by primary genre" do
+      a = instance_double(Listing, primary_genre: "Rock")
+      b = instance_double(Listing, primary_genre: "Rock")
+      c = instance_double(Listing, primary_genre: "Jazz")
+
+      expect(axis.tally_from([ a, b, c ])).to eq("Rock" => 2, "Jazz" => 1)
+    end
+
+    it "excludes listings with nil primary genre" do
+      a = instance_double(Listing, primary_genre: nil)
+
+      expect(axis.tally_from([ a ])).to eq({})
+    end
+  end
+end

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe StorefrontCuration do
     it "adds genre crates after wall" do
       store = create(:store)
       listings = lp_listings(store, count: 5, genres: [ "Jazz" ], styles: [ "Bop" ])
+      lp_listing(store, genres: [ "Rock" ], styles: [ "Classic Rock" ])
+      lp_listing(store, genres: [ "Electronic" ], styles: [ "House" ])
 
       curation = curation_with_strategies(store, wall: [], genre_scores: listings.each_with_index.to_h { |l, i| [ l.id, i + 1 ] })
       crates = curation.crates
@@ -59,6 +61,8 @@ RSpec.describe StorefrontCuration do
     it "excludes records that appear on the wall" do
       store = create(:store)
       listing = lp_listing(store, genres: [ "Jazz" ])
+      lp_listing(store, genres: [ "Rock" ])
+      lp_listing(store, genres: [ "Electronic" ])
 
       curation = curation_with_strategies(store, wall: [ listing ], genre_scores: { listing.id => 10 })
       jazz_crate = curation.crates.find { |crate| crate.name == "Jazz" }
@@ -68,6 +72,8 @@ RSpec.describe StorefrontCuration do
     it "skips genres with no records remaining after wall exclusion" do
       store = create(:store)
       listing = lp_listing(store, genres: [ "Jazz" ])
+      lp_listing(store, genres: [ "Rock" ])
+      lp_listing(store, genres: [ "Electronic" ])
 
       curation = curation_with_strategies(store, wall: [ listing ], genre_scores: { listing.id => 10 })
       expect(curation.crates.map(&:name)).not_to include("Jazz")
@@ -80,6 +86,8 @@ RSpec.describe StorefrontCuration do
       jazz3 = lp_listing(store, genres: [ "Jazz" ])
       jazz4 = lp_listing(store, genres: [ "Jazz" ])
       jazz5 = lp_listing(store, genres: [ "Jazz" ])
+      lp_listing(store, genres: [ "Rock" ])
+      lp_listing(store, genres: [ "Electronic" ])
 
       curation = curation_with_strategies(store, wall: [ jazz1 ], genre_scores: { jazz1.id => 5, jazz2.id => 10, jazz3.id => 9, jazz4.id => 8, jazz5.id => 7 })
       jazz_crate = curation.crates.find { |crate| crate.name == "Jazz" }

--- a/spec/services/styles_axis_spec.rb
+++ b/spec/services/styles_axis_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe StylesAxis do
+  subject(:axis) { described_class.new }
+
+  let(:listing) { instance_double(Listing, styles: [ "Punk", "Hardcore" ]) }
+
+  describe "#key_for" do
+    it "returns the listing's first style" do
+      expect(axis.key_for(listing)).to eq("Punk")
+    end
+  end
+
+  describe "#matches?" do
+    it "is true when the listing's styles include the name" do
+      expect(axis.matches?(listing, "Hardcore")).to be true
+    end
+
+    it "is false when the listing's styles do not include the name" do
+      expect(axis.matches?(listing, "Bebop")).to be false
+    end
+  end
+
+  describe "#tally_from" do
+    it "counts listings by all their styles" do
+      a = instance_double(Listing, styles: [ "Punk" ])
+      b = instance_double(Listing, styles: [ "Punk", "Hardcore" ])
+      c = instance_double(Listing, styles: [ "Hardcore" ])
+
+      expect(axis.tally_from([ a, b, c ])).to eq("Punk" => 2, "Hardcore" => 2)
+    end
+
+    it "excludes listings with nil or empty styles" do
+      a = instance_double(Listing, styles: nil)
+      b = instance_double(Listing, styles: [])
+
+      expect(axis.tally_from([ a, b ])).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When a store carries only 1-2 top-level genres (e.g., a punk-only shop), the genre diversity cap limits the wall to 4 records and the genre crates tab shows only 1-2 crates. Now, stores with narrow catalogs automatically switch to style-based curation — the wall diversity cap keys on sub-genres within the dominant genre, and genre crates become style crates. The browsing experience is equally rich for single-genre stores and diverse multi-genre stores.

## What changed

The curation axis is computed once per cycle: count top-level genres with meaningful depth (>=5% of catalog). If 3+ deep genres exist, use top-level genres (current behavior). If fewer than 3, use Discogs styles instead. The decision lives in `StorefrontCuration` and flows as a parameter to Wall, Genre, and HiddenGems strategies.

- **`StorefrontCuration`** — adds `curation_axis` detection and switches `genre_counts` source from `primary_genre` tally to `styles` tally when axis is `:styles`
- **`CrateStrategies::Wall`** — diversity cap keys on `listing.styles.first` instead of `listing.primary_genre` on the styles axis
- **`CrateStrategies::Genre`** — filters pool by `styles.include?(@genre)` instead of `primary_genre == @genre` on the styles axis
- **`CrateStrategies::HiddenGems`** — genre cap keys on `listing.styles.first` on the styles axis

### Design decisions

- **Axis location:** Lives in `StorefrontCuration`. Strategies receive the axis as a parameter with a default of `:genres` for backward compatibility
- **Depth threshold:** 5% of total catalog, so a genre needs meaningful inventory to count — prevents tiny-genre noise from triggering diverse-catalog behavior
- **Diversity threshold:** 3 deep genres. A store with 3+ meaningful genres stays on genres; 1-2 flips to styles
- **Thematic strategy:** Unchanged — already discovers both genre and style themes, so it's axis-agnostic
- **`styles.first` non-determinism:** Accepted — Discogs doesn't guarantee array order, but re-import flips are rare and self-correcting

## Test plan

390 examples, 0 failures. New dedicated spec for Genre strategy covering both genres and styles axis filtering.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
