### PR TITLE
fix: sitemap dedup, bulk onboard resilience, robots.txt path

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -4,7 +4,7 @@ SitemapGenerator::Sitemap.default_host = "https://milkcrate.fm"
 SitemapGenerator::Sitemap.sitemaps_path = "sitemaps/"
 SitemapGenerator::Sitemap.create_index = :auto
 
-SitemapGenerator::Sitemap.create do
+SitemapGenerator::Sitemap.create(include_root: false) do
   add "/", changefreq: "daily", priority: 1.0
   add "/explore", changefreq: "daily", priority: 0.9
 

--- a/lib/tasks/stores_bulk_onboard.rake
+++ b/lib/tasks/stores_bulk_onboard.rake
@@ -51,7 +51,11 @@ YAML format:
 
       begin
         result = StoreOnboarding.call(discogs_username: slug)
-        ScrapeStoreLocationJob.perform_later(result.store.id)
+        begin
+          ScrapeStoreLocationJob.perform_later(result.store.id)
+        rescue ArgumentError => e
+          puts " WARN (ScrapeStoreLocationJob enqueue failed: #{e.message})"
+        end
         puts " OK ##{result.store.id}"
         stats[:created] += 1
       rescue StoreOnboarding::Error => e

--- a/public/googleb40cff1b161eac96.html
+++ b/public/googleb40cff1b161eac96.html
@@ -1,0 +1,1 @@
+google-site-verification: googleb40cff1b161eac96.html

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,4 +6,4 @@ Disallow: /auth/
 Disallow: /dev/
 Disallow: /jobs/
 
-Sitemap: https://milkcrate.fm/sitemap.xml.gz
+Sitemap: https://milkcrate.fm/sitemaps/sitemap.xml.gz

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -25,6 +25,6 @@ RSpec.describe "robots.txt", type: :request do
 
   it "references the sitemap" do
     get "/robots.txt"
-    expect(response.body).to include("Sitemap: https://milkcrate.fm/sitemap.xml.gz")
+    expect(response.body).to include("Sitemap: https://milkcrate.fm/sitemaps/sitemap.xml.gz")
   end
 end


### PR DESCRIPTION
Small fixes after the SEO release deploy:

- **Google Search Console verification** — `googleb40cff1b161eac96.html` in `public/`
- **Sitemap path in robots.txt** — was pointing to `/sitemap.xml.gz`, sitemap lives at `/sitemaps/`
- **robots spec updated** — matches the new sitemap path
- **Sitemap duplicate home URL** — `include_root: false` prevents the generator from adding a second `/` entry (regenerate with `rake sitemap:refresh`)
- **Bulk onboard resilience** — `ScrapeStoreLocationJob` enqueue errors no longer block store creation