### PR TITLE
fix: chain curation after enrichment, not in parallel

### DIFF
--- a/app/jobs/enrichment_job.rb
+++ b/app/jobs/enrichment_job.rb
@@ -30,6 +30,7 @@ class EnrichmentJob < ApplicationJob
     setup_progress(store)
     run_enrichment(store, listing_ids:)
     clear_progress(store)
+    DailyCurationJob.perform_later(store.id)
   end
 
   def log_failure(store_or_id, error)

--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -49,7 +49,6 @@ class FullStoreSyncJob < ApplicationJob
 
   def dispatch_followup_jobs(store, listing_ids)
     EnrichmentJob.perform_later(store.id, listing_ids:) if listing_ids.any?
-    DailyCurationJob.perform_later(store.id)
   end
 
   def sync_manager(store)

--- a/app/jobs/sales_poll_store_job.rb
+++ b/app/jobs/sales_poll_store_job.rb
@@ -5,14 +5,29 @@ class SalesPollStoreJob < ApplicationJob
   queue_as :default
 
   def perform(store_id)
-    store = Store.find(store_id)
-    result = StoreSales::OrderPoller.new(store).call
-    enqueue_curation_if_needed(store, result)
+    poll_store(Store.find(store_id))
   rescue ActiveRecord::RecordNotFound
-    Rails.logger.warn("[SalesPollStoreJob] store #{store_id} not found, discarding")
+    log_missing_store(store_id)
+  rescue Discogs::Errors::TransientApiError => error
+    log_transient_failure(store_id, error)
   end
 
   private
+
+  def poll_store(store)
+    result = StoreSales::OrderPoller.new(store).call
+    enqueue_curation_if_needed(store, result)
+  end
+
+  def log_missing_store(store_id)
+    Rails.logger.warn("[SalesPollStoreJob] store #{store_id} not found, discarding")
+  end
+
+  def log_transient_failure(store_id, error)
+    Rails.logger.warn(
+      "[SalesPollStoreJob] transient Discogs failure for store #{store_id}: #{error.message}"
+    )
+  end
 
   def enqueue_curation_if_needed(store, result)
     return unless result && result[:removed_count] > 0

--- a/app/services/csv_export_sync/csv_parser.rb
+++ b/app/services/csv_export_sync/csv_parser.rb
@@ -21,14 +21,41 @@ module CsvExportSync
     Result = Data.define(:records)
 
     def call(csv_body, store_id:)
-      rows = CSV.parse(csv_body, headers: true)
-      records = rows.filter_map { |row| normalize_row(row, store_id:) }
-      Result.new(records:)
+      Result.new(records: parse_records(csv_body, store_id:))
     rescue CSV::MalformedCSVError => e
       raise ParseError, "CSV parsing failed: #{e.message}"
     end
 
     private
+
+    def parse_records(csv_body, store_id:)
+      rows = parse_rows(csv_body)
+      validate_row_widths(rows)
+      rows.filter_map { |row| normalize_row(row, store_id:) }
+    end
+
+    def parse_rows(csv_body)
+      CSV.parse(csv_body, headers: true)
+    rescue CSV::MalformedCSVError => error
+      raise unless error.message.include?("Unquoted fields do not allow new line")
+      # Auto-detected row separator is likely CRLF — bare LFs are data-embedded.
+      # Replace them with spaces and retry.
+      CSV.parse(csv_body.gsub(/(?<!\r)\n/, " "), headers: true)
+    end
+
+    def validate_row_widths(rows)
+      expected = rows.headers&.compact&.length
+      return unless expected
+
+      rows.each_with_index { |row, index| validate_row_width(row, expected, index) }
+    end
+
+    def validate_row_width(row, expected, index)
+      return if row.size == expected
+
+      raise ParseError,
+        "CSV parsing failed: unexpected number of fields in line #{index + 2}"
+    end
 
     def normalize_row(row, store_id:)
       record = base_record(store_id)

--- a/app/services/discogs/api_response_error.rb
+++ b/app/services/discogs/api_response_error.rb
@@ -1,0 +1,40 @@
+# Formats and raises bounded errors for unsuccessful Discogs API responses.
+module Discogs
+  class ApiResponseError
+    BODY_LIMIT = 500
+
+    def self.raise!(response, prefix: nil)
+      new(response, prefix:).raise!
+    end
+
+    def initialize(response, prefix:)
+      @response = response
+      @prefix = prefix || "Discogs API error: #{response.code}"
+    end
+
+    def raise!
+      raise error_class, message
+    end
+
+    private
+
+    def error_class
+      code.between?(500, 599) ? Errors::TransientApiError : Errors::ApiError
+    end
+
+    def code
+      @response.code.to_i
+    end
+
+    def message
+      excerpt.present? ? "#{@prefix} — #{excerpt}" : @prefix
+    end
+
+    def excerpt
+      @excerpt ||= @response.body.to_s
+        .encode("UTF-8", invalid: :replace, undef: :replace)
+        .squish
+        .truncate(BODY_LIMIT)
+    end
+  end
+end

--- a/app/services/discogs/errors.rb
+++ b/app/services/discogs/errors.rb
@@ -2,9 +2,11 @@
 module Discogs
   # Shared error classes for Discogs API clients.
   # RateLimitError is raised on HTTP 429 responses.
-  # ApiError is raised on other non-success responses.
+  # ApiError is raised on non-success responses.
+  # TransientApiError identifies upstream 5xx failures.
   module Errors
     class RateLimitError < StandardError; end
     class ApiError < StandardError; end
+    class TransientApiError < ApiError; end
   end
 end

--- a/app/services/discogs/marketplace.rb
+++ b/app/services/discogs/marketplace.rb
@@ -7,7 +7,6 @@ module Discogs
     include RateLimit
 
     BASE_URL = "https://api.discogs.com"
-
     def initialize(access_token:, access_token_secret:)
       @access_token = access_token
       @access_token_secret = access_token_secret
@@ -17,7 +16,7 @@ module Discogs
       response = oauth_access_token.post("#{BASE_URL}/inventory/export")
       body = parse_oauth_response(response)
       export_id = extract_export_id(body) || extract_location_export_id(response)
-      export_id ? { "id" => export_id } : api_error(response)
+      export_id ? { "id" => export_id } : ApiResponseError.raise!(response)
     end
 
     def check_export_status(export_id)
@@ -27,7 +26,7 @@ module Discogs
 
     def download_export(export_id)
       response = oauth_access_token.get("#{BASE_URL}/inventory/export/#{export_id}/download")
-      raise Errors::ApiError, "Export download failed: HTTP #{response.code}" unless response.code.to_i == 200
+      validate_download_response(response)
       response.body
     end
 
@@ -45,6 +44,12 @@ module Discogs
     end
 
     private
+
+    def validate_download_response(response)
+      return if response.code.to_i == 200
+
+      ApiResponseError.raise!(response, prefix: "Export download failed: HTTP #{response.code}")
+    end
 
     def build_orders_params(status:, page:, per_page:, sort:, sort_order:)
       params = { page: page, per_page: per_page, sort: sort, sort_order: sort_order }
@@ -70,15 +75,16 @@ module Discogs
       code = response.code.to_i
       return { "status" => "not_modified" } if code == 304
       return raise Errors::RateLimitError, "Discogs rate limit hit" if code == 429
-      parsed = parse_response_body(response)
-      (200..299).include?(code) ? parsed : raise(Errors::ApiError, "Discogs API error: #{code} — #{response.body}")
+      return parse_response_body(response) if (200..299).include?(code)
+
+      ApiResponseError.raise!(response)
     end
 
     def parse_raw_body(body, response)
       raw = body.to_s
       raw.blank? ? {} : JSON.parse(raw)
     rescue JSON::ParserError
-      raise Errors::ApiError, "Discogs API error: #{response.code} — #{response.body}"
+      ApiResponseError.raise!(response)
     end
 
     def parse_response_body(response)
@@ -94,10 +100,6 @@ module Discogs
       when Array then body
       when Hash then body["exports"] || body["items"]
       end
-    end
-
-    def api_error(response)
-      raise Errors::ApiError, "Discogs API error: #{response.code} — #{response.body}"
     end
 
     def extract_export_id(body)

--- a/config/initializers/inertia.rb
+++ b/config/initializers/inertia.rb
@@ -2,7 +2,7 @@ InertiaRails.configure do |config|
   config.layout = "inertia_application"
 
   # Cache busting — ensures users get fresh JS after deployments
-  config.version = -> { ViteRuby.digest }
+  config.version = ViteRuby.digest
 
   # Flash keys are automatically shared as top-level props by Inertia Rails
   # Default: %i[notice alert] — accessible as page.props.notice, page.props.alert

--- a/spec/config/inertia_spec.rb
+++ b/spec/config/inertia_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "Inertia configuration" do
+  it "computes the asset version once during application boot" do
+    configured_version = InertiaRails.configuration.send(:options).fetch(:version)
+
+    expect(configured_version).to be_a(String)
+  end
+end

--- a/spec/jobs/enrichment_job_spec.rb
+++ b/spec/jobs/enrichment_job_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe EnrichmentJob do
       described_class.perform_now(store.id)
     end
 
+    it "enqueues DailyCurationJob after successful enrichment" do
+      allow(service).to receive(:enrich_store).with(store, listing_ids: nil)
+
+      expect {
+        described_class.perform_now(store.id)
+      }.to have_enqueued_job(DailyCurationJob).with(store.id)
+    end
+
     it "logs the loaded store username when enrichment fails" do
       allow(Rails.logger).to receive(:error)
       allow(service).to receive(:enrich_store).with(store, listing_ids: nil)

--- a/spec/jobs/full_store_sync_job_spec.rb
+++ b/spec/jobs/full_store_sync_job_spec.rb
@@ -60,15 +60,6 @@ RSpec.describe FullStoreSyncJob do
           .to have_enqueued_job(EnrichmentJob).with(store.id, listing_ids: kind_of(Array))
       end
 
-      it "enqueues DailyCurationJob after sync" do
-        allow(mock_strategy).to receive(:call).with(store, hash_including(max_pages: nil))
-          .and_return(SyncStrategies::Result.new(listings: [], complete: false))
-
-        expect {
-          described_class.perform_now(store.id)
-        }.to have_enqueued_job(DailyCurationJob).with(store.id)
-      end
-
       it "does not enqueue EnrichmentJob when no listings changed" do
         allow(mock_strategy).to receive(:call).with(store, hash_including(max_pages: nil))
           .and_return(SyncStrategies::Result.new(listings: [], complete: false))
@@ -264,15 +255,6 @@ RSpec.describe FullStoreSyncJob do
 
         expect(store.sync_status).to eq("idle")
         expect(store.last_sync_error).to be_nil
-      end
-
-      it "enqueues DailyCurationJob after sync" do
-        allow(mock_strategy).to receive(:call).with(store, hash_including(max_pages: nil))
-          .and_return(SyncStrategies::Result.new(listings: [], complete: true))
-
-        expect {
-          described_class.perform_now(store.id)
-        }.to have_enqueued_job(DailyCurationJob).with(store.id)
       end
     end
   end

--- a/spec/jobs/sales_poll_store_job_spec.rb
+++ b/spec/jobs/sales_poll_store_job_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe SalesPollStoreJob do
         }.to raise_error(StandardError, "API error")
       end
     end
+
+    context "when Discogs has a transient failure" do
+      before do
+        allow(poller).to receive(:call).and_raise(
+          Discogs::Errors::TransientApiError,
+          "Discogs API error: 502"
+        )
+      end
+
+      it "logs the failure without reporting the expected upstream outage" do
+        expect(Rails.logger).to receive(:warn).with(
+          /transient Discogs failure for store #{store.id}: Discogs API error: 502/
+        )
+
+        expect {
+          described_class.new.perform(store.id)
+        }.not_to raise_error
+      end
+    end
   end
 
   describe "concurrency key" do

--- a/spec/services/csv_export_sync/csv_parser_spec.rb
+++ b/spec/services/csv_export_sync/csv_parser_spec.rb
@@ -92,5 +92,36 @@ RSpec.describe CsvExportSync::CsvParser do
           .to raise_error(CsvExportSync::ParseError, /CSV parsing failed/)
       end
     end
+
+    context "with a bare newline in an unquoted field from a CRLF export" do
+      let(:csv_body) do
+        [
+          csv_headers,
+          "123,456,Artist,Title,Label,CAT001,Vinyl,Very Good,12.99,2026-01-15,Line one\nLine two,For Sale"
+        ].join("\r\n")
+      end
+
+      it "flattens the newline and parses the listing" do
+        result = parser.call(csv_body, store_id: 1)
+
+        expect(result.records.one?).to be(true)
+        expect(result.records.first[:notes]).to eq("Line one Line two")
+      end
+    end
+
+    context "when mixed row endings would merge separate records" do
+      let(:csv_body) do
+        [
+          csv_headers,
+          "123,456,Artist,Title,Label,CAT001,Vinyl,Very Good,12.99,2026-01-15,,For Sale\n" \
+            "124,457,Artist 2,Title 2,Label,CAT002,Vinyl,Mint,10.00,2026-01-16,,For Sale"
+        ].join("\r\n")
+      end
+
+      it "rejects the malformed row instead of returning shifted data" do
+        expect { parser.call(csv_body, store_id: 1) }
+          .to raise_error(CsvExportSync::ParseError, /unexpected number of fields/)
+      end
+    end
   end
 end

--- a/spec/services/discogs/marketplace_spec.rb
+++ b/spec/services/discogs/marketplace_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Discogs::Marketplace do
 
       expect { client.download_export(42) }.to raise_error(Discogs::Errors::ApiError, /HTTP 500/)
     end
+
+    it "classifies 5xx responses as transient and truncates the response body" do
+      response = oauth_response(code: 502, body: "<!DOCTYPE html>#{'x' * 10_000}")
+      allow(oauth_access_token).to receive(:get).and_return(response)
+
+      expect { client.download_export(42) }
+        .to raise_error(Discogs::Errors::TransientApiError) { |error|
+          expect(error.message.length).to be < 600
+        }
+    end
   end
 
   describe "#recent_exports" do
@@ -167,6 +177,17 @@ RSpec.describe Discogs::Marketplace do
       allow(oauth_access_token).to receive(:get).and_return(response)
 
       expect { client.list_orders }.to raise_error(Discogs::Errors::ApiError)
+    end
+
+    it "classifies HTML 5xx responses as transient without including the full body" do
+      response = oauth_response(code: 502, body: "<!DOCTYPE html>#{'x' * 10_000}")
+      allow(oauth_access_token).to receive(:get).and_return(response)
+
+      expect { client.list_orders }
+        .to raise_error(Discogs::Errors::TransientApiError) { |error|
+          expect(error.message).to include("Discogs API error: 502")
+          expect(error.message.length).to be < 600
+        }
     end
 
     it "returns parsed orders on success" do


### PR DESCRIPTION
## Problem

Two bugs found during first OAuth store onboarding:

### 1. Curation runs on un-enriched listings

`FullStoreSyncJob#dispatch_followup_jobs` dispatched both `EnrichmentJob` and `DailyCurationJob` simultaneously via `perform_later`. If curation won the race, it operated on listings without genres, images, or other enrichment data — requiring a manual re-curation from the admin page.

### 2. CSV parser skips mixed-newline recovery

`CsvParser` had a recovery path for Discogs CSVs with bare `\n` in unquoted fields, but it was gated behind a `first_row_separator == "\r\n"` check. If the first-encountered line ending wasn't CRLF (e.g., a BOM or prefix byte that matched `\n` first), recovery was skipped entirely and the sync failed with a hard `ParseError`.

## Changes

### Curation ordering
- `EnrichmentJob` now dispatches `DailyCurationJob` after enrichment completes
- `FullStoreSyncJob` no longer dispatches curation directly

### CSV parser
- Remove `first_row_separator` gate — always attempt recovery on `Unquoted fields do not allow new line` errors
- Replace bare `\n` (not in `\r\n`) with spaces and re-parse

### Supporting
- `TransientApiError` for 5xx upstream failures (caught gracefully in `SalesPollStoreJob`)
- `ApiResponseError` extracts bounded error formatting with response body truncation