### PR TITLE
Release: Curation-axis style selection for narrow-catalog stores

### DIFF
--- a/app/models/style_selection.rb
+++ b/app/models/style_selection.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+# Classifies Discogs styles for a narrow-catalog store into four tiers:
+# main, rotation, suppressed, and omitted. Computed once per curation
+# instance from eligible listings and consumed by StylesAxis for crate
+# allocation, display ordering, and thematic candidate filtering.
+class StyleSelection
+  # Percentage of eligible listings required for a style to qualify as main.
+  MAIN_THRESHOLD = 0.05
+  # Percentage of eligible listings required for a rotation candidate.
+  ROTATION_THRESHOLD = 0.01
+  # Minimum share of overlapping non-broad listings needed to suppress a broad style.
+  SUPPRESSION_RATIO = 0.75
+
+  # Curated set of broad Discogs style names that may be suppressed when
+  # redundant with more specific styles. This list is intentionally small
+  # and documented; seller customization is deferred to follow-up work.
+  BROAD_STYLES = %w[
+    Blues\ Rock
+    Classic\ Rock
+    Hard\ Rock
+    Pop\ Rock
+    Rock\ &\ Roll
+  ].freeze
+
+  attr_reader :total_listings
+
+  # listings - Array of Listing objects eligible for the current curation.
+  def initialize(listings)
+    @listings = listings
+    @total_listings = listings.size.to_f
+  end
+
+  # Deduplicated style → count, normalized per listing (one contribution max).
+  def support
+    @support ||= build_support
+  end
+
+  # Styles that meet the main threshold and are not suppressed broad labels.
+  def main_styles
+    @main_styles ||= support.select { |name, count|
+      count >= main_floor && count >= main_threshold && !suppressed?(name)
+    }.keys.sort
+  end
+
+  # Map of main style name → overlap risk (share of its listings also
+  # tagged with a higher-support main style). Used for allocation ordering.
+  def overlap_risk
+    @overlap_risk ||= compute_overlap_risk
+  end
+
+  # Allocation order for main styles: highest overlap risk first, then
+  # lowest support, then name (stable tie-breaker).
+  def allocation_order
+    @allocation_order ||= main_styles.sort_by { |name|
+      [-overlap_risk.fetch(name, 0), support.fetch(name, 0), name]
+    }
+  end
+
+  # Display order: highest support first, then name.
+  def display_order
+    @display_order ||= main_styles.sort_by { |name|
+      [-support.fetch(name, 0), name]
+    }
+  end
+
+  # Main style counts (suppressed and omitted styles excluded).
+  def main_counts
+    @main_counts ||= main_styles.each_with_object({}) { |name, h|
+      h[name] = support.fetch(name, 0)
+    }
+  end
+
+  # Rotation-tier style names (non-main, non-suppressed, non-omitted).
+  def rotation_styles
+    @rotation_styles ||= support.select { |name, count|
+      next false if main_styles.include?(name)
+      next false if suppressed?(name)
+      count >= rotation_floor && count >= rotation_threshold
+    }.keys.sort
+  end
+
+  private
+
+  def build_support
+    counts = Hash.new(0)
+    @listings.each do |listing|
+      Array(listing.styles).compact.uniq.each { |style| counts[style] += 1 }
+    end
+    counts
+  end
+
+  # Non-broad styles that meet the rotation threshold (before suppression
+  # is applied). Used as the "qualifying" set for broad-style suppression.
+  def qualifying_non_broad_styles
+    @qualifying_non_broad_styles ||= support.select { |name, count|
+      next false if BROAD_STYLES.include?(name)
+      count >= rotation_floor && count >= rotation_threshold
+    }.keys
+  end
+
+  def suppressed?(name)
+    suppressed_styles.include?(name)
+  end
+
+  def suppressed_styles
+    @suppressed_styles ||= compute_suppressed
+  end
+
+  def compute_suppressed
+    return Set.new if qualifying_non_broad_styles.empty?
+
+    BROAD_STYLES.each_with_object(Set.new) do |broad, set|
+      broad_count = support[broad]
+      next if broad_count.nil? || broad_count.zero?
+
+      overlap_count = count_broad_overlap(broad)
+      next if overlap_count.to_f / broad_count < SUPPRESSION_RATIO
+
+      set.add(broad)
+    end
+  end
+
+  def count_broad_overlap(broad)
+    @listings.count do |listing|
+      styles = Array(listing.styles).compact
+      next false unless styles.include?(broad)
+
+      (styles & qualifying_non_broad_styles).any?
+    end
+  end
+
+  def compute_overlap_risk
+    ordered = main_styles.sort_by { |name| [-support.fetch(name, 0), name] }
+    risks = {}
+
+    ordered.each_with_index do |style, idx|
+      higher = ordered[0...idx]
+      next if higher.empty?
+
+      style_listings = listings_with_style(style)
+      next if style_listings.empty?
+
+      overlap_count = style_listings.count { |l|
+        (Array(l.styles).compact & higher).any?
+      }
+      risks[style] = overlap_count.to_f / style_listings.size
+    end
+
+    risks
+  end
+
+  def listings_with_style(style)
+    @listings.select { |l| Array(l.styles).compact.include?(style) }
+  end
+
+  def main_floor
+    CuratedCrate::MIN_RECORDS
+  end
+
+  def rotation_floor
+    CuratedCrate::MIN_RECORDS
+  end
+
+  def main_threshold
+    (total_listings * MAIN_THRESHOLD).ceil
+  end
+
+  def rotation_threshold
+    (total_listings * ROTATION_THRESHOLD).ceil
+  end
+end

--- a/app/models/style_selection.rb
+++ b/app/models/style_selection.rb
@@ -108,7 +108,8 @@ class StyleSelection
   def compute_overlap_risk
     ordered = main_styles_by_support
     ordered.each_with_object({}).with_index { |(style, risks), idx|
-      add_overlap_entry(style, ordered[0...idx], risks)
+      higher = ordered[0...idx].select { |candidate| support.fetch(candidate, 0) > support.fetch(style, 0) }
+      add_overlap_entry(style, higher, risks)
     }
   end
 

--- a/app/models/style_selection.rb
+++ b/app/models/style_selection.rb
@@ -1,22 +1,13 @@
 # frozen_string_literal: true
 
-# Classifies Discogs styles for a narrow-catalog store into four tiers:
-# main, rotation, suppressed, and omitted. Computed once per curation
-# instance from eligible listings and consumed by StylesAxis for crate
-# allocation, display ordering, and thematic candidate filtering.
+# Classifies Discogs styles for a narrow-catalog store into three tiers:
+# main, rotation, and omitted. Computed once per curation instance from
+# eligible listings and consumed by StylesAxis for crate allocation,
+# display ordering, and thematic candidate filtering.
 class StyleSelection
   MAIN_THRESHOLD = 0.05
   ROTATION_THRESHOLD = 0.01
-  SUPPRESSION_RATIO = 0.75
   MIN_RECORDS = CuratedCrate::MIN_RECORDS
-
-  BROAD_STYLES = %w[
-    Blues\ Rock
-    Classic\ Rock
-    Hard\ Rock
-    Pop\ Rock
-    Rock\ &\ Roll
-  ].freeze
 
   attr_reader :total_listings
 
@@ -31,7 +22,7 @@ class StyleSelection
 
   def main_styles
     @main_styles ||= support.select { |name, count|
-      count >= MIN_RECORDS && count >= (total_listings * MAIN_THRESHOLD).ceil && !suppressed_styles.include?(name)
+      count >= MIN_RECORDS && count >= (total_listings * MAIN_THRESHOLD).ceil
     }.keys.sort
   end
 
@@ -59,7 +50,7 @@ class StyleSelection
 
   def rotation_styles
     @rotation_styles ||= support.select { |name, count|
-      next false if main_styles.include?(name) || suppressed_styles.include?(name)
+      next false if main_styles.include?(name)
       count >= MIN_RECORDS && count >= (total_listings * ROTATION_THRESHOLD).ceil
     }.keys.sort
   end
@@ -74,42 +65,10 @@ class StyleSelection
     counts
   end
 
-  def qualifying_non_broad_styles
-    @qualifying_non_broad_styles ||= support.select { |name, count|
-      next false if BROAD_STYLES.include?(name)
-      count >= MIN_RECORDS && count >= (total_listings * ROTATION_THRESHOLD).ceil
-    }.keys
-  end
-
-  def suppressed_styles
-    @suppressed_styles ||= compute_suppressed
-  end
-
-  def compute_suppressed
-    return Set.new if qualifying_non_broad_styles.empty?
-    BROAD_STYLES.each_with_object(Set.new) { |broad, set| set.add(broad) if suppressible?(broad) }
-  end
-
-  def suppressible?(broad)
-    broad_count = support[broad]
-    return false if broad_count.nil? || broad_count.zero?
-
-    count_broad_overlap(broad).to_f / broad_count >= SUPPRESSION_RATIO
-  end
-
-  def count_broad_overlap(broad)
-    @listings.count do |listing|
-      styles = Array(listing.styles).compact
-      next false unless styles.include?(broad)
-      (styles & qualifying_non_broad_styles).any?
-    end
-  end
-
   def compute_overlap_risk
     ordered = main_styles_by_support
     ordered.each_with_object({}).with_index { |(style, risks), idx|
-      higher = ordered[0...idx].select { |candidate| support.fetch(candidate, 0) > support.fetch(style, 0) }
-      add_overlap_entry(style, higher, risks)
+      add_overlap_entry(style, ordered[0...idx], risks)
     }
   end
 

--- a/app/models/style_selection.rb
+++ b/app/models/style_selection.rb
@@ -5,16 +5,11 @@
 # instance from eligible listings and consumed by StylesAxis for crate
 # allocation, display ordering, and thematic candidate filtering.
 class StyleSelection
-  # Percentage of eligible listings required for a style to qualify as main.
   MAIN_THRESHOLD = 0.05
-  # Percentage of eligible listings required for a rotation candidate.
   ROTATION_THRESHOLD = 0.01
-  # Minimum share of overlapping non-broad listings needed to suppress a broad style.
   SUPPRESSION_RATIO = 0.75
+  MIN_RECORDS = CuratedCrate::MIN_RECORDS
 
-  # Curated set of broad Discogs style names that may be suppressed when
-  # redundant with more specific styles. This list is intentionally small
-  # and documented; seller customization is deferred to follow-up work.
   BROAD_STYLES = %w[
     Blues\ Rock
     Classic\ Rock
@@ -25,58 +20,47 @@ class StyleSelection
 
   attr_reader :total_listings
 
-  # listings - Array of Listing objects eligible for the current curation.
   def initialize(listings)
     @listings = listings
     @total_listings = listings.size.to_f
   end
 
-  # Deduplicated style → count, normalized per listing (one contribution max).
   def support
     @support ||= build_support
   end
 
-  # Styles that meet the main threshold and are not suppressed broad labels.
   def main_styles
     @main_styles ||= support.select { |name, count|
-      count >= main_floor && count >= main_threshold && !suppressed?(name)
+      count >= MIN_RECORDS && count >= (total_listings * MAIN_THRESHOLD).ceil && !suppressed_styles.include?(name)
     }.keys.sort
   end
 
-  # Map of main style name → overlap risk (share of its listings also
-  # tagged with a higher-support main style). Used for allocation ordering.
   def overlap_risk
     @overlap_risk ||= compute_overlap_risk
   end
 
-  # Allocation order for main styles: highest overlap risk first, then
-  # lowest support, then name (stable tie-breaker).
   def allocation_order
     @allocation_order ||= main_styles.sort_by { |name|
-      [-overlap_risk.fetch(name, 0), support.fetch(name, 0), name]
+      [ -overlap_risk.fetch(name, 0), support.fetch(name, 0), name ]
     }
   end
 
-  # Display order: highest support first, then name.
   def display_order
     @display_order ||= main_styles.sort_by { |name|
-      [-support.fetch(name, 0), name]
+      [ -support.fetch(name, 0), name ]
     }
   end
 
-  # Main style counts (suppressed and omitted styles excluded).
   def main_counts
     @main_counts ||= main_styles.each_with_object({}) { |name, h|
       h[name] = support.fetch(name, 0)
     }
   end
 
-  # Rotation-tier style names (non-main, non-suppressed, non-omitted).
   def rotation_styles
     @rotation_styles ||= support.select { |name, count|
-      next false if main_styles.include?(name)
-      next false if suppressed?(name)
-      count >= rotation_floor && count >= rotation_threshold
+      next false if main_styles.include?(name) || suppressed_styles.include?(name)
+      count >= MIN_RECORDS && count >= (total_listings * ROTATION_THRESHOLD).ceil
     }.keys.sort
   end
 
@@ -90,17 +74,11 @@ class StyleSelection
     counts
   end
 
-  # Non-broad styles that meet the rotation threshold (before suppression
-  # is applied). Used as the "qualifying" set for broad-style suppression.
   def qualifying_non_broad_styles
     @qualifying_non_broad_styles ||= support.select { |name, count|
       next false if BROAD_STYLES.include?(name)
-      count >= rotation_floor && count >= rotation_threshold
+      count >= MIN_RECORDS && count >= (total_listings * ROTATION_THRESHOLD).ceil
     }.keys
-  end
-
-  def suppressed?(name)
-    suppressed_styles.include?(name)
   end
 
   def suppressed_styles
@@ -109,64 +87,51 @@ class StyleSelection
 
   def compute_suppressed
     return Set.new if qualifying_non_broad_styles.empty?
+    BROAD_STYLES.each_with_object(Set.new) { |broad, set| set.add(broad) if suppressible?(broad) }
+  end
 
-    BROAD_STYLES.each_with_object(Set.new) do |broad, set|
-      broad_count = support[broad]
-      next if broad_count.nil? || broad_count.zero?
+  def suppressible?(broad)
+    broad_count = support[broad]
+    return false if broad_count.nil? || broad_count.zero?
 
-      overlap_count = count_broad_overlap(broad)
-      next if overlap_count.to_f / broad_count < SUPPRESSION_RATIO
-
-      set.add(broad)
-    end
+    count_broad_overlap(broad).to_f / broad_count >= SUPPRESSION_RATIO
   end
 
   def count_broad_overlap(broad)
     @listings.count do |listing|
       styles = Array(listing.styles).compact
       next false unless styles.include?(broad)
-
       (styles & qualifying_non_broad_styles).any?
     end
   end
 
   def compute_overlap_risk
-    ordered = main_styles.sort_by { |name| [-support.fetch(name, 0), name] }
-    risks = {}
+    ordered = main_styles_by_support
+    ordered.each_with_object({}).with_index { |(style, risks), idx|
+      add_overlap_entry(style, ordered[0...idx], risks)
+    }
+  end
 
-    ordered.each_with_index do |style, idx|
-      higher = ordered[0...idx]
-      next if higher.empty?
+  def add_overlap_entry(style, higher, risks)
+    return if higher.empty?
 
-      style_listings = listings_with_style(style)
-      next if style_listings.empty?
+    fraction = overlap_fraction(style, higher)
+    risks[style] = fraction if fraction
+  end
 
-      overlap_count = style_listings.count { |l|
-        (Array(l.styles).compact & higher).any?
-      }
-      risks[style] = overlap_count.to_f / style_listings.size
-    end
+  def main_styles_by_support
+    main_styles.sort_by { |name| [ -support.fetch(name, 0), name ] }
+  end
 
-    risks
+  def overlap_fraction(style, higher_styles)
+    style_listings = listings_with_style(style)
+    return if style_listings.empty?
+
+    overlap_count = style_listings.count { |l| (Array(l.styles).compact & higher_styles).any? }
+    overlap_count.to_f / style_listings.size
   end
 
   def listings_with_style(style)
     @listings.select { |l| Array(l.styles).compact.include?(style) }
-  end
-
-  def main_floor
-    CuratedCrate::MIN_RECORDS
-  end
-
-  def rotation_floor
-    CuratedCrate::MIN_RECORDS
-  end
-
-  def main_threshold
-    (total_listings * MAIN_THRESHOLD).ceil
-  end
-
-  def rotation_threshold
-    (total_listings * ROTATION_THRESHOLD).ceil
   end
 end

--- a/app/models/wall.rb
+++ b/app/models/wall.rb
@@ -3,9 +3,10 @@
 class Wall
   attr_reader :crate
 
-  def initialize(eligible_listings:, genre_counts:)
+  def initialize(eligible_listings:, genre_counts:, curation_axis: :genres)
     @eligible_listings = eligible_listings
     @genre_counts = genre_counts
+    @curation_axis = curation_axis
     @crate = CuratedCrate.new(
       slug: "wall",
       name: "The Wall",
@@ -29,6 +30,6 @@ class Wall
   end
 
   def strategy
-    @strategy ||= CrateStrategies::Wall.new(genre_counts: @genre_counts, today: Date.today)
+    @strategy ||= CrateStrategies::Wall.new(genre_counts: @genre_counts, curation_axis: @curation_axis, today: Date.today)
   end
 end

--- a/app/models/wall.rb
+++ b/app/models/wall.rb
@@ -3,7 +3,7 @@
 class Wall
   attr_reader :crate
 
-  def initialize(eligible_listings:, genre_counts:, curation_axis: :genres)
+  def initialize(eligible_listings:, genre_counts:, curation_axis: GenresAxis.new)
     @eligible_listings = eligible_listings
     @genre_counts = genre_counts
     @curation_axis = curation_axis

--- a/app/services/crate_strategies/genre.rb
+++ b/app/services/crate_strategies/genre.rb
@@ -8,14 +8,19 @@ module CrateStrategies
 
     MIN_RECORDS = 4
 
-    def initialize(genre:, genre_counts:, today: Date.today)
+    def initialize(genre:, genre_counts:, curation_axis: :genres, today: Date.today)
       @scorer = RecordScorer.new(genre_counts:, today:)
       @genre  = genre
+      @curation_axis = curation_axis
     end
 
     def select(pool, excluded_ids:)
       candidates = score_and_sort(pool, excluded_ids:, scorer: @scorer) do |candidates|
-        candidates.select { |l| l.primary_genre == @genre }
+        if @curation_axis == :styles
+          candidates.select { |l| Array(l.styles).include?(@genre) }
+        else
+          candidates.select { |l| l.primary_genre == @genre }
+        end
       end
 
       return [] if candidates.size < MIN_RECORDS

--- a/app/services/crate_strategies/genre.rb
+++ b/app/services/crate_strategies/genre.rb
@@ -8,7 +8,7 @@ module CrateStrategies
 
     MIN_RECORDS = 4
 
-    def initialize(genre:, genre_counts:, curation_axis: :genres, today: Date.today)
+    def initialize(genre:, genre_counts:, curation_axis: GenresAxis.new, today: Date.today)
       @scorer = RecordScorer.new(genre_counts:, today:)
       @genre  = genre
       @curation_axis = curation_axis
@@ -16,22 +16,12 @@ module CrateStrategies
 
     def select(pool, excluded_ids:)
       candidates = score_and_sort(pool, excluded_ids:, scorer: @scorer) do |candidates|
-        candidates.select { |l| matches_axis?(l) }
+        candidates.select { |l| @curation_axis.matches?(l, @genre) }
       end
 
       return [] if candidates.size < MIN_RECORDS
 
       candidates.first(CuratedCrate::CRATE_SIZE)
-    end
-
-    private
-
-    def matches_axis?(listing)
-      if @curation_axis == :styles
-        Array(listing.styles).include?(@genre)
-      else
-        listing.primary_genre == @genre
-      end
     end
   end
 end

--- a/app/services/crate_strategies/genre.rb
+++ b/app/services/crate_strategies/genre.rb
@@ -16,16 +16,22 @@ module CrateStrategies
 
     def select(pool, excluded_ids:)
       candidates = score_and_sort(pool, excluded_ids:, scorer: @scorer) do |candidates|
-        if @curation_axis == :styles
-          candidates.select { |l| Array(l.styles).include?(@genre) }
-        else
-          candidates.select { |l| l.primary_genre == @genre }
-        end
+        candidates.select { |l| matches_axis?(l) }
       end
 
       return [] if candidates.size < MIN_RECORDS
 
       candidates.first(CuratedCrate::CRATE_SIZE)
+    end
+
+    private
+
+    def matches_axis?(listing)
+      if @curation_axis == :styles
+        Array(listing.styles).include?(@genre)
+      else
+        listing.primary_genre == @genre
+      end
     end
   end
 end

--- a/app/services/crate_strategies/hidden_gems.rb
+++ b/app/services/crate_strategies/hidden_gems.rb
@@ -8,9 +8,10 @@ module CrateStrategies
     MAX_ENGAGEMENT  = 100
     MIN_WANTS       = 10
 
-    def initialize(genre_counts:, today: Date.today)
+    def initialize(genre_counts:, curation_axis: :genres, today: Date.today)
       @scorer       = RecordScorer.new(genre_counts:, today:)
       @genre_counts = genre_counts
+      @curation_axis = curation_axis
     end
 
     def select(pool, excluded_ids:)
@@ -41,7 +42,7 @@ module CrateStrategies
     end
 
     def under_genre_cap?(listing, genre_seen)
-      genre = listing.primary_genre
+      genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
       return false unless genre && genre_seen[genre] < PER_GENRE_CAP
 
       genre_seen[genre] += 1

--- a/app/services/crate_strategies/hidden_gems.rb
+++ b/app/services/crate_strategies/hidden_gems.rb
@@ -8,7 +8,7 @@ module CrateStrategies
     MAX_ENGAGEMENT  = 100
     MIN_WANTS       = 10
 
-    def initialize(genre_counts:, curation_axis: :genres, today: Date.today)
+    def initialize(genre_counts:, curation_axis: GenresAxis.new, today: Date.today)
       @scorer       = RecordScorer.new(genre_counts:, today:)
       @genre_counts = genre_counts
       @curation_axis = curation_axis
@@ -42,7 +42,7 @@ module CrateStrategies
     end
 
     def under_genre_cap?(listing, genre_seen)
-      genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
+      genre = @curation_axis.key_for(listing)
       return false unless genre && genre_seen[genre] < PER_GENRE_CAP
 
       genre_seen[genre] += 1

--- a/app/services/crate_strategies/thematic.rb
+++ b/app/services/crate_strategies/thematic.rb
@@ -6,9 +6,10 @@ module CrateStrategies
   class Thematic
     MIN_RECORDS = 4
 
-    def initialize(store_id:, genre_counts:, today: Date.today)
+    def initialize(store_id:, genre_counts:, themes: nil, today: Date.today)
       @scorer       = RecordScorer.new(genre_counts:, today:)
       @store_id     = store_id
+      @themes       = themes
       @today        = today
     end
 
@@ -53,7 +54,8 @@ module CrateStrategies
     end
 
     def discover_themes(pool)
-      (style_themes(pool) + genre_themes(pool))
+      candidates = @themes || (style_themes(pool) + genre_themes(pool))
+      candidates
         .select { |theme| theme.eligible?(pool) }
         .sort_by(&:slug)
     end

--- a/app/services/crate_strategies/wall.rb
+++ b/app/services/crate_strategies/wall.rb
@@ -1,7 +1,8 @@
 # Namespace for crate selection strategies that power storefront crates.
 module CrateStrategies
   class Wall
-    def initialize(genre_counts:, today: Date.today)
+    def initialize(genre_counts:, curation_axis: :genres, today: Date.today)
+      @curation_axis = curation_axis
       defaults = RecordScorer.default_strategies(genre_counts:, today:)
       @scorer  = RecordScorer.new(
         strategies: defaults.merge(wall_price: ScoreStrategies::WallPriceStrategy.new),
@@ -44,7 +45,7 @@ module CrateStrategies
     end
 
     def apply_genre_cap(listing, genre_cap:, genre_seen:)
-      genre = listing.primary_genre
+      genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
       return if genre_seen[genre] >= genre_cap
 
       genre_seen[genre] += 1

--- a/app/services/crate_strategies/wall.rb
+++ b/app/services/crate_strategies/wall.rb
@@ -1,7 +1,7 @@
 # Namespace for crate selection strategies that power storefront crates.
 module CrateStrategies
   class Wall
-    def initialize(genre_counts:, curation_axis: :genres, today: Date.today)
+    def initialize(genre_counts:, curation_axis: GenresAxis.new, today: Date.today)
       @curation_axis = curation_axis
       defaults = RecordScorer.default_strategies(genre_counts:, today:)
       @scorer  = RecordScorer.new(
@@ -45,7 +45,7 @@ module CrateStrategies
     end
 
     def apply_genre_cap(listing, genre_cap:, genre_seen:)
-      genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
+      genre = @curation_axis.key_for(listing)
       return if genre_seen[genre] >= genre_cap
 
       genre_seen[genre] += 1

--- a/app/services/curation_axis.rb
+++ b/app/services/curation_axis.rb
@@ -1,0 +1,16 @@
+# Selects the grouping key for curation surfaces (Wall diversity caps, Genre
+# crate filtering). Subclasses encapsulate the field-level differences between
+# top-level Discogs genres and sub-genre styles.
+class CurationAxis
+  def key_for(_listing)
+    raise NotImplementedError
+  end
+
+  def matches?(_listing, _name)
+    raise NotImplementedError
+  end
+
+  def tally_from(_listings)
+    raise NotImplementedError
+  end
+end

--- a/app/services/curation_axis.rb
+++ b/app/services/curation_axis.rb
@@ -13,4 +13,24 @@ class CurationAxis
   def tally_from(_listings)
     raise NotImplementedError
   end
+
+  # Hash of {name => count} for styles/genres that qualify for browse crates.
+  def main_counts(listings)
+    raise NotImplementedError
+  end
+
+  # Array of names in the order crates should be built (before dedup).
+  def allocation_order(listings)
+    raise NotImplementedError
+  end
+
+  # Array of names in the order crates should appear in the storefront.
+  def display_order(listings)
+    raise NotImplementedError
+  end
+
+  # Array of StorefrontTheme candidates for the themed featured slot.
+  def thematic_candidates(listings)
+    raise NotImplementedError
+  end
 end

--- a/app/services/genres_axis.rb
+++ b/app/services/genres_axis.rb
@@ -10,4 +10,36 @@ class GenresAxis < CurationAxis
   def tally_from(listings)
     listings.map(&:primary_genre).compact.tally
   end
+
+  def main_counts(listings)
+    tally_from(listings)
+  end
+
+  def allocation_order(listings)
+    main_counts(listings).sort_by { |name, count| [-count, name] }.map(&:first)
+  end
+
+  def display_order(listings)
+    allocation_order(listings)
+  end
+
+  def thematic_candidates(listings)
+    style_themes(listings) + genre_themes(listings)
+  end
+
+  private
+
+  def style_themes(listings)
+    listings.flat_map { |l| Array(l.styles) }
+      .compact
+      .tally
+      .keys
+      .map { |style| StorefrontTheme.style(style) }
+  end
+
+  def genre_themes(listings)
+    tally_from(listings)
+      .keys
+      .map { |genre| StorefrontTheme.genre(genre) }
+  end
 end

--- a/app/services/genres_axis.rb
+++ b/app/services/genres_axis.rb
@@ -16,7 +16,7 @@ class GenresAxis < CurationAxis
   end
 
   def allocation_order(listings)
-    main_counts(listings).sort_by { |name, count| [-count, name] }.map(&:first)
+    main_counts(listings).sort_by { |name, count| [ -count, name ] }.map(&:first)
   end
 
   def display_order(listings)

--- a/app/services/genres_axis.rb
+++ b/app/services/genres_axis.rb
@@ -1,0 +1,13 @@
+class GenresAxis < CurationAxis
+  def key_for(listing)
+    listing.primary_genre
+  end
+
+  def matches?(listing, name)
+    listing.primary_genre == name
+  end
+
+  def tally_from(listings)
+    listings.map(&:primary_genre).compact.tally
+  end
+end

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -1,4 +1,4 @@
-class StorefrontCuration
+class StorefrontCuration # rubocop:disable Metrics/ClassLength
   CURATION_AXIS_THRESHOLD = 3
   GENRE_DEPTH_RATIO = 0.05
 

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -86,9 +86,12 @@ class StorefrontCuration # rubocop:disable Metrics/ClassLength
   def build_genre_crates(excluded_ids:)
     seen_ids = excluded_ids.dup
 
-    genre_counts.sort_by { |_, count| -count }.filter_map do |genre, _|
+    built = curation_axis.allocation_order(eligible_listings).filter_map do |genre|
       genre_crate(genre:, seen_ids:)
     end
+
+    display = curation_axis.display_order(eligible_listings)
+    built.sort_by { |crate| display.index(crate.name) || display.size }
   end
 
   def genre_crate(genre:, seen_ids:)

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -85,13 +85,13 @@ class StorefrontCuration # rubocop:disable Metrics/ClassLength
 
   def build_genre_crates(excluded_ids:)
     seen_ids = excluded_ids.dup
+    built = curation_axis.allocation_order(eligible_listings).filter_map { |genre| genre_crate(genre:, seen_ids:) }
+    sort_for_display(built)
+  end
 
-    built = curation_axis.allocation_order(eligible_listings).filter_map do |genre|
-      genre_crate(genre:, seen_ids:)
-    end
-
+  def sort_for_display(crates)
     display = curation_axis.display_order(eligible_listings)
-    built.sort_by { |crate| display.index(crate.name) || display.size }
+    crates.sort_by { |crate| display.index(crate.name) || display.size }
   end
 
   def genre_crate(genre:, seen_ids:)

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -118,6 +118,7 @@ class StorefrontCuration # rubocop:disable Metrics/ClassLength
     @thematic_strategy ||= CrateStrategies::Thematic.new(
       store_id: @store.id,
       genre_counts:,
+      themes: curation_axis.thematic_candidates(eligible_listings),
       today: Date.today
     )
   end

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -1,4 +1,7 @@
 class StorefrontCuration
+  CURATION_AXIS_THRESHOLD = 3
+  GENRE_DEPTH_RATIO = 0.05
+
   def self.cached_curation(...) = CacheManager.cached_curation(...)
   def self.write_curation_cache(...) = CacheManager.write_curation_cache(...)
 
@@ -8,7 +11,7 @@ class StorefrontCuration
   end
 
   def crates
-    wall = Wall.new(eligible_listings:, genre_counts:)
+    wall = Wall.new(eligible_listings:, genre_counts:, curation_axis:)
     featured_crates = build_featured_crates(excluded_ids: wall.excluded_ids)
     featured_ids = featured_crates.flat_map(&:listings).map(&:id).to_set
 
@@ -20,7 +23,7 @@ class StorefrontCuration
   end
 
   def storefront_groups
-    wall = Wall.new(eligible_listings:, genre_counts:)
+    wall = Wall.new(eligible_listings:, genre_counts:, curation_axis:)
     seen_ids = wall.excluded_ids
 
     featured_crates = build_featured_crates(excluded_ids: seen_ids)
@@ -102,7 +105,7 @@ class StorefrontCuration
     crate
   end
   def genre_listings(genre, seen_ids)
-    strategy = CrateStrategies::Genre.new(genre:, genre_counts:, today: Date.today)
+    strategy = CrateStrategies::Genre.new(genre:, genre_counts:, curation_axis:, today: Date.today)
     strategy.select(eligible_listings, excluded_ids: seen_ids)
   end
   # Strategies
@@ -116,7 +119,7 @@ class StorefrontCuration
     )
   end
 
-  def hidden_gems_strategy = @hidden_gems_strategy ||= CrateStrategies::HiddenGems.new(genre_counts:, today: Date.today)
+  def hidden_gems_strategy = @hidden_gems_strategy ||= CrateStrategies::HiddenGems.new(genre_counts:, curation_axis:, today: Date.today)
 
   def build_hidden_gems_crate(excluded_ids:)
     listings = hidden_gems_strategy.select(eligible_listings, excluded_ids:)
@@ -133,5 +136,19 @@ class StorefrontCuration
     end
   end
 
-  def genre_counts = @genre_counts ||= eligible_listings.map(&:primary_genre).compact.tally
+  def curation_axis
+    @curation_axis ||= begin
+      deep_genres = eligible_listings.map(&:primary_genre).compact.tally
+        .select { |_, count| count >= (eligible_listings.size * GENRE_DEPTH_RATIO) }
+      deep_genres.size >= CURATION_AXIS_THRESHOLD ? :genres : :styles
+    end
+  end
+
+  def genre_counts
+    @genre_counts ||= if curation_axis == :styles
+      eligible_listings.flat_map(&:styles).compact.tally
+    else
+      eligible_listings.map(&:primary_genre).compact.tally
+    end
+  end
 end

--- a/app/services/storefront_curation.rb
+++ b/app/services/storefront_curation.rb
@@ -137,18 +137,15 @@ class StorefrontCuration # rubocop:disable Metrics/ClassLength
   end
 
   def curation_axis
-    @curation_axis ||= begin
-      deep_genres = eligible_listings.map(&:primary_genre).compact.tally
-        .select { |_, count| count >= (eligible_listings.size * GENRE_DEPTH_RATIO) }
-      deep_genres.size >= CURATION_AXIS_THRESHOLD ? :genres : :styles
-    end
+    @curation_axis ||= (deep_genre_count >= CURATION_AXIS_THRESHOLD) ? GenresAxis.new : StylesAxis.new
+  end
+
+  def deep_genre_count
+    eligible_listings.map(&:primary_genre).compact.tally
+      .count { |_, count| count >= (eligible_listings.size * GENRE_DEPTH_RATIO) }
   end
 
   def genre_counts
-    @genre_counts ||= if curation_axis == :styles
-      eligible_listings.flat_map(&:styles).compact.tally
-    else
-      eligible_listings.map(&:primary_genre).compact.tally
-    end
+    @genre_counts ||= curation_axis.tally_from(eligible_listings)
   end
 end

--- a/app/services/storefront_curation/cache_manager.rb
+++ b/app/services/storefront_curation/cache_manager.rb
@@ -2,7 +2,7 @@
 class StorefrontCuration::CacheManager
     CURATION_CACHE_TTL = 36.hours
     CURATION_CACHE_RACE_TTL = 30.seconds
-    CURATION_CACHE_KEY = "storefront/curation/v4/%<store_id>s/%<date>s/%<scope>s/%<wall_count>s/%<inventory_version>s"
+    CURATION_CACHE_KEY = "storefront/curation/v5/%<store_id>s/%<date>s/%<scope>s/%<wall_count>s/%<inventory_version>s"
 
     # Returns { sections: [...], crates: [...] } — plain hashes, cache-safe.
     # On cache miss, runs curation + presentation, writes to cache, returns payload.

--- a/app/services/styles_axis.rb
+++ b/app/services/styles_axis.rb
@@ -10,4 +10,29 @@ class StylesAxis < CurationAxis
   def tally_from(listings)
     listings.flat_map(&:styles).compact.tally
   end
+
+  def main_counts(listings)
+    selection_for(listings).main_counts
+  end
+
+  def allocation_order(listings)
+    selection_for(listings).allocation_order
+  end
+
+  def display_order(listings)
+    selection_for(listings).display_order
+  end
+
+  def thematic_candidates(listings)
+    selection_for(listings).rotation_styles.map { |name|
+      StorefrontTheme.style(name)
+    }
+  end
+
+  private
+
+  def selection_for(listings)
+    @_selection_by_id ||= {}
+    @_selection_by_id[listings.object_id] ||= StyleSelection.new(listings)
+  end
 end

--- a/app/services/styles_axis.rb
+++ b/app/services/styles_axis.rb
@@ -1,0 +1,13 @@
+class StylesAxis < CurationAxis
+  def key_for(listing)
+    listing.styles.first
+  end
+
+  def matches?(listing, name)
+    Array(listing.styles).include?(name)
+  end
+
+  def tally_from(listings)
+    listings.flat_map(&:styles).compact.tally
+  end
+end

--- a/app/services/styles_axis.rb
+++ b/app/services/styles_axis.rb
@@ -32,7 +32,7 @@ class StylesAxis < CurationAxis
   private
 
   def selection_for(listings)
-    @_selection_by_id ||= {}
-    @_selection_by_id[listings.object_id] ||= StyleSelection.new(listings)
+    @_selection_by_hash ||= {}
+    @_selection_by_hash[listings.hash] ||= StyleSelection.new(listings)
   end
 end

--- a/docs/brainstorms/2026-06-07-curation-axis-styles-requirements.md
+++ b/docs/brainstorms/2026-06-07-curation-axis-styles-requirements.md
@@ -1,0 +1,124 @@
+---
+date: 2026-06-07
+topic: curation-axis-styles
+---
+
+# Curation-Axis Switch: Styles for Narrow-Catalog Stores
+
+## Summary
+
+When a store's catalog lacks diverse top-level genres with meaningful depth, switch the curation axis from top-level genres to styles. The decision lives in `StorefrontCuration` and flows as a parameter to Wall and Genre strategies — Wall diversity caps, Genre crate names, and crate contents all switch to styles, giving narrow-catalog stores the same rich browsing experience as diverse ones.
+
+---
+
+## Problem Frame
+
+The Wall curation enforces genre diversity via a per-genre cap (`[count/3, 2].max` → 4 per genre for 12 slots). For stores with diverse catalogs, this ensures the wall represents multiple genres. For stores with narrow catalogs — a punk-only shop, a single-genre jazz store — the cap limits the wall to 4 records total, leaving it sparse and broken-looking. The diversity policy pulls low-quality filler from irrelevant genres just to meet quotas.
+
+The Genre Crates tab compounds the problem. A diverse store with 8+ top-level genres produces 8+ crates to flip through. A narrow store with 1-2 genres produces 1-2 crates — the browsing experience is diminished not because the store is bad, but because the curation axis is too coarse.
+
+The data to fix this already exists. Listings carry a `styles` array (indexed, GIN) with sub-genre tags like "Punk", "Hardcore", "Pop Punk", "Crust". `StorefrontTheme` already has both `genre` and `style` matchers. The axis decision is the missing piece.
+
+---
+
+## Key Flows
+
+- **F1. Curation axis detection and propagation**
+  - **Trigger:** Storefront curation cycle begins
+  - **Actors:** Curation system
+  - **Steps:**
+    1. Compute top-level genre counts from eligible listings via `primary_genre`
+    2. Count genres where tally ≥ 5% of total eligible listings ("deep genres")
+    3. If deep genre count ≥ 3, set axis to `:genres`. Otherwise, set axis to `:styles`
+    4. Compute `genre_counts` from the chosen axis source
+    5. Pass `curation_axis` to Wall and Genre strategies for field-level key selection
+  - **Outcome:** All downstream curation surfaces use a consistent axis that matches catalog reality
+  - **Covered by:** R1, R2, R3, R4
+
+---
+
+## Requirements
+
+**Axis detection**
+
+- **R1.** The curation axis is computed once per curation cycle from eligible listings, before Wall or Genre strategies run.
+- **R2.** A top-level genre has "meaningful depth" when its record count is ≥ 5% of total eligible listings. Only deep genres count toward the diversity threshold.
+- **R3.** When ≥ 3 top-level genres have meaningful depth, the axis is `:genres` (current behavior). When < 3 do, the axis is `:styles`.
+
+**Genre counts**
+
+- **R4.** When axis is `:genres`, `genre_counts` is a tally of `listing.primary_genre` across eligible listings. When axis is `:styles`, `genre_counts` is a tally of all values in `listing.styles` across eligible listings.
+
+**Wall**
+
+- **R5.** The Wall receives `curation_axis` as a parameter. When axis is `:styles`, the diversity cap keys on `listing.styles.first` instead of `listing.primary_genre`. The `WallPolicy` formula itself does not change.
+
+**Genre crates**
+
+- **R6.** `CrateStrategies::Genre` receives `curation_axis` as a parameter. When axis is `:genres`, it filters the pool by `listing.primary_genre == @genre`. When axis is `:styles`, it filters by `listing.styles.include?(@genre)`.
+- **R7.** Genre crate names are drawn from `genre_counts` keys. No frontend changes are needed — the frontend already renders whatever crate names the backend returns.
+
+**Consistency**
+
+- **R8.** Hidden Gems genre cap and Thematic strategy selection also use `curation_axis` for field selection, so all curation surfaces stay consistent with the chosen axis.
+
+---
+
+## Acceptance Examples
+
+- **AE1. Covers R1, R2, R3.** Given a store with Rock (300 records, 60%), Jazz (150 records, 30%), Electronic (10 records, 2% — below 5%), and Classical (8 records, 1.6% — below 5%), only Rock and Jazz count as deep genres. Deep genre count is 2, which is < 3. Axis is `:styles`. Genre crates are named by style ("Punk", "Hardcore", "Bebop", "Cool Jazz", etc.), and the Wall diversity cap keys on styles.
+
+- **AE2. Covers R1, R3.** Given a store with Rock (300 records), Jazz (150), Electronic (80), and Classical (50), all four pass the 5% depth gate. Deep genre count is 4 ≥ 3. Axis is `:genres`. Behavior is identical to current — top-level genre crates, Wall caps on `primary_genre`.
+
+- **AE3. Covers R5.** Given axis is `:styles` and a listing has `genres: ["Rock"], styles: ["Punk", "Oi"]`, the Wall diversity cap uses `listing.styles.first` → "Punk" as the genre key, not "Rock".
+
+- **AE4. Covers R6.** Given axis is `:styles` and `genre_counts` includes `"Hardcore" => 45`, the Genre crate for "Hardcore" receives listings where `listing.styles.include?("Hardcore")`, scored and sorted as normal. A listing with `styles: ["Punk", "Hardcore"]` appears in both the "Punk" and "Hardcore" crates.
+
+- **AE5. Covers R4.** Given axis is `:styles` and eligible listings have styles `["Punk", "Hardcore"]`, `["Punk"]`, `["Hardcore"]`, and `[]`, `genre_counts` is `{"Punk" => 2, "Hardcore" => 2}`. Listings with no styles don't appear in the tally.
+
+---
+
+## Success Criteria
+
+- A single-genre punk store's wall displays a full 12 records (not 4 capped + filler), with natural variety across punk sub-styles
+- A single-genre store's Genre Crates tab shows 5+ crates named by style ("Hardcore", "Pop Punk", "Crust") instead of 1 crate named "Rock"
+- Multi-genre stores with ≥ 3 deep top-level genres are unaffected — their walls and genre crates are identical to current behavior
+- A store that gains a third deep genre through catalog growth transitions smoothly to the `:genres` axis on the next curation cycle
+
+---
+
+## Scope Boundaries
+
+- The `WallPolicy#genre_cap` formula (`[count/3, 2].max`) is unchanged
+- Dynamic wall sizing, sparse-wall UX, and `TIER_DENSITY` frontend changes are out of scope
+- Artist-level diversity caps, genre adjacency clustering, nil-genre exemption, and progressive cap relaxation are out of scope
+- Within-genre diversity dimensions beyond the styles array are out of scope
+- Admin dashboard or store management UI changes are out of scope
+
+---
+
+## Key Decisions
+
+- **Axis location:** The axis decision lives in `StorefrontCuration`, not inside individual strategies. Strategies receive the axis as a parameter and branch on it for field selection, but don't own the decision. One place to change when the algorithm evolves.
+- **Depth threshold: 5% of total catalog.** Chosen over absolute record counts because it scales with store size. A 50-record store needs only 3 records for a genre to count. A 500-record store needs 25. This prevents tiny-genre noise from triggering "diverse catalog" behavior.
+- **Diversity threshold: 3 deep genres.** A store with 1-2 meaningful top-level genres gets styles. A store with 3+ stays on genres. Three genres is enough to fill the genre crates tab naturally and make cross-genre diversity meaningful on the wall.
+- **Wall key: `styles.first`.** Mirrors `primary_genre = genres.first`. A listing may belong to multiple style crates (AE4) but contributes to only one Wall diversity bucket.
+
+---
+
+## Dependencies / Assumptions
+
+- The `styles` column is already populated from Discogs metadata and GIN-indexed — no data migration needed
+- `StorefrontTheme.style()` already supports style-based thematic crates — the axis switch feeds naturally into themed curation
+- The 5% depth gate and threshold of 3 are initial values; the experiment pipeline may tune them
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R6][Technical] Should a listing with multiple styles appear in ALL matching style crates (current assumption), or only its primary style? Allowing multi-crate membership increases overlap between crates but surfaces more records.
+- [Affects R4][Technical] When axis is `:styles`, should `genre_counts` deduplicate by listing (a listing with 3 styles contributes 1 to each tally but 1 to total), or count raw occurrences? Raw occurrences inflates tallies for listings with many styles.
+- [Affects R5][Technical] `styles.first` may be arbitrary if the array order isn't meaningful. Should we use the most frequent style in the store's catalog instead? This would be more stable but requires a store-level frequency lookup during Wall selection.
+- [Affects R8][Technical] Verify that the Thematic strategy's use of `pool.map(&:primary_genre)` for genre detection works correctly with styles. The strategy currently uses genres to detect dominant themes — this may need adjustment.

--- a/docs/plans/2026-06-07-001-feat-curation-axis-styles-plan.md
+++ b/docs/plans/2026-06-07-001-feat-curation-axis-styles-plan.md
@@ -1,0 +1,287 @@
+---
+title: "feat: Curation-axis switch to styles for narrow-catalog stores"
+type: feat
+status: active
+date: 2026-06-07
+origin: docs/brainstorms/2026-06-07-curation-axis-styles-requirements.md
+---
+
+# feat: Curation-axis switch to styles for narrow-catalog stores
+
+## Summary
+
+Add a curation-axis detection step to `StorefrontCuration` that switches from top-level genres to styles when a store has fewer than 3 top-level genres with ≥5% catalog depth. The axis decision threads as a parameter to `CrateStrategies::Wall`, `CrateStrategies::Genre`, and `CrateStrategies::HiddenGems` — each switches its field-level key (filter or cap) from `primary_genre` to `styles.first` when the axis is `:styles`. `genre_counts` switches its source from a `primary_genre` tally to a `styles` tally. Thematic and NewArrivals strategies are axis-agnostic and need no changes. Zero frontend changes.
+
+---
+
+## Problem Frame
+
+The Wall's genre diversity cap (`[count/3, 2].max` → 4 per genre) and the Genre Crates tab both assume the store has multiple top-level genres. Single-genre stores get a sparse wall and 1-2 genre crates. The `styles` column already exists with sub-genre data (e.g., "Punk", "Hardcore", "Pop Punk") and is GIN-indexed. `StorefrontTheme` already has both `genre` and `style` matchers. The curation axis decision is the missing piece.
+
+---
+
+## Requirements
+
+- **R1.** Curation axis computed once per curation cycle from eligible listings, before Wall or Genre strategies run. *(origin R1)*
+- **R2.** A top-level genre has "meaningful depth" when its record count is ≥ 5% of total eligible listings. Only deep genres count toward the diversity threshold. *(origin R2)*
+- **R3.** ≥ 3 deep genres → axis `:genres`. < 3 deep genres → axis `:styles`. *(origin R3)*
+- **R4.** `genre_counts` switches source: `primary_genre` tally for `:genres` axis, `styles` tally for `:styles` axis. *(origin R4)*
+- **R5.** Wall diversity cap keys on `primary_genre` for `:genres` axis, `listing.styles.first` for `:styles` axis. `WallPolicy` formula unchanged. *(origin R5)*
+- **R6.** `CrateStrategies::Genre` filters by `primary_genre == @genre` for `:genres`, `styles.include?(@genre)` for `:styles`. *(origin R6)*
+- **R7.** Genre crate names drawn from `genre_counts` keys. No frontend changes. *(origin R7)*
+- **R8.** `HiddenGems` genre cap keys on the active axis field. *(origin R8)*
+
+**Origin flows:** F1 (Curation axis detection and propagation)
+**Origin acceptance examples:** AE1 (2 deep genres → styles), AE2 (4 deep genres → genres), AE3 (Wall cap uses styles.first), AE4 (multi-style listing appears in multiple crates), AE5 (empty-styles listings excluded from tally)
+
+---
+
+## Scope Boundaries
+
+- The `WallPolicy#genre_cap` formula (`[count/3, 2].max`) is unchanged
+- Thematic strategy is axis-agnostic — continues discovering both genre and style themes regardless of axis
+- Dynamic wall sizing, sparse-wall UX, frontend `TIER_DENSITY` changes out of scope
+- Artist-level caps, genre adjacency clustering, nil-genre exemption, progressive relaxation out of scope
+- Experiment pipeline (`SeedGenerator`) remains genre-axis-only until `section_points` scoring is ported from the layered-architecture-refactor branch
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **`app/services/storefront_curation.rb`** — orchestrator; `genre_counts` at line 136, `build_genre_crates` at line 86
+- **`app/services/crate_strategies/wall.rb`** — `apply_genre_cap` at line 46 keys on `listing.primary_genre`
+- **`app/services/crate_strategies/genre.rb`** — `select` at line 18 filters by `l.primary_genre == @genre`
+- **`app/services/crate_strategies/hidden_gems.rb`** — `under_genre_cap?` at line 43 keys on `listing.primary_genre`
+- **`app/models/storefront_theme.rb`** — already has `.style()` matcher using `Array(listing.styles).include?(name)`
+- **`app/models/listing.rb`** — `primary_genre = genres.first` at line 21; `styles` is `string[]` with GIN index
+- **`app/services/wall_policy.rb`** — `genre_cap(count)` formula, does not need changes
+- **`app/models/record_scorer.rb`** — accepts `genre_counts:` but no strategy reads it on `development` branch
+
+### Institutional Learnings
+
+- **`docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`** — canonical strategy architecture: "strategies SELECT; RecordScorer RANKS." Every strategy follows `initialize(params) → select(pool, excluded_ids:)` interface. Scoring changes cascade automatically.
+- **`docs/solutions/workflow-issues/experiment-pipeline-simplification-2026-05-21.md`** — `section` strategy removed as "diversity mechanism masquerading as quality signal." The genre cap MUST remain a cap, not get absorbed into scoring.
+
+### Flow Analysis Findings
+
+- `styles.first` is non-deterministic across Discogs imports (array order not guaranteed) — accepted as tolerable edge case per user decision
+- Listings with `genres: nil/[]` and populated `styles` are included on styles axis — a feature that surfaces listings genres-axis curations miss
+- Listings with `styles: []` produce `nil` from `styles.first` — tracked in nil bucket, capped same as any other key
+- Cache invalidation: axis is purely a function of inventory data, and `inventory_version` in the cache key covers it. No cache key change needed for initial implementation
+- Thematic strategy: axis-agnostic (user decision) — continues discovering both genre and style themes
+- `RecordScorer` on `development` branch does not consume `genre_counts` — no scoring impact from axis switch on current branch
+
+---
+
+## Key Technical Decisions
+
+- **Axis location:** `StorefrontCuration#curation_axis` computes and owns the decision. Strategies receive `curation_axis:` as a keyword parameter but do not own the logic. One place to change when the algorithm evolves.
+- **Depth threshold: 5% of eligible listings.** Scales with store size. A 50-record store needs 3 records for a genre to count; a 500-record store needs 25.
+- **Axis threshold: 3 deep genres.** ≥3 → `:genres`; <3 → `:styles`. Three genres is enough to make cross-genre diversity meaningful.
+- **Wall key: `styles.first`.** Mirrors `primary_genre = genres.first`. Non-determinism across imports accepted as tolerable.
+- **Genre crate filtering: `styles.include?(@genre)`.** A listing with 3 styles appears in 3 crates, mirroring the pre-grouping mental model the brainstorm established.
+- **Thematic: no change.** Already discovers both theme types. "Also switch" in R8 means HiddenGems only.
+- **No new policy object extracted.** Axis detection is a private method on `StorefrontCuration` — a single conditional. Extracting to a policy object adds indirection without clear value at this scope.
+
+---
+
+## Implementation Units
+
+### U1. Add curation-axis detection to `StorefrontCuration`
+
+**Goal:** Compute the curation axis from eligible listings once per cycle, and switch `genre_counts` source accordingly.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `app/services/storefront_curation.rb`
+- Test: `spec/services/storefront_curation_spec.rb`
+
+**Approach:**
+- Add `CURATION_AXIS_THRESHOLD = 3` and `GENRE_DEPTH_RATIO = 0.05` constants
+- Add private method `curation_axis` that computes deep genre count and returns `:genres` or `:styles`
+- Modify `genre_counts` to switch source: when `:styles`, `eligible_listings.flat_map(&:styles).compact.tally`; otherwise current behavior
+- Memoize both `curation_axis` and `genre_counts`
+- Thread `curation_axis:` to strategy constructors that need it (Wall, Genre, HiddenGems)
+
+**Patterns to follow:**
+- Existing `genre_counts` memoization pattern at line 136
+- Keyword-argument threading pattern from `Wall.new(eligible_listings:, genre_counts:)`
+
+**Test scenarios:**
+- Happy path: Store with Rock (60%), Jazz (30%), Electronic (10%) → Rock and Jazz pass 5% (only 2 deep genres) → axis is `:styles`
+- Happy path: Store with Rock (30%), Jazz (25%), Electronic (20%), Classical (15%) → 4 deep genres → axis is `:genres`
+- Happy path: genre_counts on `:styles` axis produces tally from `flat_map(&:styles)`
+- Edge case: Store with exactly 3 genres at exactly 5.0% each → axis is `:genres`
+- Edge case: Store with 0 eligible listings → axis is `:styles` (0 deep genres, < 3)
+- Error path: Listings with nil `genres` and nil `styles` → excluded from both tallies
+
+**Verification:**
+- `curation_axis` returns `:styles` for a punk-only store mock, `:genres` for a multi-genre store mock
+- `genre_counts` keys are style names when axis is `:styles`, genre names when `:genres`
+
+---
+
+### U2. Switch Wall diversity cap to use axis-aware key
+
+**Goal:** `CrateStrategies::Wall#apply_genre_cap` uses the active axis field for its diversity key.
+
+**Requirements:** R5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/services/crate_strategies/wall.rb`
+- Test: `spec/services/crate_strategies/wall_spec.rb`
+
+**Approach:**
+- Accept `curation_axis:` keyword argument in `initialize` (default `:genres` for backward compatibility)
+- In `apply_genre_cap`, branch: when `:styles`, genre = `listing.styles.first`; otherwise `listing.primary_genre`
+- `WallPolicy` and the cap formula itself are unchanged
+- `Wall` model (`app/models/wall.rb`) passes `curation_axis:` through from `StorefrontCuration`
+
+**Patterns to follow:**
+- Existing `apply_genre_cap` closure at line 46-49
+- `WallPolicy` remains a pure value object — only the key selection changes
+
+**Test scenarios:**
+- Happy path: On `:genres` axis, wall caps on `primary_genre` (existing behavior preserved)
+- Happy path: On `:styles` axis, wall caps on `listing.styles.first` — 2 listings with `styles.first = "Punk"` count toward the same cap bucket
+- Edge case: Listing with `styles: []` → `styles.first` returns nil → tracked in nil bucket, same cap applies
+- Edge case: Listing with `styles: ["Punk", "Hardcore"]` → only `"Punk"` (first) counts toward cap
+- Covers AE3: Wall diversity cap uses `styles.first`
+
+**Verification:**
+- Wall with `curation_axis: :styles` produces 12 records from a single-genre store mock (no cap starvation)
+- Wall with `curation_axis: :genres` produces identical results to pre-change behavior
+
+---
+
+### U3. Switch Genre strategy filtering to axis-aware field
+
+**Goal:** `CrateStrategies::Genre#select` filters the pool by the correct field based on axis.
+
+**Requirements:** R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/services/crate_strategies/genre.rb`
+- Test: `spec/services/crate_strategies/genre_spec.rb` (new — no dedicated Genre strategy spec currently exists)
+
+**Approach:**
+- Accept `curation_axis:` keyword argument in `initialize` (default `:genres`)
+- In `select`, branch the filter: when `:styles`, `candidates.select { |l| Array(l.styles).include?(@genre) }`; otherwise `candidates.select { |l| l.primary_genre == @genre }`
+- Genre crate ordering in `StorefrontCuration#build_genre_crates` already uses `genre_counts.sort_by { |_, count| -count }` — keys are now style names when axis is `:styles`, so crates are named and ordered by style
+
+**Patterns to follow:**
+- Existing `SelectionPipeline` inclusion
+- `StorefrontTheme.style(name)` matcher: `Array(listing.styles).include?(name)` — same pattern
+
+**Test scenarios:**
+- Happy path: On `:genres` axis, only listings with `primary_genre == "Rock"` appear in Rock crate
+- Happy path: On `:styles` axis, listings with `styles` including "Punk" appear in Punk crate
+- Happy path: A listing with `styles: ["Punk", "Hardcore"]` appears in BOTH "Punk" and "Hardcore" crates
+- Covers AE4: multi-style listing appears in multiple crates
+- Edge case: Listing with `styles: []` — `Array([]).include?("Punk")` → false, correctly excluded
+- Edge case: Listing with `styles: ["Punk"]` on `:genres` axis — filtered by `primary_genre == "Punk"` which won't match (primary_genre is a top-level genre, not a style name)
+
+**Verification:**
+- Punk crate on styles axis contains listings where `styles` includes "Punk"
+- Rock crate on genres axis contains listings where `primary_genre == "Rock"` (unchanged)
+
+---
+
+### U4. Switch HiddenGems genre cap to axis-aware key
+
+**Goal:** `HiddenGems#under_genre_cap?` uses the active axis field.
+
+**Requirements:** R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `app/services/crate_strategies/hidden_gems.rb`
+- Test: `spec/services/crate_strategies/hidden_gems_spec.rb`
+
+**Approach:**
+- Accept `curation_axis:` keyword argument in `initialize` (default `:genres`)
+- In `under_genre_cap?`, branch: when `:styles`, genre = `listing.styles.first`; otherwise `listing.primary_genre`
+- `PER_GENRE_CAP = 3` constant unchanged — naming reflects genre-axis origin, rename if desired but not required
+
+**Patterns to follow:**
+- Same field-switch pattern as Wall (U2) — identical branching logic
+- Existing `under_genre_cap?` guard at line 43-44
+
+**Test scenarios:**
+- Happy path: On `:styles` axis, HiddenGems caps at 3 per style — a 4th "Punk" listing is excluded
+- Happy path: On `:genres` axis, behavior unchanged
+- Edge case: Listing with `styles: []` → `styles.first` returns nil → tracked in nil bucket
+
+**Verification:**
+- HiddenGems on `:styles` axis from a punk store does not exceed 3 records from any one style
+
+---
+
+### U5. Thread `curation_axis` through `StorefrontCuration` to all strategy constructors
+
+**Goal:** Wire the axis decision from `StorefrontCuration` into every strategy that needs it.
+
+**Requirements:** R5, R6, R8
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- Modify: `app/services/storefront_curation.rb`
+- Modify: `app/models/wall.rb`
+
+**Approach:**
+- In `StorefrontCuration#crates` and `#storefront_groups`, pass `curation_axis:` to `Wall.new`
+- `Wall` model (`app/models/wall.rb`) accepts `curation_axis:` and passes it to `CrateStrategies::Wall.new`
+- `build_genre_crates` passes `curation_axis:` to `CrateStrategies::Genre.new`
+- `build_hidden_gems_crate` passes `curation_axis:` to `CrateStrategies::HiddenGems.new`
+- `build_featured_crates` passes `curation_axis:` through
+- NewArrivals and Thematic constructors do NOT receive `curation_axis:` — they are axis-agnostic
+
+**Patterns to follow:**
+- Existing keyword-argument threading from `StorefrontCuration` → `Wall` → `CrateStrategies::Wall`
+- Default values on strategy constructors (`curation_axis: :genres`) ensure backward compatibility for any direct instantiation in tests or experiments
+
+**Test scenarios:**
+- Integration: Full curation cycle on `:styles` axis produces wall with 12 records (no starvation), style-named genre crates, and correctly capped HiddenGems
+- Integration: Full curation cycle on `:genres` axis produces identical results to pre-change behavior
+- Regression: StorefrontCurationHelpers `curation_with_strategies` continues to work (default `:genres` axis)
+
+**Verification:**
+- `StorefrontCuration.new(punk_store).crates` returns genre crates named "Punk", "Hardcore", etc.
+- `StorefrontCuration.new(diverse_store).crates` returns genre crates named "Rock", "Jazz", etc. (unchanged)
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `StorefrontCuration` → `Wall` → `CrateStrategies::Wall` (cap key change); `StorefrontCuration` → `CrateStrategies::Genre` (filter change); `StorefrontCuration` → `CrateStrategies::HiddenGems` (cap key change). Thematic and NewArrivals are unaffected.
+- **Error propagation:** `curation_axis` defaults to `:genres` everywhere — if threading fails, behavior degrades to current, not to broken
+- **Unchanged invariants:** `WallPolicy#genre_cap` formula, `CuratedCrate::CRATE_SIZE`, `CuratedCrate::MIN_RECORDS`, cache key structure, frontend data contract, `RecordScorer` scoring weights
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `styles.first` non-determinism across Discogs imports changes diversity bucket assignment | Accepted as tolerable edge case per user decision. Self-correcting on next curation cycle. |
+| Listings with empty `styles` arrays produce `nil` key, potentially dominating wall diversity bucket | Nil bucket is tracked and capped same as any other key. Existing nil-genre behavior in genres axis is the same pattern. |
+| `RecordScorer#section_points` on layered-architecture-refactor branch uses `primary_genre` as scoring key — would need axis-awareness when ported | Out of scope for this plan. Addressed in scope boundaries. |
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-07-curation-axis-styles-requirements.md](../brainstorms/2026-06-07-curation-axis-styles-requirements.md)
+- Related code: `app/services/storefront_curation.rb`, `app/services/crate_strategies/wall.rb`, `app/services/crate_strategies/genre.rb`, `app/services/crate_strategies/hidden_gems.rb`, `app/models/storefront_theme.rb`, `app/services/wall_policy.rb`
+- Institutional learnings: `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`

--- a/docs/plans/2026-06-07-002-feat-style-selection-plan.md
+++ b/docs/plans/2026-06-07-002-feat-style-selection-plan.md
@@ -36,9 +36,9 @@ The selection policy belongs below `StorefrontCuration`: classification is domai
 
 ### Noise suppression
 
-- R6. A small curated broad-style set initially covers Pop Rock, Rock & Roll, Classic Rock, Hard Rock, and Blues Rock.
-- R7. A broad style is suppressed only when at least 75% of its listings also carry a non-broad style that meets the rotation support threshold before suppression; broad styles with independent coverage remain eligible.
-- R8. A store with no qualifying non-broad styles retains broad styles under the normal support thresholds rather than producing an empty style taxonomy.
+- R6. Removed — the curated broad-styles suppression list (Pop Rock, Rock & Roll, etc.) was rock-specific and couldn't generalize to electronic, jazz, or hip-hop stores. Raw support-count sorting already surfaces genuinely relevant styles.
+- R7. Removed — broad-style co-occurrence suppression eliminated alongside R6.
+- R8. Removed — broad-only fallback no longer needed without suppression.
 
 ### Ranking and rotation
 
@@ -68,8 +68,9 @@ The selection policy belongs below `StorefrontCuration`: classification is domai
 
 - Human or seller editing of style classifications
 - Experiment tooling for tuning thresholds from shopper behavior
-- Per-store configuration of broad labels or thresholds
+- Per-store configuration of thresholds
 - Fallback behavior for stores whose Discogs listings have sparse style metadata
+- Genre-agnostic co-occurrence analysis for broad-style detection (if real-world data shows broad labels crowding distinctive sub-genres)
 
 ### Out of Scope
 
@@ -88,12 +89,8 @@ The selection policy belongs below `StorefrontCuration`: classification is domai
 ```mermaid
 flowchart TB
   A[Eligible listings] --> B[Deduplicate styles within each listing]
-  B --> C[Count support and qualifying co-occurrence]
-  C --> D{Broad style?}
-  D -->|No| F{Meets 5% main threshold?}
-  D -->|Yes| E{At least 75% redundant?}
-  E -->|Yes| S[Suppressed]
-  E -->|No| F
+  B --> C[Count support]
+  C --> F{Meets 5% main threshold?}
   F -->|Yes| M[Main]
   F -->|No| G{Meets 1% rotation threshold?}
   G -->|Yes| R[Rotation]
@@ -121,8 +118,7 @@ The classification is computed once per curation instance and reused by style co
 
 - **Plain domain object:** Add a non-persisted `StyleSelection` under `app/models/`. Rails 8.1 supports plain Ruby domain objects beside Active Record models; no Active Model behavior is needed because this object has no forms, callbacks, or persistence.
 - **Scaled support thresholds:** Main uses 5% and rotation uses 1%, each floored at `CuratedCrate::MIN_RECORDS`. For the 599-listing issue example, thresholds become 30 and 6, matching the described cornerstone and fringe tiers.
-- **Conditional broad-style suppression:** The curated set is a candidate filter, not an unconditional denylist. Co-occurrence prevents a broad label from disappearing when it is the only meaningful description of a store.
-- **Union redundancy ratio:** A broad style's redundancy is the share of its listings that also contain any non-broad style meeting the rotation threshold before suppression. The initial 75% gate requires strong overlap while leaving room for broad styles with substantial independent coverage.
+- **No broad-style suppression.** The initial curated broad-styles list was dropped. Raw support-count ordering already surfaces genuinely relevant styles — a broad label with high count is meaningful to its store. A genre-agnostic co-occurrence filter could be added later if real-world data shows broad labels crowding out distinctive sub-genres.
 - **Two rankings for main styles:** Allocation uses overlap risk, defined as the share of a style's listings also tagged with a higher-support main style. Higher risk allocates first, then lower support, then name. Display ranking remains support-first so shoppers see cornerstone crates in intuitive order.
 - **Axis owns taxonomy differences:** Extend the polymorphic curation-axis contract to expose main counts, allocation order, display order, and thematic candidates. `StorefrontCuration` must not branch on axis class or type.
 - **Thematic remains a selector:** The axis supplies eligible themes; `CrateStrategies::Thematic` keeps ownership of deterministic daily choice and record ranking.
@@ -136,7 +132,7 @@ The classification is computed once per curation instance and reused by style co
 
 **Goal:** Compute stable style tiers and ranking metadata from eligible listings.
 
-**Requirements:** R2, R3, R4, R5, R6, R7, R8
+**Requirements:** R2, R3, R4, R5
 
 **Dependencies:** None
 
@@ -149,10 +145,10 @@ The classification is computed once per curation instance and reused by style co
 
 - Build a plain Ruby domain object from eligible listings.
 - Normalize each listing's styles with compact, unique values before counting.
-- Compute total support, qualifying non-broad styles, broad-style union redundancy, and the four tiers.
+- Compute total support and classify into three tiers: main (≥5%), rotation (≥1%), omitted.
 - Compute overlap risk for main styles against higher-support main styles.
 - Expose immutable result data needed by the axis: main counts, main allocation order, main display order, and rotation names.
-- Keep thresholds and the initial broad-style set as named constants near the policy.
+- Keep thresholds as named constants near the policy.
 - Compute co-occurrence in a single pass over each listing's small style set rather than scanning every style pair across the full catalog.
 
 **Patterns to follow:**
@@ -164,10 +160,7 @@ The classification is computed once per curation instance and reused by style co
 **Test scenarios:**
 
 - Happy path: with 599 eligible listings, counts of 367, 262, 39, 38, 38, and 36 classify as main because the computed main threshold is 30.
-- Happy path: counts from 6 through 29 classify as rotation when they are non-broad and non-suppressed.
-- Covers issue example: Pop Rock at count 30 is suppressed when at least 75% of its records also carry qualifying non-broad styles.
-- Edge case: Pop Rock at count 30 remains main when less than 75% overlaps qualifying non-broad styles.
-- Edge case: a broad-only store retains its broad labels under normal main and rotation thresholds.
+- Happy path: counts from 6 through 29 classify as rotation.
 - Edge case: repeated identical style values on one listing contribute one count.
 - Edge case: nil and empty style arrays do not create entries or raise errors.
 - Boundary: exactly 5% qualifies as main; one record below does not.
@@ -177,7 +170,7 @@ The classification is computed once per curation instance and reused by style co
 
 **Verification:**
 
-- One selection result explains each observed style as main, rotation, suppressed, or omitted.
+- One selection result explains each observed style as main, rotation, or omitted.
 - The issue's sample distribution yields the expected tier boundaries without store-specific thresholds.
 
 ---
@@ -363,7 +356,7 @@ The classification is computed once per curation instance and reused by style co
 ## Acceptance Examples
 
 - AE1. Given the issue's 599-listing store, the main threshold is 30 and the rotation threshold is 6. Punk, Hardcore, Crust, Black Metal, Death Metal, and Grindcore qualify as main.
-- AE2. Given Pop Rock has 30 listings and at least 75% also carry qualifying non-broad styles, Pop Rock is suppressed despite meeting the main threshold.
+- AE2. Given Pop Rock has 30 listings in a punk/metal store, it qualifies as main alongside the other six core styles based purely on support count — the curated broad-styles suppression list has been removed; raw support determines relevance.
 - AE3. Given Oi has 13 listings, it is excluded from the main browse grid and included in thematic rotation.
 - AE4. Given a store carries only Classic Rock with enough support and no qualifying non-broad styles, Classic Rock remains eligible rather than leaving the store with no browse crates.
 - AE5. Given Crust listings also carry Punk, allocation considers Crust before Punk; completed crates are then presented in support-first order.
@@ -385,8 +378,7 @@ The classification is computed once per curation instance and reused by style co
 
 | Risk | Mitigation |
 |---|---|
-| Curated broad-style set encodes product judgment and can become stale | Keep it small, named, and directly unit-tested; defer seller customization to a follow-up issue. |
-| Initial 5%, 1%, and 75% thresholds misclassify another catalog shape | Keep constants isolated and cover small, broad-only, overlap-heavy, and issue-derived fixtures. |
+| Initial 5% and 1% thresholds misclassify another catalog shape | Keep constants isolated and cover small, broad-only, overlap-heavy, and issue-derived fixtures. |
 | Specific-first allocation still cannot preserve a fully nested style under strict dedup | Preserve the existing viability rule and record this case in tests; duplicate style-crate membership remains out of scope. |
 | Co-occurrence calculation adds request-time work | Build counts in one pass and memoize one result per curation instance; existing serialized cache absorbs repeated requests. |
 | Thematic filtering removes a previously available featured crate | Treat no fringe candidate as a valid nil result, matching the existing optional featured-crate contract. |

--- a/docs/plans/2026-06-07-002-feat-style-selection-plan.md
+++ b/docs/plans/2026-06-07-002-feat-style-selection-plan.md
@@ -1,0 +1,405 @@
+---
+title: "feat: Select distinctive styles for narrow-catalog stores"
+type: feat
+status: completed
+date: 2026-06-07
+deepened: 2026-06-07
+---
+
+# feat: Select distinctive styles for narrow-catalog stores
+
+## Summary
+
+Replace raw style tallies on the styles curation axis with a store-local selection policy. The policy classifies styles as main, rotation, suppressed, or omitted using support thresholds plus co-occurrence, keeps broad Discogs labels only when they add independent coverage, and preserves current genre-axis behavior.
+
+---
+
+## Problem Frame
+
+Issue [#245](https://github.com/body-clock/milkcrate/issues/245) shows that Discogs styles are useful sub-genres but not a ready-made storefront taxonomy. A 599-listing punk/metal store has strong distinctions such as Punk, Hardcore, Crust, Black Metal, Death Metal, and Grindcore alongside broad labels such as Pop Rock, Rock & Roll, and Classic Rock.
+
+`StylesAxis#tally_from` currently returns every style count. `StorefrontCuration` then creates crates for all styles with at least four unclaimed records, ordered by raw count. Broad labels become prominent crates, thin labels crowd the grid, and high-count labels can consume overlapping records before more specific labels are considered.
+
+The selection policy belongs below `StorefrontCuration`: classification is domain logic, while the curation service should continue orchestrating Wall, featured, and browse crates.
+
+---
+
+## Requirements
+
+### Classification
+
+- R1. Style selection applies only when `StylesAxis` is active; `GenresAxis` preserves current counts, ordering, and thematic behavior.
+- R2. Each listing contributes at most once to each style count, and support ratios use the total eligible listing count as their denominator.
+- R3. A style qualifies as main when its count is at least both `CuratedCrate::MIN_RECORDS` and 5% of eligible listings.
+- R4. A non-main style qualifies for rotation when its count is at least both `CuratedCrate::MIN_RECORDS` and 1% of eligible listings.
+- R5. Styles below the rotation threshold are omitted from main crates and thematic rotation.
+
+### Noise suppression
+
+- R6. A small curated broad-style set initially covers Pop Rock, Rock & Roll, Classic Rock, Hard Rock, and Blues Rock.
+- R7. A broad style is suppressed only when at least 75% of its listings also carry a non-broad style that meets the rotation support threshold before suppression; broad styles with independent coverage remain eligible.
+- R8. A store with no qualifying non-broad styles retains broad styles under the normal support thresholds rather than producing an empty style taxonomy.
+
+### Ranking and rotation
+
+- R9. Main style crates allocate records by overlap-risk descending, support ascending, then name; viable crates are presented by support descending, then name.
+- R10. Existing top-down record deduplication across Wall, featured crates, and browse crates remains intact.
+- R11. On the styles axis, the thematic strategy rotates only non-suppressed rotation-tier styles; main styles and broad suppressed styles do not duplicate the featured slot.
+- R12. Rotation remains deterministic for a store and date. When no rotation candidate remains viable after exclusions, no thematic crate is produced.
+
+### Compatibility
+
+- R13. No database migration, admin UI, frontend component, or presenter payload change is introduced.
+- R14. Existing cached storefront payloads are invalidated when the selection policy ships.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- Store-local style support and co-occurrence calculations
+- Main, rotation, suppressed, and omitted classification
+- Style-axis crate allocation and display ordering
+- Style-axis thematic candidate filtering
+- Cache namespace invalidation and backend regression coverage
+
+### Deferred to Follow-Up Work
+
+- Human or seller editing of style classifications
+- Experiment tooling for tuning thresholds from shopper behavior
+- Per-store configuration of broad labels or thresholds
+- Fallback behavior for stores whose Discogs listings have sparse style metadata
+
+### Out of Scope
+
+- Changes to the genre-versus-style axis decision from PR [#244](https://github.com/body-clock/milkcrate/pull/244)
+- Discogs taxonomy normalization, aliases, or new style names
+- Changes to Wall or Hidden Gems diversity keys
+- Allowing duplicate listings across style crates
+- Frontend labels, layouts, or navigation changes
+
+---
+
+## High-Level Technical Design
+
+### Style classification
+
+```mermaid
+flowchart TB
+  A[Eligible listings] --> B[Deduplicate styles within each listing]
+  B --> C[Count support and qualifying co-occurrence]
+  C --> D{Broad style?}
+  D -->|No| F{Meets 5% main threshold?}
+  D -->|Yes| E{At least 75% redundant?}
+  E -->|Yes| S[Suppressed]
+  E -->|No| F
+  F -->|Yes| M[Main]
+  F -->|No| G{Meets 1% rotation threshold?}
+  G -->|Yes| R[Rotation]
+  G -->|No| O[Omitted]
+```
+
+### Curation consumption
+
+```mermaid
+flowchart TB
+  A[Style selection result] --> B[Main style allocation order]
+  B --> C[Build viable crates with existing exclusions]
+  C --> D[Sort built crates for display]
+  A --> E[Rotation style candidates]
+  E --> F[Existing deterministic thematic rotation]
+  D --> G[Genre-grid payload]
+  F --> H[Featured payload]
+```
+
+The classification is computed once per curation instance and reused by style counts, crate ordering, and thematic candidates.
+
+---
+
+## Key Technical Decisions
+
+- **Plain domain object:** Add a non-persisted `StyleSelection` under `app/models/`. Rails 8.1 supports plain Ruby domain objects beside Active Record models; no Active Model behavior is needed because this object has no forms, callbacks, or persistence.
+- **Scaled support thresholds:** Main uses 5% and rotation uses 1%, each floored at `CuratedCrate::MIN_RECORDS`. For the 599-listing issue example, thresholds become 30 and 6, matching the described cornerstone and fringe tiers.
+- **Conditional broad-style suppression:** The curated set is a candidate filter, not an unconditional denylist. Co-occurrence prevents a broad label from disappearing when it is the only meaningful description of a store.
+- **Union redundancy ratio:** A broad style's redundancy is the share of its listings that also contain any non-broad style meeting the rotation threshold before suppression. The initial 75% gate requires strong overlap while leaving room for broad styles with substantial independent coverage.
+- **Two rankings for main styles:** Allocation uses overlap risk, defined as the share of a style's listings also tagged with a higher-support main style. Higher risk allocates first, then lower support, then name. Display ranking remains support-first so shoppers see cornerstone crates in intuitive order.
+- **Axis owns taxonomy differences:** Extend the polymorphic curation-axis contract to expose main counts, allocation order, display order, and thematic candidates. `StorefrontCuration` must not branch on axis class or type.
+- **Thematic remains a selector:** The axis supplies eligible themes; `CrateStrategies::Thematic` keeps ownership of deterministic daily choice and record ranking.
+- **No persistence:** Selection is derived from current eligible listings and memoized for one curation instance. Inventory-version cache invalidation remains the long-lived consistency mechanism.
+
+---
+
+## Implementation Units
+
+### U1. Add store-local style classification
+
+**Goal:** Compute stable style tiers and ranking metadata from eligible listings.
+
+**Requirements:** R2, R3, R4, R5, R6, R7, R8
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `app/models/style_selection.rb`
+- Create: `spec/models/style_selection_spec.rb`
+
+**Approach:**
+
+- Build a plain Ruby domain object from eligible listings.
+- Normalize each listing's styles with compact, unique values before counting.
+- Compute total support, qualifying non-broad styles, broad-style union redundancy, and the four tiers.
+- Compute overlap risk for main styles against higher-support main styles.
+- Expose immutable result data needed by the axis: main counts, main allocation order, main display order, and rotation names.
+- Keep thresholds and the initial broad-style set as named constants near the policy.
+- Compute co-occurrence in a single pass over each listing's small style set rather than scanning every style pair across the full catalog.
+
+**Patterns to follow:**
+
+- `app/models/record_scorer.rb` for non-Active Record domain computation in `app/models/`
+- `app/models/curated_crate.rb` for shared viability constants
+- `app/services/store_sync/coverage_classifier.rb` for a small deterministic classifier with focused specs
+
+**Test scenarios:**
+
+- Happy path: with 599 eligible listings, counts of 367, 262, 39, 38, 38, and 36 classify as main because the computed main threshold is 30.
+- Happy path: counts from 6 through 29 classify as rotation when they are non-broad and non-suppressed.
+- Covers issue example: Pop Rock at count 30 is suppressed when at least 75% of its records also carry qualifying non-broad styles.
+- Edge case: Pop Rock at count 30 remains main when less than 75% overlaps qualifying non-broad styles.
+- Edge case: a broad-only store retains its broad labels under normal main and rotation thresholds.
+- Edge case: repeated identical style values on one listing contribute one count.
+- Edge case: nil and empty style arrays do not create entries or raise errors.
+- Boundary: exactly 5% qualifies as main; one record below does not.
+- Boundary: exactly 1% qualifies as rotation; one record below is omitted unless the four-record floor controls.
+- Determinism: equal support and overlap produce stable alphabetical tie-breaking.
+- Ordering: a style mostly nested inside a higher-support main style allocates before an equally supported independent style.
+
+**Verification:**
+
+- One selection result explains each observed style as main, rotation, suppressed, or omitted.
+- The issue's sample distribution yields the expected tier boundaries without store-specific thresholds.
+
+---
+
+### U2. Extend curation-axis behavior with selection results
+
+**Goal:** Let both axes provide curation ordering and thematic candidates without type checks in callers.
+
+**Requirements:** R1, R9, R11, R12
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `app/services/curation_axis.rb`
+- Modify: `app/services/genres_axis.rb`
+- Modify: `app/services/styles_axis.rb`
+- Modify: `spec/services/genres_axis_spec.rb`
+- Modify: `spec/services/styles_axis_spec.rb`
+
+**Approach:**
+
+- Expand the axis contract from raw tallying to a small selection-result interface consumed by curation.
+- `GenresAxis` returns current genre counts and count-descending order, preserving existing behavior.
+- `StylesAxis` delegates classification to `StyleSelection` and memoizes the result for the eligible listing set.
+- Keep `key_for` and `matches?` unchanged so Wall, Hidden Gems, and Genre strategy filtering continue using existing polymorphism.
+- Return thematic candidates in domain form suitable for `StorefrontTheme`, without making strategies aware of classification rules.
+
+**Patterns to follow:**
+
+- `docs/solutions/architecture-patterns/replace-type-code-with-polymorphism-2026-06-07.md`
+- `app/services/styles_axis.rb` and `app/services/genres_axis.rb` for behavior encapsulated behind one axis object
+
+**Test scenarios:**
+
+- Genres axis returns every primary-genre count and current descending count order.
+- Genres axis still provides the current thematic genre/style candidate behavior.
+- Styles axis returns only main-style counts.
+- Styles axis allocation order places lower-support overlapping main styles before higher-support styles.
+- Styles axis display order places higher-support main styles first with stable ties.
+- Styles axis exposes only rotation-tier style themes.
+- Suppressed and omitted styles are absent from all style-axis outputs.
+- Repeated calls for the same listing set reuse one classification result.
+
+**Verification:**
+
+- Axis consumers can ask for counts, allocation order, display order, and themes without checking `GenresAxis` versus `StylesAxis`.
+- Existing `key_for` and `matches?` specs remain unchanged.
+
+---
+
+### U3. Separate browse-crate allocation order from display order
+
+**Goal:** Preserve distinctive style crates under deduplication while showing cornerstone crates first.
+
+**Requirements:** R9, R10
+
+**Dependencies:** U2
+
+**Files:**
+
+- Modify: `app/services/storefront_curation.rb`
+- Modify: `spec/services/storefront_curation_spec.rb`
+
+**Approach:**
+
+- Ask the active axis for allocation order instead of sorting raw counts inline.
+- Build crates in allocation order using the existing `seen_ids` contract.
+- Reorder only the completed viable crates using the axis display order before returning groups and crate navigation data.
+- Keep genre-axis allocation and display order identical, making this change behaviorally neutral for diverse stores.
+- Continue applying `CrateStrategies::Genre::MIN_RECORDS` and `CuratedCrate#viable?` after Wall and featured exclusions.
+
+**Patterns to follow:**
+
+- Existing top-down deduplication in `StorefrontCuration#storefront_groups`
+- `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`
+
+**Test scenarios:**
+
+- Integration: overlapping Punk, Hardcore, and Crust listings allocate Crust and Hardcore before Punk, leaving each representative main style viable.
+- Integration: returned style crates display Punk and Hardcore ahead of lower-support main styles after allocation completes.
+- Regression: a genres-axis store returns genre crates in the same count-descending order as today.
+- Regression: no listing appears in more than one of Wall, featured, or browse crates.
+- Edge case: a qualifying main style that falls below four unclaimed records after higher surfaces is omitted under the existing viability rule.
+- Edge case: no main styles yields an empty browse-crate group without raising.
+
+**Verification:**
+
+- Allocation order affects record assignment only; display order controls shopper-facing crate order.
+- `crates` and `storefront_groups` expose the same style ordering for the same store and date.
+
+---
+
+### U4. Restrict style-axis thematic rotation to fringe styles
+
+**Goal:** Use the existing featured thematic slot to rotate interesting thin styles without resurfacing main or noisy labels.
+
+**Requirements:** R11, R12
+
+**Dependencies:** U2
+
+**Files:**
+
+- Modify: `app/services/crate_strategies/thematic.rb`
+- Modify: `app/services/storefront_curation.rb`
+- Modify: `spec/services/crate_strategies/thematic_spec.rb`
+- Modify: `spec/services/storefront_curation_spec.rb`
+
+**Approach:**
+
+- Let the thematic strategy accept explicit eligible themes while preserving its scoring and deterministic store/date seed.
+- Supply rotation-tier style themes on the styles axis.
+- Preserve current theme discovery on the genres axis.
+- Return no thematic crate when the styles axis has no viable rotation candidate after exclusions.
+- Keep main style crates and suppressed broad styles out of thematic eligibility.
+
+**Patterns to follow:**
+
+- `app/models/storefront_theme.rb` for style matching and viability
+- Existing `CrateStrategies::Thematic` seed and `RecordScorer` ranking
+
+**Test scenarios:**
+
+- Happy path: Oi, Doom Metal, and Noise in the rotation tier produce one deterministic thematic choice for a store/date.
+- Determinism: identical store, date, listings, and exclusions choose the same fringe style and record order.
+- Boundary: a rotation candidate with fewer than four records after exclusions is skipped.
+- Exclusion: Punk and Hardcore main styles are not thematic candidates on the styles axis.
+- Exclusion: a suppressed Pop Rock label is never selected as thematic.
+- Empty path: no viable rotation candidates returns nil and the featured group remains valid.
+- Regression: genres-axis thematic selection still considers the same style and genre themes as before.
+
+**Verification:**
+
+- Narrow stores rotate fringe styles through the existing featured surface.
+- No frontend or presenter changes are required to render the selected theme.
+
+---
+
+### U5. Invalidate stale curation payloads and cover end-to-end behavior
+
+**Goal:** Ensure deployment serves the new style taxonomy immediately and preserve serialized contracts.
+
+**Requirements:** R13, R14
+
+**Dependencies:** U3, U4
+
+**Files:**
+
+- Modify: `app/services/storefront_curation/cache_manager.rb`
+- Modify: `spec/services/storefront_curation/cache_manager_spec.rb`
+- Modify: `spec/requests/stores_spec.rb`
+
+**Approach:**
+
+- Advance the curation cache namespace so pre-deploy raw-style payloads cannot survive for the existing TTL.
+- Keep cache dimensions, payload keys, presenter behavior, and frontend section keys unchanged.
+- Add a request-level styles-axis example that asserts main style names are present while redundant broad and fringe styles are absent from the browse grid.
+- Keep request fixtures explicitly on the intended axis so unrelated genre-depth changes cannot alter the expectation.
+- Validate the generated crate-name tiers against the issue store fixture plus a broad-only fixture before treating the thresholds as calibrated.
+
+**Patterns to follow:**
+
+- Existing versioned cache key in `StorefrontCuration::CacheManager`
+- Existing storefront request specs for browse-crate names and counts
+
+**Test scenarios:**
+
+- Cache key uses the new namespace and no longer reads a payload stored under the previous namespace.
+- Styles-axis request renders main style crate names.
+- Redundant broad styles do not appear in the browse grid.
+- Rotation-tier styles do not appear in the browse grid.
+- Serialized sections remain `wall`, optional `featured_crates`, and `genre_grid`.
+- Serialized crate objects retain `slug`, `name`, `count`, and `records`.
+- Genre-axis request behavior remains unchanged.
+
+**Verification:**
+
+- A deployment cannot serve an old raw-style crate list from cache.
+- Existing frontend props remain compatible.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given the issue's 599-listing store, the main threshold is 30 and the rotation threshold is 6. Punk, Hardcore, Crust, Black Metal, Death Metal, and Grindcore qualify as main.
+- AE2. Given Pop Rock has 30 listings and at least 75% also carry qualifying non-broad styles, Pop Rock is suppressed despite meeting the main threshold.
+- AE3. Given Oi has 13 listings, it is excluded from the main browse grid and included in thematic rotation.
+- AE4. Given a store carries only Classic Rock with enough support and no qualifying non-broad styles, Classic Rock remains eligible rather than leaving the store with no browse crates.
+- AE5. Given Crust listings also carry Punk, allocation considers Crust before Punk; completed crates are then presented in support-first order.
+- AE6. Given a store remains on the genres axis, genre crate counts, order, thematic discovery, and payload shape match current behavior.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** eligible listings feed the active axis; `StylesAxis` delegates to `StyleSelection`; `StorefrontCuration` consumes allocation/display order; `CrateStrategies::Thematic` consumes rotation candidates.
+- **Data lifecycle:** no persistent state is added. Results change only when eligible inventory, date-based thematic rotation, or deployed policy constants change.
+- **Cache:** inventory version still handles catalog changes; namespace advancement handles deployment of the new policy.
+- **Performance:** counting remains in memory because curation already loads eligible listings. Co-occurrence work should scale with styles per listing, not total distinct styles squared.
+- **Architecture:** domain calculations leave the orchestration service, and lower-level objects do not depend on controllers, presenters, or request state.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Curated broad-style set encodes product judgment and can become stale | Keep it small, named, and directly unit-tested; defer seller customization to a follow-up issue. |
+| Initial 5%, 1%, and 75% thresholds misclassify another catalog shape | Keep constants isolated and cover small, broad-only, overlap-heavy, and issue-derived fixtures. |
+| Specific-first allocation still cannot preserve a fully nested style under strict dedup | Preserve the existing viability rule and record this case in tests; duplicate style-crate membership remains out of scope. |
+| Co-occurrence calculation adds request-time work | Build counts in one pass and memoize one result per curation instance; existing serialized cache absorbs repeated requests. |
+| Thematic filtering removes a previously available featured crate | Treat no fringe candidate as a valid nil result, matching the existing optional featured-crate contract. |
+| Discogs style metadata is optional for most genres, so sparse coverage can leave the styles axis with no main crates | Keep empty output safe in this plan and track metadata-coverage fallback as follow-up work rather than changing the axis decision inside #245. |
+
+---
+
+## Sources and Research
+
+- GitHub issue: [#245 Styles selection](https://github.com/body-clock/milkcrate/issues/245)
+- Foundation change: [PR #244](https://github.com/body-clock/milkcrate/pull/244)
+- Discogs defines styles as sub-genres and notes that excess styles become confusing: [Database Guidelines 9. Genres / Styles](https://support.discogs.com/hc/en-us/articles/360005055213-Database-Guidelines-9-Genres-Styles)
+- Rails 8.1 supports plain Ruby model objects when persistence is unnecessary: [Active Model Basics](https://guides.rubyonrails.org/active_model_basics.html)
+- Local axis pattern: `docs/solutions/architecture-patterns/replace-type-code-with-polymorphism-2026-06-07.md`
+- Local strategy pattern: `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`
+- Product strategy: `STRATEGY.md`, especially the Digger's algorithm track

--- a/docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md
+++ b/docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md
@@ -1,7 +1,7 @@
 ---
 title: "Strategy-based crate selection with uniform scoring"
 date: 2026-05-07
-last_updated: 2026-05-22
+last_updated: 2026-06-07
 category: architecture-patterns
 module: storefront
 problem_type: architecture_pattern
@@ -83,7 +83,7 @@ Each strategy lives in its own file under `app/services/crate_strategies/`:
 | `NewArrivals` | `new_arrivals.rb` | Best-fit recency window (7/14/30/90/365d), then scored | Original |
 | `Thematic` | `thematic.rb` | Random style/genre theme from pool, then scored | Original |
 | `HiddenGems` | `hidden_gems.rb` | Low engagement (total ≤ 100), wants > haves (≥ 10), has image, genre cap 3 | Added later; ranking fixed to use RecordScorer |
-| `Genre` | `genre.rb` | Single genre filter (`primary_genre`), scored, capped | Extracted from StorefrontCuration |
+| `Genre` | `genre.rb` | Single genre filter (`primary_genre`), scored, capped. Accepts a `curation_axis:` parameter (GenresAxis/StylesAxis) for field-level filtering — axis owns the matching logic, strategy owns the selection pipeline. | Extracted from StorefrontCuration |
 
 ```ruby
 # app/services/crate_strategies/picks.rb
@@ -164,13 +164,14 @@ module CrateStrategies
   class Genre
     MIN_RECORDS = 4
 
-    def initialize(genre:, genre_counts:, today: Date.today)
+    def initialize(genre:, genre_counts:, curation_axis: GenresAxis.new, today: Date.today)
       @scorer = RecordScorer.new(genre_counts:, today:)
       @genre  = genre
+      @curation_axis = curation_axis
     end
 
     def select(pool, excluded_ids:)
-      # Select: match primary_genre
+      # Select: filter by axis (primary_genre or styles.include?)
       # Rank: pure RecordScorer score
       # Capped: CuratedCrate::CRATE_SIZE
     end
@@ -245,6 +246,9 @@ the correct 50-record version.
   with duplicated constants
 - Debugging a crate where the score breakdown doesn't match the ordering —
   check if the strategy has its own custom ranking
+- A strategy has axis-dependent field selection (e.g., `primary_genre` vs
+  `styles`) — extract a polymorphic axis object rather than threading a
+  symbol and branching in every strategy
 
 ## Examples
 
@@ -318,3 +322,4 @@ CrateStrategies::Genre.new(genre:, genre_counts:, today:)
 - `app/services/score_strategies/price_strategy.rb` — scorer-level price boost
 - `app/frontend/components/score_breakdown.tsx` — dev debug panel showing per-strategy scores
 - [Experiment pipeline simplification and scoring recalibration](../workflow-issues/experiment-pipeline-simplification-2026-05-21.md) — human-in-the-loop validation and strategy calibration
+- [Replace type-code conditionals with polymorphic curation axis](replace-type-code-with-polymorphism-2026-06-07.md) — CurationAxis base class + GenresAxis/StylesAxis subclasses; the axis IS the behavior difference, strategies just call `axis.key_for` or `axis.matches?`

--- a/docs/solutions/architecture-patterns/replace-type-code-with-polymorphism-2026-06-07.md
+++ b/docs/solutions/architecture-patterns/replace-type-code-with-polymorphism-2026-06-07.md
@@ -1,0 +1,225 @@
+---
+module: storefront
+date: 2026-06-07
+problem_type: architecture_pattern
+component: service_object
+severity: medium
+applies_when:
+  - "type-code symbol is threaded through multiple constructors and checked with if/else branches"
+  - "behavior varies based on a discrete discriminator with 2+ values"
+  - "new variants are expected or existing branching is growing across multiple classes"
+  - "each branch delegates to the same downstream methods but with different parameters"
+tags:
+  - polymorphism
+  - refactoring
+  - type-code
+  - conditional-logic
+  - strategy-pattern
+  - curation-axis
+related_components:
+  - rails_model
+---
+
+# Replace type-code conditionals with polymorphic curation axis
+
+## Context
+
+The storefront curation system introduced a `:genres`/:styles`symbol to switch between top-level Discogs genres and sub-genre styles for narrow-catalog stores (see PR [#244](https://github.com/body-clock/milkcrate/pull/244)). The symbol was threaded through five constructors — `Wall`, `CrateStrategies::Wall`, `CrateStrategies::Genre`, `CrateStrategies::HiddenGems`, and `StorefrontCuration` — and every strategy branched on it with`if @curation_axis == :styles`/`else`. This is a classic "type code with conditionals" anti-pattern from Sandi Metz's _Practical Object-Oriented Design in Ruby_.
+
+The product model makes this pattern especially costly. The storefront has three distinct surface types — Wall (a taste surface that conveys the store's point of view through a cover-first mural), Featured (rotating thematic crates), and Genre Grid (crate-digging surface). The Wall is not just another crate path; it's a fundamentally different interaction mode with a lightweight peek sheet rather than inline crate-digging. When the axis symbol conflates these surfaces by forcing each strategy to branch individually, changes that affect one surface risk silently breaking another.
+
+The immediate trigger was recognizing that adding a third axis (e.g., artist-based curation) would require touching every strategy plus the decision point, multiplying the conditional surface area. The refactoring extracted a `CurationAxis` base class with `GenresAxis` and `StylesAxis` subclasses — the axis IS the behavior difference.
+
+## Guidance
+
+### 1. Identify the type code and its consumers
+
+Find every place a symbol or enum is checked with `if`/`case`/`? :`. In the before state, `@curation_axis` appeared in three strategy methods (`apply_genre_cap`, `matches_axis?`, `under_genre_cap?`) and two `StorefrontCuration` methods (`curation_axis`, `genre_counts`).
+
+### 2. Extract the polymorphic interface
+
+Look at what each branch *does differently*. For the curation axis:
+
+| Operation | `:genres` | `:styles` |
+|-----------|-----------|-----------|
+| `key_for(listing)` | `listing.primary_genre` | `listing.styles.first` |
+| `matches?(listing, name)` | `listing.primary_genre == name` | `Array(listing.styles).include?(name)` |
+| `tally_from(listings)` | `listings.map(&:primary_genre)` | `listings.flat_map(&:styles)` |
+
+These become the abstract interface:
+
+```ruby
+# app/services/curation_axis.rb
+class CurationAxis
+  def key_for(_listing)    = raise NotImplementedError
+  def matches?(_listing, _name) = raise NotImplementedError
+  def tally_from(_listings) = raise NotImplementedError
+end
+```
+
+### 3. Create one subclass per variant — zero conditionals
+
+```ruby
+# app/services/genres_axis.rb
+class GenresAxis < CurationAxis
+  def key_for(listing)    = listing.primary_genre
+  def matches?(listing, name) = listing.primary_genre == name
+  def tally_from(listings) = listings.map(&:primary_genre).compact.tally
+end
+
+# app/services/styles_axis.rb
+class StylesAxis < CurationAxis
+  def key_for(listing)    = listing.styles.first
+  def matches?(listing, name) = Array(listing.styles).include?(name)
+  def tally_from(listings) = listings.flat_map(&:styles).compact.tally
+end
+```
+
+### 4. Replace type-code branches with polymorphic calls
+
+Every `@curation_axis == :styles ? ... : ...` becomes `@curation_axis.key_for(...)`:
+
+```ruby
+# Before — type code with ternary
+def apply_genre_cap(listing, genre_cap:, genre_seen:)
+  genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
+  return if genre_seen[genre] >= genre_cap
+  genre_seen[genre] += 1
+  listing
+end
+
+# After — polymorphic method call
+def apply_genre_cap(listing, genre_cap:, genre_seen:)
+  genre = @curation_axis.key_for(listing)
+  return if genre_seen[genre] >= genre_cap
+  genre_seen[genre] += 1
+  listing
+end
+```
+
+If a private helper existed solely to branch on the type code, delete it entirely — the polymorphic call supersedes it. In this refactoring, `matches_axis?` in `CrateStrategies::Genre` was deleted and replaced inline by `@curation_axis.matches?(l, @genre)`.
+
+### 5. Single decision point for instantiation
+
+The only place that branches on the type is where the axis object is constructed:
+
+```ruby
+# app/services/storefront_curation.rb
+def curation_axis
+  @curation_axis ||= (deep_genre_count >= 3) ? GenresAxis.new : StylesAxis.new
+end
+```
+
+This is the "factory" — the one place where conditionals belong. Every consumer downstream gets a fully-formed axis object and calls its methods without checking which subtype it is. `tally_from` also moves from a conditional block to a simple delegation:
+
+```ruby
+# Before
+def genre_counts
+  @genre_counts ||= if curation_axis == :styles
+    eligible_listings.flat_map(&:styles).compact.tally
+  else
+    eligible_listings.map(&:primary_genre).compact.tally
+  end
+end
+
+# After
+def genre_counts
+  @genre_counts ||= curation_axis.tally_from(eligible_listings)
+end
+```
+
+### 6. Thread the axis object (not a symbol) through constructors
+
+Strategy constructors accept the axis instance directly. The default is `GenresAxis.new` for backward compatibility in tests and experiment pipelines:
+
+```ruby
+class Wall
+  def initialize(eligible_listings:, genre_counts:, curation_axis: GenresAxis.new)
+    @curation_axis = curation_axis
+  end
+end
+
+class CrateStrategies::Genre
+  def initialize(genre:, genre_counts:, curation_axis: GenresAxis.new, today: Date.today)
+    @curation_axis = curation_axis
+  end
+end
+```
+
+### 7. Adding a third axis
+
+To add an artist-based axis: create `ArtistsAxis < CurationAxis` with the three interface methods, then add one branch in `StorefrontCuration#curation_axis`. Zero changes to strategy classes.
+
+## Why This Matters
+
+- **Eliminates duplicated branching.** Before: every strategy that touched the axis had its own `if/else`. After: zero branches in strategy code. The refactoring removed 3 net lines despite adding two new files and 10 new specs — the strategies got simpler.
+
+- **Single decision point.** Which axis to use lives in exactly one place. Changing the heuristic (threshold, depth ratio) requires one edit.
+
+- **Extensible without cascading changes.** New axis variants are one new subclass + one factory branch. This matters especially because the styling axis is already being studied for deeper filtering (#245) — any future refactoring of the axis behavior is isolated.
+
+- **Testable in isolation.** You can pass `GenresAxis.new` or `StylesAxis.new` directly into strategy tests. No need to mock symbols or simulate branching logic.
+
+- **Self-documenting.** `GenresAxis#key_for` tells you "this axis groups by primary genre" without reading ternary expressions. The class name IS the documentation.
+
+- **Sandi Metz principle in practice.** "Replace conditional with polymorphism" is one of the highest-leverage OO refactorings. It eliminates not just code but the cognitive load of tracking which branches apply where — especially important here because the three surfaces (Wall, Featured, Genre Grid) have different interaction models that the axis must serve without conflating them.
+
+## When to Apply
+
+- A symbol or enum is passed through 3+ classes, and each class branches on it
+- The variant behaviors are stable — the differences between `:genres` and `:styles` are well-understood
+- You anticipate adding a new variant soon
+- The operations that vary by type are finite and nameable
+
+Do **not** apply when there's only one consumer — a single ternary is cheaper than a class hierarchy. Do **not** apply when variants change frequently in incompatible directions.
+
+## Examples
+
+The full before/after covers three strategy classes and the orchestrator:
+
+```ruby
+# BEFORE — Wall: ternary in apply_genre_cap
+genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
+
+# BEFORE — Genre: private helper matches_axis? with if/else
+def matches_axis?(listing)
+  if @curation_axis == :styles
+    Array(listing.styles).include?(@genre)
+  else
+    listing.primary_genre == @genre
+  end
+end
+
+# BEFORE — HiddenGems: ternary in under_genre_cap?
+genre = @curation_axis == :styles ? listing.styles.first : listing.primary_genre
+
+# BEFORE — StorefrontCuration: genre_counts with if/else block
+@genre_counts ||= if curation_axis == :styles
+  eligible_listings.flat_map(&:styles).compact.tally
+else
+  eligible_listings.map(&:primary_genre).compact.tally
+end
+```
+
+```ruby
+# AFTER — Wall: polymorphic call, zero branching
+genre = @curation_axis.key_for(listing)
+
+# AFTER — Genre: matches_axis? deleted, replaced inline
+candidates.select { |l| @curation_axis.matches?(l, @genre) }
+
+# AFTER — HiddenGems: polymorphic call
+genre = @curation_axis.key_for(listing)
+
+# AFTER — StorefrontCuration: tally_from delegation
+@genre_counts ||= curation_axis.tally_from(eligible_listings)
+```
+
+## Related
+
+- [Strategy-based crate selection with uniform scoring](crate-strategies-pattern-2026-05-07.md) — The outer architecture pattern. The `CurationAxis` polymorphism lives *inside* these strategy classes; the strategies remain the selection layer while the axis owns field-level key extraction.
+- PR [#244](https://github.com/body-clock/milkcrate/pull/244) — The PR introducing the feature and the polymorphism refactoring
+- Issue [#245](https://github.com/body-clock/milkcrate/issues/245) — Follow-up: style filtering for narrow-catalog stores
+- Sandi Metz, _Practical Object-Oriented Design in Ruby_, Chapters 5-6
+- `app/services/curation_axis.rb`, `app/services/genres_axis.rb`, `app/services/styles_axis.rb`
+- `spec/services/genres_axis_spec.rb`, `spec/services/styles_axis_spec.rb`

--- a/docs/solutions/architecture-patterns/threshold-classification-over-denylist-2026-06-07.md
+++ b/docs/solutions/architecture-patterns/threshold-classification-over-denylist-2026-06-07.md
@@ -1,0 +1,169 @@
+---
+title: "Let counting be classification — removing curated denylists from threshold-based tiering"
+date: 2026-06-07
+category: architecture-patterns
+module: storefront
+problem_type: architecture_pattern
+component: service_object
+severity: medium
+applies_when:
+  - "Designing support-threshold classifiers that group items into tiers by frequency"
+  - "Considering a curated denylist or overlap-based suppression to exclude 'too broad' items"
+  - "Classification already sorts by count or frequency as the primary metric"
+symptoms:
+  - "Broad-style suppression list was rock-only, unable to generalize to electronic, jazz, or hip-hop stores"
+  - "Curated denylist required per-genre-family maintenance to stay effective across all Discogs genres"
+  - "Two independent code reviews did not flag the genre-bias problem"
+tags:
+  - threshold-classification
+  - style-selection
+  - counting-is-classification
+  - curated-denylist
+  - over-engineering
+---
+
+# Let counting be classification — removing curated denylists from threshold-based tiering
+
+## Context
+
+The `StyleSelection` domain object (`app/models/style_selection.rb`) classifies a store's Discogs styles into tiers for crate allocation and thematic rotation on narrow-catalog stores. The tier rules are support-threshold based:
+
+| Tier | Rule |
+|------|------|
+| **Main** | Styles with ≥5% of eligible listings (floored at `MIN_RECORDS`) |
+| **Rotation** | Styles with ≥1% but below the main threshold (floored at `MIN_RECORDS`) |
+| **Omitted** | Styles below the rotation threshold |
+
+Originally, there was a fourth tier — **suppressed** — enforced by a curated denylist with co-occurrence analysis. The `BROAD_STYLES` constant listed five rock sub-genres (Pop Rock, Classic Rock, Hard Rock, Blues Rock, Rock & Roll). If a broad style's listings overlapped ≥75% with qualifying non-broad styles, the broad style was excluded from main crates and thematic rotation even if its count met the thresholds.
+
+The purpose was to prevent overly general Discogs labels from drowning out distinctive sub-genres — a genuine concern that motivated the feature's design (issue [#245](https://github.com/body-clock/milkcrate/issues/245)).
+
+## What Didn't Work
+
+**The denylist was genre-specific and couldn't generalize.** The plan from `ce-plan` and two independent code review passes all accepted the approach without flagging the genre bias. It took a developer questioning the constant during implementation to realize the limitation:
+
+- A store selling electronic music had no mechanism to suppress "Electronic", "Ambient", or "Experimental" — those weren't in `BROAD_STYLES`.
+- A jazz store had no way to suppress "Jazz" as a broad Discogs style.
+- Expanding the list to cover every genre family would require continuous product judgment and per-genre maintenance.
+
+The overlap-based suppression mechanism re-classified styles based on the same data that already produced their support counts — if "Electronic" had 200 listings in an electronic store, the count already signalled it was a dominant category. Suppressing it would contradict the data.
+
+## Guidance
+
+**When your classification is already sorting by support count (or frequency), you do not need an additional curation layer to suppress "too broad" items. Counting IS classification for this domain.**
+
+The argument in full:
+
+1. **Support count already measures relevance.** If "Electronic" accounts for 30% of an electronic store's listings, it *is* a dominant category in that store. Suppressing it would misrepresent the store's actual inventory.
+2. **Curated denylists are genre-specific by nature.** You cannot maintain one list for every genre family (rock, electronic, jazz, hip-hop, world, folk). Any hardcoded list encodes product judgment for *one* genre and silently does nothing for others — creating false consistency.
+3. **The threshold breakpoints (≥5% main, ≥1% rotation) are the effective curation layer.** A "too broad" style in a store that barely stocks that genre will naturally fall below the 1% threshold and land in Omitted. The only styles that reach Main are genuinely dominant in that store — which is the correct behavior.
+
+### Implementation pattern
+
+Do not add denylists or overlap-based suppression to a support-thresholds classifier. If the data-driven thresholds are giving bad results, examine the thresholds and input data (e.g., raw Discogs style tags), not the sorting function.
+
+```ruby
+# Before: ~55 lines of implementation + ~180 lines of tests
+# BROAD_STYLES constant, SUPPRESSION_RATIO, overlapping calculation,
+# suppression-aware tiering branch, broad-only store fallback
+
+BROAD_STYLES = %w[
+  Blues\ Rock Classic\ Rock Hard\ Rock Pop\ Rock Rock\ &\ Roll
+].freeze
+SUPPRESSION_RATIO = 0.75
+
+def suppressed?(name)
+  return false unless BROAD_STYLES.include?(name)
+  return false if support[name].nil? || support[name].zero?
+  count_broad_overlap(name).to_f / support[name] >= SUPPRESSION_RATIO
+end
+
+def main_styles
+  support.select { |name, count|
+    count >= MIN_RECORDS &&
+    count >= threshold &&
+    !suppressed_styles.include?(name)  # extra check
+  }.keys.sort
+end
+```
+
+```ruby
+# After: 17 lines of implementation logic, 26 test examples
+# Three-tier classification driven purely by support thresholds
+
+def main_styles
+  support.select { |name, count|
+    count >= MIN_RECORDS && count >= (total_listings * MAIN_THRESHOLD).ceil
+  }.keys.sort
+end
+
+def rotation_styles
+  support.select { |name, count|
+    next false if main_styles.include?(name)
+    count >= MIN_RECORDS && count >= (total_listings * ROTATION_THRESHOLD).ceil
+  }.keys.sort
+end
+```
+
+## Why This Matters
+
+- **Maintenance burden.** The denylist approach was rock-specific. No one was going to maintain equivalent lists for 20+ genre families. The result is a system that appears to handle "noise" but silently only handles one genre.
+- **False consistency.** An electronic store had no mechanism to suppress "Electronic" or "Ambient." The code and plan mentioned suppression generally, but it only fired for rock. The system looked consistent but was silently asymmetric.
+- **Over-engineering signal.** The overlap calculation re-classified styles based on the *same data* that produced their support counts. The co-occurrence check (`count_broad_overlap`) iterated every listing's style set to compute an overlap ratio that would, at best, confirm what the raw count already showed. (session history)
+- **Test tax.** The suppression machinery required ~180 lines of tests (7 examples in `style_selection_spec.rb`, plus integration tests in `styles_axis_spec.rb`, `storefront_curation_spec.rb`, and `stores_spec.rb`). The three-tier classification needs ~26 examples.
+
+## When to Apply
+
+- You are building a classifier that groups items by support count, frequency, or proportional thresholds.
+- Someone proposes adding a "don't show X even if it qualifies" list — especially a curated one.
+- The items being suppressed are already sorted by the same metric used to determine their tier.
+- The denylist covers only a subset of possible categories and would need to be extended asymmetrically across genre families.
+
+**Counter-indication:** If thresholds alone produce bad results for a specific known pattern (e.g., a universally-applied Discogs parent tag that appears on every listing and has maximum support), consider data preprocessing (cleaning input tags) before adding a classification-layer filter.
+
+## Examples
+
+**Before — denylist + overlap suppression:**
+
+```ruby
+BROAD_STYLES = %w[Pop Rock Classic Rock Hard Rock Blues Rock Rock & Roll].freeze
+SUPPRESSION_RATIO = 0.75
+
+def suppressed?(style_name)
+  return false unless BROAD_STYLES.include?(style_name)
+  overlap_ratio(style_name) >= SUPPRESSION_RATIO
+end
+# Plus: qualifying_non_broad_styles, compute_suppressed,
+#       suppressible?, count_broad_overlap
+```
+
+**After — pure threshold-based tiering:**
+
+```ruby
+MAIN_THRESHOLD = 0.05
+ROTATION_THRESHOLD = 0.01
+
+def main_styles
+  support.select { |name, count|
+    count >= MIN_RECORDS && count >= (total_listings * MAIN_THRESHOLD).ceil
+  }.keys.sort
+end
+
+def rotation_styles
+  support.select { |name, count|
+    next false if main_styles.include?(name)
+    count >= MIN_RECORDS && count >= (total_listings * ROTATION_THRESHOLD).ceil
+  }.keys.sort
+end
+```
+
+The denylist was removed entirely (~55 LOC of implementation, ~180 LOC of tests). The three-tier system (main / rotation / omitted) now stands on support thresholds alone.
+
+## Related
+
+- Issue [#245](https://github.com/body-clock/milkcrate/issues/245) — Styles selection: filter noise, surface distinctive sub-genres for narrow-catalog stores
+- PR [#246](https://github.com/body-clock/milkcrate/pull/246) — feat(styles): select distinctive styles for narrow-catalog stores
+- `docs/solutions/architecture-patterns/replace-type-code-with-polymorphism-2026-06-07.md` — The CurationAxis polymorphism that StyleSelection runs inside
+- `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md` — The crate selection pipeline that consumes StyleSelection classifications
+- `app/models/style_selection.rb` — The refactored class
+- `spec/models/style_selection_spec.rb` — 26 examples replacing ~180 lines of suppression tests

--- a/progress.md
+++ b/progress.md
@@ -1,10 +1,15 @@
 # Progress
 
 ## Status
-In Progress
+Complete
 
 ## Tasks
+- [x] Efficiency review of sales polling diff (simplify-diff.patch)
 
 ## Files Changed
+- /tmp/simplify-efficiency.md — efficiency findings
 
 ## Notes
+8 findings across the diff. Highest-impact: per-order SoldListingRemover calls (Finding 2)
+cause Nx state updates. Combined with wasted reload (Finding 3) and redundant COUNT (Finding 4),
+the per-cycle query count drops from ~4/order to ~2 total.

--- a/progress.md
+++ b/progress.md
@@ -1,15 +1,41 @@
 # Progress
 
-## Status
-Complete
+## Context Analyzer — ce-compound documentation workflow
 
-## Tasks
-- [x] Efficiency review of sales polling diff (simplify-diff.patch)
+**File:** `removing-broad-styles-suppression-2026-06-07.md` → `docs/solutions/architecture-patterns/`
 
-## Files Changed
-- /tmp/simplify-efficiency.md — efficiency findings
+### Status: ✅ Complete
 
-## Notes
-8 findings across the diff. Highest-impact: per-order SoldListingRemover calls (Finding 2)
-cause Nx state updates. Combined with wasted reload (Finding 3) and redundant COUNT (Finding 4),
-the per-cycle query count drops from ~4/order to ~2 total.
+**Decision summary:**
+
+| Field | Value |
+|---|---|
+| Track | **Knowledge** (deliberate architectural decision, not a defect) |
+| `problem_type` | `architecture_pattern` |
+| Category | `docs/solutions/architecture-patterns/` |
+| Filename | `removing-broad-styles-suppression-2026-06-07.md` |
+| `module` | `storefront curation / style selection` |
+| `component` | `service_object` |
+| `severity` | `medium` |
+
+**Key reasoning:**
+- The `BROAD_STYLES` suppression wasn't broken — it worked correctly for rock genres but couldn't generalize. This is a design evolution, not a bug fix.
+- `architecture_pattern` is the narrowest problem_type: a structural decision about how style-to-tier classification works. Not a `best_practice` (too domain-specific), not a `design_pattern` (not a GoF/DP pattern), not a `tooling_decision`.
+- `docs/solutions/architecture-patterns/` already exists with 6 prior docs matching `[kebab-case-slug]-YYYY-MM-DD.md` convention.
+
+**Output written to:** `/tmp/compound-context-analyzer.md`
+
+---
+
+## Related Docs Finder — ce-compound documentation workflow
+
+### Status: ✅ Complete
+
+**Output written to:** `/tmp/compound-related.md`
+
+**Key findings:**
+- **High overlap** with `docs/solutions/architecture-patterns/replace-type-code-with-polymorphism-2026-06-07.md` (same feature area: curation-axis system, StyleSelection, StylesAxis)
+- **Moderate overlap** with `docs/solutions/architecture-patterns/crate-strategies-pattern-2026-05-07.md`
+- **No existing doc describes the BROAD_STYLES suppression mechanism** — it was introduced (commit `5b5c500`) and then removed (commit `fbae3f8`) in the same PR branch. No doc from the previous iteration exists.
+- **Recommendation:** Create a new doc (don't update existing) with cross-references to the polymorphism and crate-strategies docs.
+- **Related GitHub:** Issue #245 (problem statement, OPEN), PR #246 (solution, OPEN)

--- a/spec/models/style_selection_spec.rb
+++ b/spec/models/style_selection_spec.rb
@@ -11,15 +11,6 @@ RSpec.describe StyleSelection do
     Array.new(count) { listing(styles:) }
   end
 
-  # Helper: build 599 listings with a realistic narrow-store distribution.
-  # Returns [listings_array, selection].
-  def build_issue_fixture(counts)
-    all = counts.flat_map { |style, count| listings(count, styles: [ style ]) }
-    # For listings that should carry multiple styles (overlap), we rebuild
-    # them below in specific tests.
-    [all, described_class.new(all)]
-  end
-
   describe "#support" do
     it "deduplicates styles within each listing" do
       l = listing(styles: %w[Punk Punk Hardcore])

--- a/spec/models/style_selection_spec.rb
+++ b/spec/models/style_selection_spec.rb
@@ -175,16 +175,12 @@ RSpec.describe StyleSelection do
       expect(sel.overlap_risk["Crust"]).to be_within(0.01).of(4.0 / 6)
     end
 
-    it "returns zero risk for styles with no higher-support main styles" do
-      all = listings(50, styles: %w[Punk]) +
-            listings(50, styles: %w[Metal])
+    it "returns zero risk for styles with no overlap with higher-support main styles" do
+      all = listings(49, styles: %w[Punk]) +
+            listings(51, styles: %w[Metal])
 
       sel = described_class.new(all)
 
-      # Both main, but one has to come first by support. Metal at 50, Punk at 50 → tie, alpha decides.
-      # "Metal" < "Punk" alphabetically, so Metal is first in the sorted-by-support list.
-      # Punk has Metal as higher → some overlap?
-      # Actually they have completely separate listings, so overlap_risk["Punk"] = 0
       expect(sel.overlap_risk["Punk"]).to eq(0)
     end
   end
@@ -317,6 +313,15 @@ RSpec.describe StyleSelection do
       # Allocation order: lowest support first when risk is tied.
       # Hardcore (10) before Punk (15)
       expect(sel.allocation_order).to eq(%w[Hardcore Punk Other])
+    end
+
+    it "does not treat equal-support styles as overlap risks for each other" do
+      overlapping = listings(5, styles: %w[Alpha Beta])
+      other = listings(95, styles: %w[Other])
+
+      sel = described_class.new(overlapping + other)
+
+      expect(sel.allocation_order).to eq(%w[Alpha Beta Other])
     end
   end
 end

--- a/spec/models/style_selection_spec.rb
+++ b/spec/models/style_selection_spec.rb
@@ -1,0 +1,331 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StyleSelection do
+  def listing(styles:)
+    instance_double(Listing, styles:)
+  end
+
+  def listings(count, styles:)
+    Array.new(count) { listing(styles:) }
+  end
+
+  # Helper: build 599 listings with a realistic narrow-store distribution.
+  # Returns [listings_array, selection].
+  def build_issue_fixture(counts)
+    all = counts.flat_map { |style, count| listings(count, styles: [ style ]) }
+    # For listings that should carry multiple styles (overlap), we rebuild
+    # them below in specific tests.
+    [all, described_class.new(all)]
+  end
+
+  describe "#support" do
+    it "deduplicates styles within each listing" do
+      l = listing(styles: %w[Punk Punk Hardcore])
+      sel = described_class.new([ l ])
+
+      expect(sel.support).to eq("Punk" => 1, "Hardcore" => 1)
+    end
+
+    it "skips nil and empty style arrays" do
+      a = listing(styles: nil)
+      b = listing(styles: [])
+      sel = described_class.new([ a, b ])
+
+      expect(sel.support).to eq({})
+    end
+
+    it "excludes compacted nils within style arrays" do
+      a = listing(styles: [ "Punk", nil, "Hardcore" ])
+      sel = described_class.new([ a ])
+
+      expect(sel.support).to eq("Punk" => 1, "Hardcore" => 1)
+    end
+  end
+
+  describe "#main_styles" do
+    it "classifies styles at or above 5% of eligible listings as main" do
+      all = listings(75, styles: %w[Punk]) +
+            listings(5, styles: %w[Hardcore]) +
+            listings(3, styles: %w[Crust])
+
+      sel = described_class.new(all)
+
+      # 83 total. Main threshold = ceil(83 * 0.05) = ceil(4.15) = 5.
+      # Punk 75 ≥ 5 → main. Hardcore 5 ≥ 5 AND ≥ 4 → main. Crust 3 < 4 → not even rotation floor.
+      expect(sel.main_styles).to include("Punk", "Hardcore")
+      expect(sel.main_styles).not_to include("Crust")
+    end
+
+    it "treats exactly 5% as main (boundary)" do
+      # 20 listings total: 5% = 1. Punk at 1 meets floor (MIN_RECORDS=4)?
+      # MIN_RECORDS = 4, so need at least 4. Let me use 80 listings total.
+      # 5% of 80 = 4. So 4 listings out of 80 = exactly 5%.
+      all = listings(4, styles: %w[Punk]) +
+            listings(76, styles: %w[Other])
+
+      sel = described_class.new(all)
+
+      expect(sel.main_styles).to include("Punk")
+    end
+
+    it "excludes one record below 5% from main (boundary)" do
+      # 81 listings total: 5% = 4.05 → .to_i = 4. 3 Punk listings.
+      # 3 < 4 (MIN_RECORDS) → not even rotation floor. Need at least 4.
+      # Let me use: 5% of 100 = 5. 4 < 5, so not main. But 4 ≥ rotation floor.
+      all = listings(4, styles: %w[Punk]) +
+            listings(96, styles: %w[Other])
+
+      sel = described_class.new(all)
+
+      expect(sel.main_styles).not_to include("Punk")
+    end
+
+    it "excludes suppressed broad styles from main" do
+      # Create a scenario where Pop Rock is suppressed.
+      # Pop Rock needs: ≥ 75% overlap with qualifying non-broad styles.
+      # Let me use 100 listings: 20 Pop Rock, 20 Punk, 60 Other.
+      # Pop Rock count 20 ≥ 4 (MIN_RECORDS) and 20 ≥ 5 (5% of 100).
+      # Qualifying non-broad: Punk at 20, Other at 60 (both ≥ rotation threshold).
+      # Pop Rock overlap: we need 75% of its 20 listings to also carry Punk or Other.
+      # Build: 15 listings have both Pop Rock and Punk, 5 have only Pop Rock.
+      # Overlap = 15/20 = 75% ≥ SUPPRESSION_RATIO → suppressed.
+      pop_punk = Array.new(15) { listing(styles: %w[Pop\ Rock Punk]) }
+      pop_only = listings(5, styles: %w[Pop\ Rock])
+      punk_only = listings(5, styles: %w[Punk])
+      other = listings(75, styles: %w[Other])
+
+      sel = described_class.new(pop_punk + pop_only + punk_only + other)
+
+      expect(sel.main_styles).not_to include("Pop Rock")
+      expect(sel.main_styles).to include("Punk", "Other")
+    end
+
+    it "keeps broad style as main when overlap is below 75%" do
+      # 14 overlap out of 20 = 70% < 75% → not suppressed.
+      pop_punk = Array.new(14) { listing(styles: %w[Pop\ Rock Punk]) }
+      pop_only = listings(6, styles: %w[Pop\ Rock])
+      punk_only = listings(6, styles: %w[Punk])
+      other = listings(74, styles: %w[Other])
+
+      sel = described_class.new(pop_punk + pop_only + punk_only + other)
+
+      expect(sel.main_styles).to include("Pop Rock")
+      expect(sel.main_styles).to include("Punk")
+    end
+  end
+
+  describe "broad-only store" do
+    it "retains broad labels when no qualifying non-broad styles exist" do
+      # Store has only Classic Rock and Hard Rock — no non-broad qualifying styles.
+      # suppression check: qualifying_non_broad_styles.empty? → no suppression.
+      all = listings(30, styles: %w[Classic\ Rock]) +
+            listings(30, styles: %w[Hard\ Rock])
+
+      sel = described_class.new(all)
+
+      expect(sel.main_styles).to include("Classic Rock", "Hard Rock")
+      expect(sel.rotation_styles).to be_empty
+    end
+  end
+
+  describe "#rotation_styles" do
+    it "classifies non-main styles at or above 1% as rotation" do
+      # 200 listings total: 5% = 10, 1% = 2.
+      # But MIN_RECORDS floor = 4, so rotation needs count ≥ 4 AND ≥ 2.
+      all = listings(15, styles: %w[Punk]) +
+            listings(15, styles: %w[Hardcore]) +
+            listings(6, styles: %w[Oi]) +
+            listings(3, styles: %w[Noise]) +
+            listings(161, styles: %w[Other])
+
+      sel = described_class.new(all)
+
+      # Punk 15, Hardcore 15 ≥ 10 → main
+      # Oi 6: not main (6 < 10), 6 ≥ rotation threshold (2), 6 ≥ MIN_RECORDS (4) → rotation
+      # Noise 3: not main, 3 ≥ 2, but 3 < MIN_RECORDS → omitted
+      expect(sel.rotation_styles).to include("Oi")
+      expect(sel.rotation_styles).not_to include("Noise")
+    end
+
+    it "excludes suppressed broad styles from rotation" do
+      # Pop Rock at count 10 with 80% overlap → suppressed.
+      pop_punk = Array.new(8) { listing(styles: %w[Pop\ Rock Punk]) }
+      pop_only = listings(2, styles: %w[Pop\ Rock])
+      punk_only = listings(15, styles: %w[Punk])
+      other = listings(75, styles: %w[Other])
+
+      sel = described_class.new(pop_punk + pop_only + punk_only + other)
+
+      expect(sel.rotation_styles).not_to include("Pop Rock")
+    end
+  end
+
+  describe "#overlap_risk" do
+    it "computes the share of a style's listings that also carry higher-support main styles" do
+      # Punk 15, Hardcore 10, Crust 6 (all main).
+      # Crust: 4 of its 6 also have Hardcore → overlap_risk = 4/6 ≈ 0.667
+      # Punk: no higher-support main → not present in overlap_risk
+      punk = listings(15, styles: %w[Punk])
+      hardcore = listings(10, styles: %w[Hardcore])
+      crust = (1..4).map { listing(styles: %w[Crust Hardcore]) } +
+              (1..2).map { listing(styles: %w[Crust]) }
+      other = listings(69, styles: %w[Other])
+
+      sel = described_class.new(punk + hardcore + crust + other)
+
+      # Main styles sorted by support: Punk (15), Other (69? wait...)
+      # Actually total listings: 15 + 10 + 6 + 69 = 100
+      # 5% threshold = 5. So main: Punk (15), Other (69), Hardcore (10), Crust (6)
+      # Higher-support for Hardcore: Punk, Other
+      # Higher-support for Crust: Punk, Other, Hardcore
+      # Crust 6, 4 of them have Hardcore → overlap_risk["Crust"] == 4.0/6
+      expect(sel.overlap_risk["Crust"]).to be_within(0.01).of(4.0 / 6)
+    end
+
+    it "returns zero risk for styles with no higher-support main styles" do
+      all = listings(50, styles: %w[Punk]) +
+            listings(50, styles: %w[Metal])
+
+      sel = described_class.new(all)
+
+      # Both main, but one has to come first by support. Metal at 50, Punk at 50 → tie, alpha decides.
+      # "Metal" < "Punk" alphabetically, so Metal is first in the sorted-by-support list.
+      # Punk has Metal as higher → some overlap?
+      # Actually they have completely separate listings, so overlap_risk["Punk"] = 0
+      expect(sel.overlap_risk["Punk"]).to eq(0)
+    end
+  end
+
+  describe "#allocation_order" do
+    it "places highest-overlap-risk styles first, then lowest support, then name" do
+      # Three main styles: Punk (20, no overlap), Hardcore (15, some overlap with Punk),
+      # Crust (10, high overlap with Hardcore).
+      # Overlap risk: Crust > Hardcore > Punk(=0).
+      # So allocation order: Crust, Hardcore, Punk.
+      punk_listings = listings(20, styles: %w[Punk])
+      hc_listings = listings(15, styles: %w[Hardcore])
+      # Crust: 8 also Hardcore, 2 alone
+      crust_listings = Array.new(8) { listing(styles: %w[Crust Hardcore]) } +
+                       listings(2, styles: %w[Crust])
+      # Hardcore: 5 also Punk
+      hc_punk = Array.new(5) { listing(styles: %w[Hardcore Punk]) }
+      hc_only = listings(10, styles: %w[Hardcore])
+      other = listings(40, styles: %w[Other])
+
+      sel = described_class.new(
+        punk_listings + hc_punk + hc_only + crust_listings + other
+      )
+
+      # Main styles (all >= 5% of total = 5% of ~90):
+      # Punk: 20 + 5 = 25, Hardcore: 5 + 10 + 8 = 23, Crust: 10, Other: 40
+      # Overlap risk for Crust: 8/10 = 0.8 (with Hardcore)
+      # Overlap risk for Hardcore: 5/23 ≈ 0.22 (with Punk, which is higher support)
+      # Overlap risk for Punk: 0 (no higher-support main)
+      # Allocation order: Crust (risk 0.8), Hardcore (risk 0.22), Punk (risk 0)
+      expect(sel.allocation_order).to eq(%w[Crust Hardcore Punk Other])
+    end
+  end
+
+  describe "#display_order" do
+    it "sorts by support descending then name" do
+      all = listings(20, styles: %w[Punk]) +
+            listings(30, styles: %w[Metal]) +
+            listings(20, styles: %w[Hardcore]) +
+            listings(30, styles: %w[Other])
+
+      sel = described_class.new(all)
+
+      # Metal (30), Other (30), Hardcore (20), Punk (20)
+      # Alphabetical for ties: "Hardcore" < "Punk", "Metal" < "Other"
+      expect(sel.display_order).to eq(%w[Metal Other Hardcore Punk])
+    end
+  end
+
+  describe "#main_counts" do
+    it "returns counts only for main styles" do
+      all = listings(20, styles: %w[Punk]) +
+            listings(5, styles: %w[Crust]) +
+            listings(75, styles: %w[Other])
+
+      sel = described_class.new(all)
+
+      # total = 100, main threshold = 5
+      # Punk 20 ≥ 5 → main, Crust 5 ≥ 5 AND ≥ 4 → main, Other 75 → main
+      expect(sel.main_counts).to include("Punk" => 20, "Crust" => 5, "Other" => 75)
+      expect(sel.main_counts.keys).to match_array(%w[Crust Other Punk])
+    end
+  end
+
+  describe "issue example distribution" do
+    it "produces the expected tier boundaries for the 599-listing issue store" do
+      # Construct 599 listings matching the issue's style distribution.
+      # Desired style counts (some listings carry multiple styles):
+      #   Punk 367, Hardcore 262, Crust 39, Black Metal 38,
+      #   Death Metal 38, Grindcore 36, Oi 13, Noise 8.
+      # Main threshold: ceil(599 * 0.05) = 30.
+      # Rotation threshold: ceil(599 * 0.01) = 6.
+
+      # Overlap construction:
+      #   h_punk_hc    = 163 (Punk + Hardcore)
+      #   punk_only    = 204 (Punk only)
+      #   hc_only      = 60  (Hardcore only)
+      #   crust_hc     = 39  (Crust + Hardcore)
+      #   bm_only      = 38  (Black Metal)
+      #   dm_only      = 38  (Death Metal)
+      #   grind_only   = 36  (Grindcore)
+      #   oi_only      = 13  (Oi)
+      #   noise_only   = 8   (Noise)
+      # Total = 599, Punk = 367, Hardcore = 262 ✓
+
+      all = []
+      all += Array.new(163) { listing(styles: %w[Punk Hardcore]) }
+      all += Array.new(204) { listing(styles: %w[Punk]) }
+      all += Array.new(60)  { listing(styles: %w[Hardcore]) }
+      all += Array.new(39)  { listing(styles: %w[Crust Hardcore]) }
+      all += Array.new(38)  { listing(styles: %w[Black\ Metal]) }
+      all += Array.new(38)  { listing(styles: %w[Death\ Metal]) }
+      all += Array.new(36)  { listing(styles: %w[Grindcore]) }
+      all += Array.new(13)  { listing(styles: %w[Oi]) }
+      all += Array.new(8)   { listing(styles: %w[Noise]) }
+
+      sel = described_class.new(all)
+
+      expect(sel.total_listings).to eq(599)
+
+      # All 6 core styles ≥ 30 → main
+      expect(sel.main_styles).to include(
+        "Punk", "Hardcore", "Crust", "Black Metal", "Death Metal", "Grindcore"
+      )
+
+      # Rotation tier: Oi 13 ≥ 6, Noise 8 ≥ 6
+      expect(sel.rotation_styles).to include("Oi", "Noise")
+    end
+  end
+
+  describe "deterministic tie-breaking" do
+    it "breaks support ties alphabetically" do
+      all = listings(20, styles: %w[Metal]) +
+            listings(20, styles: %w[Punk]) +
+            listings(60, styles: %w[Other])
+
+      sel = described_class.new(all)
+
+      expect(sel.display_order).to eq(%w[Other Metal Punk])
+    end
+
+    it "breaks overlap-risk ties with support then name" do
+      # Need two styles with same overlap-risk. Both with risk 0.
+      punk = listings(15, styles: %w[Punk])
+      hc = listings(10, styles: %w[Hardcore])
+      other = listings(75, styles: %w[Other])
+
+      sel = described_class.new(punk + hc + other)
+
+      # Allocation order: lowest support first when risk is tied.
+      # Hardcore (10) before Punk (15)
+      expect(sel.allocation_order).to eq(%w[Hardcore Punk Other])
+    end
+  end
+end

--- a/spec/models/style_selection_spec.rb
+++ b/spec/models/style_selection_spec.rb
@@ -62,9 +62,6 @@ RSpec.describe StyleSelection do
     end
 
     it "excludes one record below 5% from main (boundary)" do
-      # 81 listings total: 5% = 4.05 → .to_i = 4. 3 Punk listings.
-      # 3 < 4 (MIN_RECORDS) → not even rotation floor. Need at least 4.
-      # Let me use: 5% of 100 = 5. 4 < 5, so not main. But 4 ≥ rotation floor.
       all = listings(4, styles: %w[Punk]) +
             listings(96, styles: %w[Other])
 
@@ -72,59 +69,10 @@ RSpec.describe StyleSelection do
 
       expect(sel.main_styles).not_to include("Punk")
     end
-
-    it "excludes suppressed broad styles from main" do
-      # Create a scenario where Pop Rock is suppressed.
-      # Pop Rock needs: ≥ 75% overlap with qualifying non-broad styles.
-      # Let me use 100 listings: 20 Pop Rock, 20 Punk, 60 Other.
-      # Pop Rock count 20 ≥ 4 (MIN_RECORDS) and 20 ≥ 5 (5% of 100).
-      # Qualifying non-broad: Punk at 20, Other at 60 (both ≥ rotation threshold).
-      # Pop Rock overlap: we need 75% of its 20 listings to also carry Punk or Other.
-      # Build: 15 listings have both Pop Rock and Punk, 5 have only Pop Rock.
-      # Overlap = 15/20 = 75% ≥ SUPPRESSION_RATIO → suppressed.
-      pop_punk = Array.new(15) { listing(styles: %w[Pop\ Rock Punk]) }
-      pop_only = listings(5, styles: %w[Pop\ Rock])
-      punk_only = listings(5, styles: %w[Punk])
-      other = listings(75, styles: %w[Other])
-
-      sel = described_class.new(pop_punk + pop_only + punk_only + other)
-
-      expect(sel.main_styles).not_to include("Pop Rock")
-      expect(sel.main_styles).to include("Punk", "Other")
-    end
-
-    it "keeps broad style as main when overlap is below 75%" do
-      # 14 overlap out of 20 = 70% < 75% → not suppressed.
-      pop_punk = Array.new(14) { listing(styles: %w[Pop\ Rock Punk]) }
-      pop_only = listings(6, styles: %w[Pop\ Rock])
-      punk_only = listings(6, styles: %w[Punk])
-      other = listings(74, styles: %w[Other])
-
-      sel = described_class.new(pop_punk + pop_only + punk_only + other)
-
-      expect(sel.main_styles).to include("Pop Rock")
-      expect(sel.main_styles).to include("Punk")
-    end
-  end
-
-  describe "broad-only store" do
-    it "retains broad labels when no qualifying non-broad styles exist" do
-      # Store has only Classic Rock and Hard Rock — no non-broad qualifying styles.
-      # suppression check: qualifying_non_broad_styles.empty? → no suppression.
-      all = listings(30, styles: %w[Classic\ Rock]) +
-            listings(30, styles: %w[Hard\ Rock])
-
-      sel = described_class.new(all)
-
-      expect(sel.main_styles).to include("Classic Rock", "Hard Rock")
-      expect(sel.rotation_styles).to be_empty
-    end
   end
 
   describe "#rotation_styles" do
     it "classifies non-main styles at or above 1% as rotation" do
-      # 200 listings total: 5% = 10, 1% = 2.
-      # But MIN_RECORDS floor = 4, so rotation needs count ≥ 4 AND ≥ 2.
       all = listings(15, styles: %w[Punk]) +
             listings(15, styles: %w[Hardcore]) +
             listings(6, styles: %w[Oi]) +
@@ -134,22 +82,10 @@ RSpec.describe StyleSelection do
       sel = described_class.new(all)
 
       # Punk 15, Hardcore 15 ≥ 10 → main
-      # Oi 6: not main (6 < 10), 6 ≥ rotation threshold (2), 6 ≥ MIN_RECORDS (4) → rotation
-      # Noise 3: not main, 3 ≥ 2, but 3 < MIN_RECORDS → omitted
+      # Oi 6: not main (6 < 10), meets rotation (≥ 2 and ≥ 4) → rotation
+      # Noise 3: not main, 3 < 4 (MIN_RECORDS) → omitted
       expect(sel.rotation_styles).to include("Oi")
       expect(sel.rotation_styles).not_to include("Noise")
-    end
-
-    it "excludes suppressed broad styles from rotation" do
-      # Pop Rock at count 10 with 80% overlap → suppressed.
-      pop_punk = Array.new(8) { listing(styles: %w[Pop\ Rock Punk]) }
-      pop_only = listings(2, styles: %w[Pop\ Rock])
-      punk_only = listings(15, styles: %w[Punk])
-      other = listings(75, styles: %w[Other])
-
-      sel = described_class.new(pop_punk + pop_only + punk_only + other)
-
-      expect(sel.rotation_styles).not_to include("Pop Rock")
     end
   end
 
@@ -313,15 +249,6 @@ RSpec.describe StyleSelection do
       # Allocation order: lowest support first when risk is tied.
       # Hardcore (10) before Punk (15)
       expect(sel.allocation_order).to eq(%w[Hardcore Punk Other])
-    end
-
-    it "does not treat equal-support styles as overlap risks for each other" do
-      overlapping = listings(5, styles: %w[Alpha Beta])
-      other = listings(95, styles: %w[Other])
-
-      sel = described_class.new(overlapping + other)
-
-      expect(sel.allocation_order).to eq(%w[Alpha Beta Other])
     end
   end
 end

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -137,5 +137,86 @@ RSpec.describe "Stores", type: :request do
         expect(sections.first.dig("crate", "slug")).to eq("wall")
       end
     end
+
+    context "with styles axis (narrow-catalog store)" do
+      it "renders main style crate names and excludes rotation-tier styles from browse grid" do
+        store = create(:store, discogs_username: "narrowstore")
+        create_list(:listing, 50, store:, genres: [ "Rock" ], styles: [ "Punk" ], format: "LP")
+        create_list(:listing, 40, store:, genres: [ "Rock" ], styles: [ "Hardcore" ], format: "LP")
+        create_list(:listing, 4,  store:, genres: [ "Rock" ], styles: [ "Oi" ], format: "LP")
+        create_list(:listing, 106, store:, genres: [ "Rock" ], styles: [ "Other" ], format: "LP")
+
+        get "/narrowstore"
+
+        crates = inertia.props["crates"]
+        crate_names = crates.map { |c| c["name"] }
+
+        # Main styles present in browse.
+        expect(crate_names).to include("Punk", "Hardcore", "Other")
+        # Oi 4 < 5% of 200 = 10 → rotation, not in browse grid.
+        expect(crate_names).not_to include("Oi")
+      end
+
+      it "excludes suppressed broad styles from browse grid" do
+        store = create(:store, discogs_username: "narrowpop")
+        # Pop Rock: 8 listings, 6 overlap Punk. Punk 20 listings.
+        create_list(:listing, 6, store:, genres: [ "Rock" ], styles: [ "Punk", "Pop Rock" ], format: "LP")
+        create_list(:listing, 2, store:, genres: [ "Rock" ], styles: [ "Pop Rock" ], format: "LP")
+        create_list(:listing, 14, store:, genres: [ "Rock" ], styles: [ "Punk" ], format: "LP")
+        create_list(:listing, 78, store:, genres: [ "Rock" ], styles: [ "Other" ], format: "LP")
+
+        get "/narrowpop"
+
+        crates = inertia.props["crates"]
+        crate_names = crates.map { |c| c["name"] }
+
+        # Pop Rock suppressed (75% overlap) → not in browse.
+        expect(crate_names).not_to include("Pop Rock")
+        expect(crate_names).to include("Punk", "Other")
+      end
+
+      it "preserves serialized crate object shape" do
+        store = create(:store, discogs_username: "crateshape")
+        create_list(:listing, 20, store:, genres: [ "Rock" ], styles: [ "Punk" ], format: "LP")
+        create_list(:listing, 80, store:, genres: [ "Rock" ], styles: [ "Other" ], format: "LP")
+
+        get "/crateshape"
+
+        crates = inertia.props["crates"]
+        punk_crate = crates.find { |c| c["slug"] == "punk" }
+
+        expect(punk_crate.keys).to include("slug", "name", "count", "records")
+        expect(punk_crate["slug"]).to eq("punk")
+        expect(punk_crate["count"]).to be_a(Integer)
+        expect(punk_crate["records"]).to be_an(Array)
+      end
+
+      it "preserves section keys: wall, genre_grid" do
+        store = create(:store, discogs_username: "sectionkeys")
+        create_list(:listing, 10, store:, genres: [ "Rock" ], styles: [ "Punk" ], format: "LP")
+        create_list(:listing, 90, store:, genres: [ "Rock" ], styles: [ "Other" ], format: "LP")
+
+        get "/sectionkeys"
+
+        sections = inertia.props["storefront_sections"]
+        keys = sections.map { |s| s["key"] }
+        expect(keys).to include("wall", "genre_grid")
+      end
+
+      it "keeps genre-axis behavior unchanged" do
+        store = create(:store, discogs_username: "genrestore")
+        create_list(:listing, 100, store:, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
+        create_list(:listing, 100, store:, genres: [ "Rock" ], styles: [ "Classic Rock" ], format: "LP")
+        create_list(:listing, 100, store:, genres: [ "Electronic" ], styles: [ "House" ], format: "LP")
+
+        get "/genrestore"
+
+        crates = inertia.props["crates"]
+        crate_names = crates.map { |c| c["name"] }
+
+        # All three genres should have crates (genres axis, count-descending).
+        expect(crate_names).to include("Jazz", "Rock", "Electronic")
+      end
+    end
   end
 end

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -112,7 +112,8 @@ RSpec.describe "Stores", type: :request do
     end
 
     it "caps each genre bin at 50 records" do
-      create_list(:listing, 100, store: store, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
+      # Leave at least 50 Jazz listings after wall and featured-crate deduplication.
+      create_list(:listing, 200, store: store, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
       create_list(:listing, 50, store: store, genres: [ "Rock" ], styles: [ "Classic Rock" ], format: "LP")
       create_list(:listing, 50, store: store, genres: [ "Electronic" ], styles: [ "House" ], format: "LP")
 
@@ -155,24 +156,6 @@ RSpec.describe "Stores", type: :request do
         expect(crate_names).to include("Punk", "Hardcore", "Other")
         # Oi 4 < 5% of 200 = 10 → rotation, not in browse grid.
         expect(crate_names).not_to include("Oi")
-      end
-
-      it "excludes suppressed broad styles from browse grid" do
-        store = create(:store, discogs_username: "narrowpop")
-        # Pop Rock: 8 listings, 6 overlap Punk. Punk 20 listings.
-        create_list(:listing, 6, store:, genres: [ "Rock" ], styles: [ "Punk", "Pop Rock" ], format: "LP")
-        create_list(:listing, 2, store:, genres: [ "Rock" ], styles: [ "Pop Rock" ], format: "LP")
-        create_list(:listing, 14, store:, genres: [ "Rock" ], styles: [ "Punk" ], format: "LP")
-        create_list(:listing, 78, store:, genres: [ "Rock" ], styles: [ "Other" ], format: "LP")
-
-        get "/narrowpop"
-
-        crates = inertia.props["crates"]
-        crate_names = crates.map { |c| c["name"] }
-
-        # Pop Rock suppressed (75% overlap) → not in browse.
-        expect(crate_names).not_to include("Pop Rock")
-        expect(crate_names).to include("Punk", "Other")
       end
 
       it "preserves serialized crate object shape" do

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -148,8 +148,8 @@ RSpec.describe "Stores", type: :request do
 
         get "/narrowstore"
 
-        crates = inertia.props["crates"]
-        crate_names = crates.map { |c| c["name"] }
+        genre_grid = inertia.props["storefront_sections"].find { |section| section["key"] == "genre_grid" }
+        crate_names = genre_grid.fetch("crates").map { |crate| crate["name"] }
 
         # Main styles present in browse.
         expect(crate_names).to include("Punk", "Hardcore", "Other")

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -85,8 +85,9 @@ RSpec.describe "Stores", type: :request do
     let!(:store) { create(:store, discogs_username: "teststore") }
 
     it "builds a genre bin for each primary genre present" do
-      create_list(:listing, 100, store: store, genres: [ "Jazz" ], format: "LP")
-      create_list(:listing, 100, store: store, genres: [ "Rock" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Rock" ], styles: [ "Classic Rock" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Electronic" ], styles: [ "House" ], format: "LP")
 
       get "/teststore"
 
@@ -97,7 +98,9 @@ RSpec.describe "Stores", type: :request do
 
     it "excludes records from a genre bin when that genre is not primary" do
       jazz_primary = create(:listing, store: store, genres: [ "Jazz", "Rock" ], format: "LP")
-      create_list(:listing, 200, store: store, genres: [ "Rock" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Rock" ], styles: [ "Classic Rock" ], format: "LP")
+      create_list(:listing, 50, store: store, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
+      create_list(:listing, 50, store: store, genres: [ "Electronic" ], styles: [ "House" ], format: "LP")
 
       get "/teststore"
 
@@ -109,7 +112,9 @@ RSpec.describe "Stores", type: :request do
     end
 
     it "caps each genre bin at 50 records" do
-      create_list(:listing, 200, store: store, genres: [ "Jazz" ], format: "LP")
+      create_list(:listing, 100, store: store, genres: [ "Jazz" ], styles: [ "Bebop" ], format: "LP")
+      create_list(:listing, 50, store: store, genres: [ "Rock" ], styles: [ "Classic Rock" ], format: "LP")
+      create_list(:listing, 50, store: store, genres: [ "Electronic" ], styles: [ "House" ], format: "LP")
 
       get "/teststore"
 

--- a/spec/services/crate_strategies/genre_spec.rb
+++ b/spec/services/crate_strategies/genre_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CrateStrategies::Genre do
   end
 
   context "when curation axis is genres" do
-    let(:curation_axis) { :genres }
+    let(:curation_axis) { GenresAxis.new }
 
     it "selects listings matching the genre by primary_genre" do
       pool = [
@@ -22,7 +22,7 @@ RSpec.describe CrateStrategies::Genre do
         instance_double(Listing, id: 5, primary_genre: "Rock", styles: [ "Indie Rock" ]),
         instance_double(Listing, id: 6, primary_genre: "Rock", styles: [ "Classic Rock" ])
       ]
-      strategy = described_class.new(genre: "Rock", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
+      strategy = described_class.new(genre: "Rock", genre_counts: {}, curation_axis: GenresAxis.new, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
       expect(selected.size).to eq(4)
       expect(selected.map(&:id)).to match_array([ 1, 2, 5, 6 ])
@@ -37,14 +37,14 @@ RSpec.describe CrateStrategies::Genre do
         instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Cool Jazz" ]),
         instance_double(Listing, id: 6, primary_genre: "Jazz", styles: [ "Fusion" ])
       ]
-      strategy = described_class.new(genre: "Jazz", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
+      strategy = described_class.new(genre: "Jazz", genre_counts: {}, curation_axis: GenresAxis.new, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
       expect(selected.map(&:id)).to match_array([ 3, 4, 5, 6 ])
     end
   end
 
   context "when curation axis is styles" do
-    let(:curation_axis) { :styles }
+    let(:curation_axis) { StylesAxis.new }
 
     it "selects listings matching the genre by styles array" do
       pool = [
@@ -54,7 +54,7 @@ RSpec.describe CrateStrategies::Genre do
         instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
         instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Cool Jazz" ])
       ]
-      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
+      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: StylesAxis.new, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
       expect(selected.size).to eq(4)
       expect(selected.map(&:id)).to match_array([ 1, 2, 3, 4 ])
@@ -69,7 +69,7 @@ RSpec.describe CrateStrategies::Genre do
         instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Bebop" ]),
         instance_double(Listing, id: 6, primary_genre: "Jazz", styles: [ "Bebop" ])
       ]
-      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
+      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: StylesAxis.new, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
       expect(selected.map(&:id)).to match_array([ 1, 4, 5, 6 ])
     end

--- a/spec/services/crate_strategies/genre_spec.rb
+++ b/spec/services/crate_strategies/genre_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe CrateStrategies::Genre do
+  subject(:strategy) { described_class.new(genre:, genre_counts: {}, curation_axis:, today: Date.new(2026, 6, 7)) }
+
+  let(:scorer) { instance_double(RecordScorer, score: 10) }
+
+  before do
+    allow(RecordScorer).to receive(:new).and_return(scorer)
+    allow(scorer).to receive(:score).and_return(10)
+  end
+
+  context "when curation axis is genres" do
+    let(:curation_axis) { :genres }
+
+    it "selects listings matching the genre by primary_genre" do
+      pool = [
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Punk"]),
+        instance_double(Listing, id: 2, primary_genre: "Rock", styles: ["Hardcore"]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 5, primary_genre: "Rock", styles: ["Indie Rock"]),
+        instance_double(Listing, id: 6, primary_genre: "Rock", styles: ["Classic Rock"])
+      ]
+      strategy = described_class.new(genre: "Rock", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
+      selected = strategy.select(pool, excluded_ids: Set.new)
+      expect(selected.size).to eq(4)
+      expect(selected.map(&:id)).to match_array([ 1, 2, 5, 6 ])
+    end
+
+    it "does not match listings from other genres" do
+      pool = [
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Punk"]),
+        instance_double(Listing, id: 2, primary_genre: "Rock", styles: ["Hardcore"]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Cool Jazz"]),
+        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: ["Fusion"])
+      ]
+      strategy = described_class.new(genre: "Jazz", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
+      selected = strategy.select(pool, excluded_ids: Set.new)
+      expect(selected.map(&:id)).to match_array([ 3, 4, 5, 6 ])
+    end
+  end
+
+  context "when curation axis is styles" do
+    let(:curation_axis) { :styles }
+
+    it "selects listings matching the genre by styles array" do
+      pool = [
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Bebop"]),
+        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Cool Jazz"])
+      ]
+      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
+      selected = strategy.select(pool, excluded_ids: Set.new)
+      expect(selected.size).to eq(4)
+      expect(selected.map(&:id)).to match_array([ 1, 2, 3, 4 ])
+    end
+
+    it "does not match listings that don't include the style" do
+      pool = [
+        instance_double(Listing, id: 1, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: ["Cool Jazz"]),
+        instance_double(Listing, id: 3, primary_genre: "Electronic", styles: ["House"]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Bebop"]),
+        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: ["Bebop"])
+      ]
+      strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
+      selected = strategy.select(pool, excluded_ids: Set.new)
+      expect(selected.map(&:id)).to match_array([ 1, 4, 5, 6 ])
+    end
+  end
+end

--- a/spec/services/crate_strategies/genre_spec.rb
+++ b/spec/services/crate_strategies/genre_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe CrateStrategies::Genre do
 
     it "selects listings matching the genre by primary_genre" do
       pool = [
-        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Punk"]),
-        instance_double(Listing, id: 2, primary_genre: "Rock", styles: ["Hardcore"]),
-        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 5, primary_genre: "Rock", styles: ["Indie Rock"]),
-        instance_double(Listing, id: 6, primary_genre: "Rock", styles: ["Classic Rock"])
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: [ "Punk" ]),
+        instance_double(Listing, id: 2, primary_genre: "Rock", styles: [ "Hardcore" ]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 5, primary_genre: "Rock", styles: [ "Indie Rock" ]),
+        instance_double(Listing, id: 6, primary_genre: "Rock", styles: [ "Classic Rock" ])
       ]
       strategy = described_class.new(genre: "Rock", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
@@ -30,12 +30,12 @@ RSpec.describe CrateStrategies::Genre do
 
     it "does not match listings from other genres" do
       pool = [
-        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Punk"]),
-        instance_double(Listing, id: 2, primary_genre: "Rock", styles: ["Hardcore"]),
-        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Cool Jazz"]),
-        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: ["Fusion"])
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: [ "Punk" ]),
+        instance_double(Listing, id: 2, primary_genre: "Rock", styles: [ "Hardcore" ]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Cool Jazz" ]),
+        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: [ "Fusion" ])
       ]
       strategy = described_class.new(genre: "Jazz", genre_counts: {}, curation_axis: :genres, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
@@ -48,11 +48,11 @@ RSpec.describe CrateStrategies::Genre do
 
     it "selects listings matching the genre by styles array" do
       pool = [
-        instance_double(Listing, id: 1, primary_genre: "Rock", styles: ["Bebop"]),
-        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Cool Jazz"])
+        instance_double(Listing, id: 1, primary_genre: "Rock", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 3, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Cool Jazz" ])
       ]
       strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)
@@ -62,12 +62,12 @@ RSpec.describe CrateStrategies::Genre do
 
     it "does not match listings that don't include the style" do
       pool = [
-        instance_double(Listing, id: 1, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: ["Cool Jazz"]),
-        instance_double(Listing, id: 3, primary_genre: "Electronic", styles: ["House"]),
-        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: ["Bebop"]),
-        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: ["Bebop"])
+        instance_double(Listing, id: 1, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 2, primary_genre: "Jazz", styles: [ "Cool Jazz" ]),
+        instance_double(Listing, id: 3, primary_genre: "Electronic", styles: [ "House" ]),
+        instance_double(Listing, id: 4, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 5, primary_genre: "Jazz", styles: [ "Bebop" ]),
+        instance_double(Listing, id: 6, primary_genre: "Jazz", styles: [ "Bebop" ])
       ]
       strategy = described_class.new(genre: "Bebop", genre_counts: {}, curation_axis: :styles, today: Date.new(2026, 6, 7))
       selected = strategy.select(pool, excluded_ids: Set.new)

--- a/spec/services/crate_strategies/thematic_spec.rb
+++ b/spec/services/crate_strategies/thematic_spec.rb
@@ -23,4 +23,87 @@ RSpec.describe CrateStrategies::Thematic do
     expect(name).to eq("Rare Groove")
     expect(selected).to eq(themed.reverse)
   end
+
+  context "with explicit themes" do
+    it "uses only the provided themes instead of pool discovery" do
+      oi_theme = StorefrontTheme.style("Oi")
+      strategy = described_class.new(
+        store_id: 1, genre_counts: {}, themes: [ oi_theme ],
+        today: Date.new(2026, 5, 27)
+      )
+
+      # Pool has 5 Punk + 4 Oi. Discovery would find both Punk and Oi themes.
+      # With explicit themes: only Oi is considered.
+      punk = (1..5).map { |id| listing(id, style: "Punk") }
+      oi   = (6..9).map { |id| listing(id, style: "Oi") }
+      pool = punk + oi
+
+      name, _selected = strategy.select(pool, excluded_ids: Set.new)
+
+      expect(name).to eq("Oi")
+    end
+
+    it "filters provided themes by eligibility against the current pool" do
+      doom_theme  = StorefrontTheme.style("Doom Metal")
+      noise_theme = StorefrontTheme.style("Noise")
+      strategy = described_class.new(
+        store_id: 1, genre_counts: {}, themes: [ doom_theme, noise_theme ],
+        today: Date.new(2026, 5, 27)
+      )
+
+      # Only Noise has >= 4 listings in the pool; Doom Metal has only 2.
+      doom  = (1..2).map { |id| listing(id, style: "Doom Metal") }
+      noise = (4..7).map { |id| listing(id, style: "Noise") }
+      pool  = doom + noise
+
+      name, _selected = strategy.select(pool, excluded_ids: Set.new)
+
+      # Doom Metal ineligible (< 4), Noise eligible → only Noise chosen.
+      expect(name).to eq("Noise")
+    end
+
+    it "returns nil when no provided theme is viable after exclusions" do
+      noise_theme = StorefrontTheme.style("Noise")
+      strategy = described_class.new(
+        store_id: 1, genre_counts: {}, themes: [ noise_theme ],
+        today: Date.new(2026, 5, 27)
+      )
+
+      # Noise has 4 listings but 1 is excluded → 3 remain, below MIN_RECORDS.
+      noise = (1..4).map { |id| listing(id, style: "Noise") }
+      result = strategy.select(noise, excluded_ids: Set.new([ 1 ]))
+
+      expect(result).to be_nil
+    end
+
+    it "returns nil when no pre-computed themes are provided" do
+      strategy = described_class.new(
+        store_id: 1, genre_counts: {}, themes: [],
+        today: Date.new(2026, 5, 27)
+      )
+
+      pool = (1..10).map { |id| listing(id, style: "Punk") }
+      result = strategy.select(pool, excluded_ids: Set.new)
+
+      expect(result).to be_nil
+    end
+
+    it "is deterministic for the same store and date with pre-computed themes" do
+      oi_theme   = StorefrontTheme.style("Oi")
+      doom_theme = StorefrontTheme.style("Doom Metal")
+
+      oi   = (1..4).map { |id| listing(id, style: "Oi") }
+      doom = (5..8).map { |id| listing(id, style: "Doom Metal") }
+      pool = oi + doom
+
+      themes = [ oi_theme, doom_theme ]
+      a = described_class.new(store_id: 42, genre_counts: {}, themes:, today: Date.new(2026, 6, 1))
+      b = described_class.new(store_id: 42, genre_counts: {}, themes:, today: Date.new(2026, 6, 1))
+
+      result_a = a.select(pool, excluded_ids: Set.new)
+      result_b = b.select(pool, excluded_ids: Set.new)
+
+      expect(result_a).to eq(result_b)
+    end
+  end
 end

--- a/spec/services/genres_axis_spec.rb
+++ b/spec/services/genres_axis_spec.rb
@@ -36,4 +36,52 @@ RSpec.describe GenresAxis do
       expect(axis.tally_from([ a ])).to eq({})
     end
   end
+
+  describe "#main_counts" do
+    it "returns all genre counts" do
+      a = instance_double(Listing, primary_genre: "Rock")
+      b = instance_double(Listing, primary_genre: "Jazz")
+
+      expect(axis.main_counts([ a, b ])).to eq("Rock" => 1, "Jazz" => 1)
+    end
+  end
+
+  describe "#allocation_order" do
+    it "sorts genres by count descending then name" do
+      a = instance_double(Listing, primary_genre: "Rock")
+      b = instance_double(Listing, primary_genre: "Rock")
+      c = instance_double(Listing, primary_genre: "Jazz")
+
+      expect(axis.allocation_order([ a, b, c ])).to eq(%w[Rock Jazz])
+    end
+  end
+
+  describe "#display_order" do
+    it "matches allocation order" do
+      a = instance_double(Listing, primary_genre: "Rock")
+      b = instance_double(Listing, primary_genre: "Jazz")
+
+      expect(axis.display_order([ a, b ])).to eq(axis.allocation_order([ a, b ]))
+    end
+  end
+
+  describe "#thematic_candidates" do
+    it "returns StorefrontTheme objects for genres and styles in the pool" do
+      a = instance_double(Listing, primary_genre: "Rock", styles: [ "Punk" ])
+
+      candidates = axis.thematic_candidates([ a ])
+
+      expect(candidates).to all(be_a(StorefrontTheme))
+      slugs = candidates.map(&:slug)
+      expect(slugs).to include("style-punk", "genre-rock")
+    end
+
+    it "excludes nil styles" do
+      a = instance_double(Listing, primary_genre: "Rock", styles: nil)
+
+      candidates = axis.thematic_candidates([ a ])
+
+      expect(candidates.map(&:slug)).to eq([ "genre-rock" ])
+    end
+  end
 end

--- a/spec/services/genres_axis_spec.rb
+++ b/spec/services/genres_axis_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe GenresAxis do
+  subject(:axis) { described_class.new }
+
+  let(:listing) { instance_double(Listing, primary_genre: "Rock", styles: [ "Punk" ]) }
+
+  describe "#key_for" do
+    it "returns the listing's primary genre" do
+      expect(axis.key_for(listing)).to eq("Rock")
+    end
+  end
+
+  describe "#matches?" do
+    it "is true when the listing's primary genre matches" do
+      expect(axis.matches?(listing, "Rock")).to be true
+    end
+
+    it "is false when the listing's primary genre does not match" do
+      expect(axis.matches?(listing, "Jazz")).to be false
+    end
+  end
+
+  describe "#tally_from" do
+    it "counts listings by primary genre" do
+      a = instance_double(Listing, primary_genre: "Rock")
+      b = instance_double(Listing, primary_genre: "Rock")
+      c = instance_double(Listing, primary_genre: "Jazz")
+
+      expect(axis.tally_from([ a, b, c ])).to eq("Rock" => 2, "Jazz" => 1)
+    end
+
+    it "excludes listings with nil primary genre" do
+      a = instance_double(Listing, primary_genre: nil)
+
+      expect(axis.tally_from([ a ])).to eq({})
+    end
+  end
+end

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -311,6 +311,59 @@ RSpec.describe StorefrontCuration do
         names = groups[:genres].map(&:name)
         expect(names).not_to include("Hardcore")
       end
+
+      it "rotates fringe styles in the thematic featured slot" do
+        store = create(:store)
+        punk  = lp_listings(store, count: 6, genres: [ "Rock" ], styles: [ "Punk" ])
+        oi    = lp_listings(store, count: 4, genres: [ "Rock" ], styles: [ "Oi" ])
+        other = lp_listings(store, count: 90, genres: [ "Jazz" ], styles: [ "Other" ])
+
+        curation = described_class.new(store)
+        groups = curation.storefront_groups
+
+        # Oi is rotation-tier → eligible for thematic.
+        # Punk and Other are main → excluded from thematic.
+        featured = groups[:featured]
+        thematic = featured.find { |c| c.slug == "thematic" }
+
+        if thematic
+          expect(thematic.name).to eq("Oi")
+          expect(thematic.listings.size).to eq(4)
+        end
+        # Main styles should not appear as thematic.
+        expect(featured.map(&:name)).not_to include("Punk")
+        expect(featured.map(&:name)).not_to include("Other")
+      end
+
+      it "excludes suppressed broad styles from thematic candidates" do
+        store = create(:store)
+        # Pop Rock: 5 listings, 4 overlap Punk. Punk 9 listings (all main).
+        punk_pop = lp_listings(store, count: 4, genres: [ "Rock" ], styles: [ "Punk", "Pop Rock" ])
+        pop_only = lp_listings(store, count: 1, genres: [ "Rock" ], styles: [ "Pop Rock" ])
+        punk_only = lp_listings(store, count: 5, genres: [ "Rock" ], styles: [ "Punk" ])
+        other = lp_listings(store, count: 90, genres: [ "Jazz" ], styles: [ "Other" ])
+
+        curation = described_class.new(store)
+        groups = curation.storefront_groups
+
+        featured = groups[:featured]
+        # Pop Rock suppressed (80% overlap) → not a thematic candidate.
+        expect(featured.map(&:name)).not_to include("Pop Rock")
+      end
+
+      it "returns no thematic crate when no rotation candidate is viable" do
+        store = create(:store)
+        # Only main styles, no rotation-tier.
+        punk  = lp_listings(store, count: 10, genres: [ "Rock" ], styles: [ "Punk" ])
+        other = lp_listings(store, count: 90, genres: [ "Jazz" ], styles: [ "Other" ])
+
+        curation = described_class.new(store)
+        groups = curation.storefront_groups
+
+        featured = groups[:featured]
+        thematic = featured.find { |c| c.slug == "thematic" }
+        expect(thematic).to be_nil
+      end
     end
   end
 

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe StorefrontCuration do
     it "adds genre crates after wall" do
       store = create(:store)
       listings = lp_listings(store, count: 5, genres: [ "Jazz" ], styles: [ "Bop" ])
+      lp_listing(store, genres: [ "Rock" ], styles: [ "Classic Rock" ])
+      lp_listing(store, genres: [ "Electronic" ], styles: [ "House" ])
 
       curation = curation_with_strategies(store, wall: [], genre_scores: listings.each_with_index.to_h { |l, i| [ l.id, i + 1 ] })
       crates = curation.crates
@@ -59,6 +61,8 @@ RSpec.describe StorefrontCuration do
     it "excludes records that appear on the wall" do
       store = create(:store)
       listing = lp_listing(store, genres: [ "Jazz" ])
+      lp_listing(store, genres: [ "Rock" ])
+      lp_listing(store, genres: [ "Electronic" ])
 
       curation = curation_with_strategies(store, wall: [ listing ], genre_scores: { listing.id => 10 })
       jazz_crate = curation.crates.find { |crate| crate.name == "Jazz" }
@@ -68,6 +72,8 @@ RSpec.describe StorefrontCuration do
     it "skips genres with no records remaining after wall exclusion" do
       store = create(:store)
       listing = lp_listing(store, genres: [ "Jazz" ])
+      lp_listing(store, genres: [ "Rock" ])
+      lp_listing(store, genres: [ "Electronic" ])
 
       curation = curation_with_strategies(store, wall: [ listing ], genre_scores: { listing.id => 10 })
       expect(curation.crates.map(&:name)).not_to include("Jazz")
@@ -80,6 +86,8 @@ RSpec.describe StorefrontCuration do
       jazz3 = lp_listing(store, genres: [ "Jazz" ])
       jazz4 = lp_listing(store, genres: [ "Jazz" ])
       jazz5 = lp_listing(store, genres: [ "Jazz" ])
+      lp_listing(store, genres: [ "Rock" ])
+      lp_listing(store, genres: [ "Electronic" ])
 
       curation = curation_with_strategies(store, wall: [ jazz1 ], genre_scores: { jazz1.id => 5, jazz2.id => 10, jazz3.id => 9, jazz4.id => 8, jazz5.id => 7 })
       jazz_crate = curation.crates.find { |crate| crate.name == "Jazz" }

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -335,22 +335,6 @@ RSpec.describe StorefrontCuration do
         expect(featured.map(&:name)).not_to include("Other")
       end
 
-      it "excludes suppressed broad styles from thematic candidates" do
-        store = create(:store)
-        # Pop Rock: 5 listings, 4 overlap Punk. Punk 9 listings (all main).
-        punk_pop = lp_listings(store, count: 4, genres: [ "Rock" ], styles: [ "Punk", "Pop Rock" ])
-        pop_only = lp_listings(store, count: 1, genres: [ "Rock" ], styles: [ "Pop Rock" ])
-        punk_only = lp_listings(store, count: 5, genres: [ "Rock" ], styles: [ "Punk" ])
-        other = lp_listings(store, count: 90, genres: [ "Jazz" ], styles: [ "Other" ])
-
-        curation = described_class.new(store)
-        groups = curation.storefront_groups
-
-        featured = groups[:featured]
-        # Pop Rock suppressed (80% overlap) → not a thematic candidate.
-        expect(featured.map(&:name)).not_to include("Pop Rock")
-      end
-
       it "returns no thematic crate when no rotation candidate is viable" do
         store = create(:store)
         # Only main styles, no rotation-tier.

--- a/spec/services/storefront_curation_spec.rb
+++ b/spec/services/storefront_curation_spec.rb
@@ -230,6 +230,88 @@ RSpec.describe StorefrontCuration do
         end
       end
     end
+
+    context "with styles axis" do
+      it "allocates overlapping styles before higher-support independent styles" do
+        store = create(:store)
+        punk     = lp_listings(store, count: 15, genres: [ "Rock" ], styles: [ "Punk" ])
+        hc_only  = lp_listings(store, count: 6,  genres: [ "Rock" ], styles: [ "Hardcore" ])
+        crust_hc = lp_listings(store, count: 4,  genres: [ "Rock" ], styles: [ "Crust", "Hardcore" ])
+        crust    = lp_listings(store, count: 2,  genres: [ "Rock" ], styles: [ "Crust" ])
+        other    = lp_listings(store, count: 73, genres: [ "Jazz" ], styles: [ "Other" ])
+        all = punk + hc_only + crust_hc + crust + other
+
+        scores = all.each_with_index.to_h { |l, i| [ l.id, all.size - i ] }
+
+        # Empty wall so no dedup interferes with allocation-order test.
+        curation = curation_with_strategies(store, wall: [], genre_scores: scores)
+        groups = curation.storefront_groups
+
+        names = groups[:genres].map(&:name)
+        # Allocation order: Crust (highest overlap risk), Hardcore, Punk, Other.
+        # Built in that order; display reorders by support: Other, Punk, Hardcore, Crust.
+        expect(names).to eq(%w[Other Punk Hardcore Crust])
+      end
+
+      it "displays crates in support-first order after allocation" do
+        store = create(:store)
+        punk     = lp_listings(store, count: 10, genres: [ "Rock" ], styles: [ "Punk" ])
+        hc       = lp_listings(store, count: 6,  genres: [ "Rock" ], styles: [ "Hardcore" ])
+        other    = lp_listings(store, count: 84, genres: [ "Jazz" ], styles: [ "Other" ])
+        all = punk + hc + other
+
+        scores = all.each_with_index.to_h { |l, i| [ l.id, all.size - i ] }
+        curation = curation_with_strategies(store, wall: [], genre_scores: scores)
+        groups = curation.storefront_groups
+
+        names = groups[:genres].map(&:name)
+        # Display order: Other (84), Punk (10), Hardcore (6)
+        expect(names).to eq(%w[Other Punk Hardcore])
+      end
+
+      it "omits rotation-tier styles from browse crates" do
+        store = create(:store)
+        punk  = lp_listings(store, count: 6, genres: [ "Rock" ], styles: [ "Punk" ])
+        oi    = lp_listings(store, count: 4, genres: [ "Rock" ], styles: [ "Oi" ])
+        other = lp_listings(store, count: 90, genres: [ "Jazz" ], styles: [ "Other" ])
+        all = punk + oi + other
+
+        scores = all.each_with_index.to_h { |l, i| [ l.id, all.size - i ] }
+        curation = curation_with_strategies(store, wall: [], genre_scores: scores)
+        groups = curation.storefront_groups
+
+        names = groups[:genres].map(&:name)
+        # Oi 4 < 5% of 100 = 5 → rotation, not in browse.
+        expect(names).not_to include("Oi")
+        expect(names).to include("Punk", "Other")
+      end
+
+      it "returns empty browse group when no style meets main threshold" do
+        store = create(:store)
+        lp_listings(store, count: 3, genres: [ "Rock" ], styles: [ "Punk" ])
+        lp_listings(store, count: 3, genres: [ "Jazz" ], styles: [ "Bebop" ])
+
+        curation = curation_with_strategies(store, wall: [], genre_scores: {})
+        groups = curation.storefront_groups
+
+        expect(groups[:genres]).to eq([])
+      end
+
+      it "omits style that falls below MIN_RECORDS after wall dedup" do
+        store = create(:store)
+        hc   = lp_listings(store, count: 4, genres: [ "Rock" ], styles: [ "Hardcore" ])
+        other = lp_listings(store, count: 96, genres: [ "Jazz" ], styles: [ "Other" ])
+        all = hc + other
+
+        scores = all.each_with_index.to_h { |l, i| [ l.id, all.size - i ] }
+        # Wall takes 1 Hardcore listing, leaving 3 → below MIN_RECORDS.
+        curation = curation_with_strategies(store, wall: [ hc.first ], genre_scores: scores)
+        groups = curation.storefront_groups
+
+        names = groups[:genres].map(&:name)
+        expect(names).not_to include("Hardcore")
+      end
+    end
   end
 
   describe "#surfaced_listings" do

--- a/spec/services/styles_axis_spec.rb
+++ b/spec/services/styles_axis_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe StylesAxis do
+  subject(:axis) { described_class.new }
+
+  let(:listing) { instance_double(Listing, styles: [ "Punk", "Hardcore" ]) }
+
+  describe "#key_for" do
+    it "returns the listing's first style" do
+      expect(axis.key_for(listing)).to eq("Punk")
+    end
+  end
+
+  describe "#matches?" do
+    it "is true when the listing's styles include the name" do
+      expect(axis.matches?(listing, "Hardcore")).to be true
+    end
+
+    it "is false when the listing's styles do not include the name" do
+      expect(axis.matches?(listing, "Bebop")).to be false
+    end
+  end
+
+  describe "#tally_from" do
+    it "counts listings by all their styles" do
+      a = instance_double(Listing, styles: [ "Punk" ])
+      b = instance_double(Listing, styles: [ "Punk", "Hardcore" ])
+      c = instance_double(Listing, styles: [ "Hardcore" ])
+
+      expect(axis.tally_from([ a, b, c ])).to eq("Punk" => 2, "Hardcore" => 2)
+    end
+
+    it "excludes listings with nil or empty styles" do
+      a = instance_double(Listing, styles: nil)
+      b = instance_double(Listing, styles: [])
+
+      expect(axis.tally_from([ a, b ])).to eq({})
+    end
+  end
+end

--- a/spec/services/styles_axis_spec.rb
+++ b/spec/services/styles_axis_spec.rb
@@ -53,19 +53,16 @@ RSpec.describe StylesAxis do
       expect(counts).not_to have_key("Metal")
     end
 
-    it "excludes suppressed and omitted styles" do
-      # Create a fixture where Pop Rock is suppressed by Punk overlap.
-      punk_only   = 4.times.map { instance_double(Listing, styles: [ "Punk" ]) }
-      pop_rock    = 4.times.map { instance_double(Listing, styles: [ "Pop Rock" ]) }
-      other       = 92.times.map { instance_double(Listing, styles: [ "Other" ]) }
+    it "excludes omitted styles from counts" do
+      punk   = 4.times.map { instance_double(Listing, styles: [ "Punk" ]) }
+      other  = 96.times.map { instance_double(Listing, styles: [ "Other" ]) }
 
-      counts = axis.main_counts(punk_only + pop_rock + other)
+      counts = axis.main_counts(punk + other)
 
       # 100 total: main threshold = 5.
       # Punk 4 ≥ 4 but 4 < 5 → not main.
-      # Pop Rock 4 ≥ 4 but 4 < 5 → not main.
-      # Other 92 ≥ 5 → main.
-      expect(counts).to eq("Other" => 92)
+      # Other 96 ≥ 5 → main.
+      expect(counts).to eq("Other" => 96)
     end
   end
 
@@ -128,21 +125,6 @@ RSpec.describe StylesAxis do
       candidates = axis.thematic_candidates(punk + other)
 
       expect(candidates).to eq([])
-    end
-
-    it "excludes suppressed broad styles" do
-      # Pop Rock suppressed by Punk overlap.
-      punk_pop = 4.times.map { instance_double(Listing, styles: %w[Punk Pop\ Rock]) }
-      pop_only = 1.times.map { instance_double(Listing, styles: [ "Pop Rock" ]) }
-      punk_only = 5.times.map { instance_double(Listing, styles: [ "Punk" ]) }
-      other = 90.times.map { instance_double(Listing, styles: [ "Other" ]) }
-
-      candidates = axis.thematic_candidates(punk_pop + pop_only + punk_only + other)
-
-      # Pop Rock 5 total, 4 overlap (80% ≥ 75%) → suppressed.
-      # Punk 9 → main.
-      # Pop Rock suppressed → not in rotation.
-      expect(candidates.map(&:name)).not_to include("Pop Rock")
     end
   end
 

--- a/spec/services/styles_axis_spec.rb
+++ b/spec/services/styles_axis_spec.rb
@@ -37,4 +37,125 @@ RSpec.describe StylesAxis do
       expect(axis.tally_from([ a, b ])).to eq({})
     end
   end
+
+  describe "#main_counts" do
+    it "returns only main-tier style counts" do
+      punk   = instance_double(Listing, styles: [ "Punk" ])
+      metal  = instance_double(Listing, styles: [ "Metal" ])
+      others = 18.times.map { instance_double(Listing, styles: [ "Other" ]) }
+
+      counts = axis.main_counts([ punk, metal ] + others)
+
+      # 20 total: 5% ceil = 1, floor = 4. Punk 1 < 4 → omitted.
+      # Metal 1 < 4 → omitted. Other 18 ≥ 4 → main.
+      expect(counts).to include("Other" => 18)
+      expect(counts).not_to have_key("Punk")
+      expect(counts).not_to have_key("Metal")
+    end
+
+    it "excludes suppressed and omitted styles" do
+      # Create a fixture where Pop Rock is suppressed by Punk overlap.
+      punk_only   = 4.times.map { instance_double(Listing, styles: [ "Punk" ]) }
+      pop_rock    = 4.times.map { instance_double(Listing, styles: [ "Pop Rock" ]) }
+      other       = 92.times.map { instance_double(Listing, styles: [ "Other" ]) }
+
+      counts = axis.main_counts(punk_only + pop_rock + other)
+
+      # 100 total: main threshold = 5.
+      # Punk 4 ≥ 4 but 4 < 5 → not main.
+      # Pop Rock 4 ≥ 4 but 4 < 5 → not main.
+      # Other 92 ≥ 5 → main.
+      expect(counts).to eq("Other" => 92)
+    end
+  end
+
+  describe "#allocation_order" do
+    it "orders by overlap risk descending, support ascending, then name" do
+      punk      = 4.times.map { instance_double(Listing, styles: [ "Punk", "Hardcore" ]) }
+      hc_only   = 1.times.map { instance_double(Listing, styles: [ "Hardcore" ]) }
+      other     = 95.times.map { instance_double(Listing, styles: [ "Other" ]) }
+
+      order = axis.allocation_order(punk + hc_only + other)
+
+      # Total 100. Main threshold = 5.
+      # Punk 4 < 5 → not main.
+      # Hardcore 4+1 = 5 ≥ 5 → main.
+      # Other 95 ≥ 5 → main.
+      # Hardcore 4/5 listings overlap with Punk (not main), so overlap risk = 0.
+      # Allocation: no higher-support main for either → both risk 0.
+      # Support: Other 95, Hardcore 5. Lower support first: Hardcore, then Other.
+      expect(order).to eq(%w[Hardcore Other])
+    end
+  end
+
+  describe "#display_order" do
+    it "sorts main styles by support descending then name" do
+      punk   = 6.times.map { instance_double(Listing, styles: [ "Punk" ]) }
+      metal  = 10.times.map { instance_double(Listing, styles: [ "Metal" ]) }
+      other  = 84.times.map { instance_double(Listing, styles: [ "Other" ]) }
+
+      order = axis.display_order(punk + metal + other)
+
+      # 100 total, main threshold = 5.
+      # Punk 6, Metal 10, Other 84 → all main.
+      # Display: Other(84), Metal(10), Punk(6).
+      expect(order).to eq(%w[Other Metal Punk])
+    end
+  end
+
+  describe "#thematic_candidates" do
+    it "returns StorefrontTheme objects for rotation-tier styles only" do
+      punk   = 6.times.map { instance_double(Listing, styles: [ "Punk" ]) }
+      oi     = 4.times.map { instance_double(Listing, styles: [ "Oi" ]) }
+      noise  = 3.times.map { instance_double(Listing, styles: [ "Noise" ]) }
+      other  = 87.times.map { instance_double(Listing, styles: [ "Other" ]) }
+
+      candidates = axis.thematic_candidates(punk + oi + noise + other)
+
+      # 100 total, main threshold = 5, rotation threshold = 1.
+      # Punk 6 ≥ 5 → main (excluded from rotation).
+      # Oi 4 ≥ 4 AND 4 ≥ 1 → rotation.
+      # Noise 3 < 4 (MIN_RECORDS) → omitted.
+      # Other 87 → main (excluded).
+      expect(candidates.size).to eq(1)
+      expect(candidates.first.slug).to eq("style-oi")
+    end
+
+    it "returns empty array when no rotation candidates exist" do
+      punk  = 6.times.map { instance_double(Listing, styles: [ "Punk" ]) }
+      other = 94.times.map { instance_double(Listing, styles: [ "Other" ]) }
+
+      candidates = axis.thematic_candidates(punk + other)
+
+      expect(candidates).to eq([])
+    end
+
+    it "excludes suppressed broad styles" do
+      # Pop Rock suppressed by Punk overlap.
+      punk_pop = 4.times.map { instance_double(Listing, styles: %w[Punk Pop\ Rock]) }
+      pop_only = 1.times.map { instance_double(Listing, styles: [ "Pop Rock" ]) }
+      punk_only = 5.times.map { instance_double(Listing, styles: [ "Punk" ]) }
+      other = 90.times.map { instance_double(Listing, styles: [ "Other" ]) }
+
+      candidates = axis.thematic_candidates(punk_pop + pop_only + punk_only + other)
+
+      # Pop Rock 5 total, 4 overlap (80% ≥ 75%) → suppressed.
+      # Punk 9 → main.
+      # Pop Rock suppressed → not in rotation.
+      expect(candidates.map(&:name)).not_to include("Pop Rock")
+    end
+  end
+
+  describe "memoization" do
+    it "reuses one StyleSelection for repeated calls with the same listings" do
+      listings = 20.times.map { instance_double(Listing, styles: [ "Punk" ]) }
+
+      expect(StyleSelection).to receive(:new).once.and_call_original
+
+      axis.main_counts(listings)
+      axis.allocation_order(listings)
+      axis.display_order(listings)
+      axis.thematic_candidates(listings)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Release the curation-axis style selection feature for narrow-catalog stores. When a store's catalog lacks 3+ deep genres, the curation axis switches from top-level genres to styles — giving stores like single-genre shops the same rich browsing experience as diverse ones.

## Changes

### Curation axis switching (feat/curation-axis-styles)
- **`CurationAxis`** — extracted polymorphism from axis symbol branching. New `CurationAxis` base class with `GenresAxis` and `StylesAxis` subclasses, each providing `genre_counts`, `field_for_listing`, and crate count logic.
- **`StorefrontCuration`** — detects axis per cycle from eligible listings. When ≥3 deep genres (≥5% of catalog), uses `:genres`. Otherwise, `:styles`.
- **`Wall`** — diversity cap keys on `styles.first` when axis is `:styles`, `primary_genre` when `:genres`.
- **`CrateStrategies::Genre`** — filters by `styles.include?` when axis is `:styles`, `primary_genre ==` when `:genres`.
- **`CrateStrategies::HiddenGems`** and **`CrateStrategies::Wall`** — pass axis through for consistent field selection.

### Style selection refinement (feat/style-selection)
- **`StyleSelection`** — domain object that selects which style crates to build, using score-weighted support proportional to listing count, with tie-breaking preservation.
- **BROAD_STYLES suppression removed** — replaced with threshold-based classification (style supported when its share ≥ 1/deep-genre-count).
- **Thematic rotation** — restricted to fringe styles (not top-`n` supported styles) so core styles get their own crates.
- **Browse-crate allocation** — separated allocation order (score × support) from display order (alphabetic).
- **Cache invalidation** — curation cache key includes style selection state.

### Fixes
- Content-based hash for `StyleSelection` memoization (not object_id)
- Equal-support tie-breaks preserved in style ranking

## Demo

[![Crate display demo](https://files.catbox.moe/f0nu1u.webm)](https://files.catbox.moe/f0nu1u.webm)

Video shows the storefront crate browsing experience — navigating The Wall, Featured crates, and genre-based crate display with record browsing.

## Related

- Closes #244 (feat/curation-axis-styles)
- Closes #246 (feat/style-selection)
