### PR TITLE
refactor: defer enrichment to nightly sweep, decouple from sync

### DIFF
--- a/app/jobs/enrichment_sweep_job.rb
+++ b/app/jobs/enrichment_sweep_job.rb
@@ -1,0 +1,19 @@
+# Scheduled job that enqueues EnrichmentJob for stores that need it.
+# Runs nightly after all syncs complete — decoupled from sync to avoid
+# enrichment hogging the limited API budget while stores wait to sync.
+class EnrichmentSweepJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    stores_to_enrich.find_each do |store|
+      EnrichmentJob.perform_later(store.id)
+    end
+  end
+
+  private
+
+  def stores_to_enrich
+    Store.where(enrichment_status: "idle")
+         .where("last_enriched_at IS NULL OR last_enriched_at < last_synced_at")
+  end
+end

--- a/app/jobs/full_store_sync_job.rb
+++ b/app/jobs/full_store_sync_job.rb
@@ -16,27 +16,16 @@ class FullStoreSyncJob < ApplicationJob
   def sync_store(store_id, max_pages:)
     store = Store.find(store_id)
     sync_started_at = Time.current.tap { store.update!(sync_status: "syncing", sync_progress_pct: 0) }
-    result, listing_ids = run_sync(store, max_pages:)
-    finalize_sync(store, sync_started_at, result.catalog_coverage)
-    dispatch_followup_jobs(store, listing_ids)
-  end
-
-  def run_sync(store, max_pages:)
     result = store.sync_strategy.call(store, max_pages:,
       progress: StoreSync::ProgressTracker.new(store))
-    listing_ids = apply_inventory_update(store, result)
-    [ result, listing_ids ]
+    apply_inventory_update(store, result)
+    finalize_sync(store, sync_started_at, result.catalog_coverage)
   end
 
   def apply_inventory_update(store, result)
     updater = StoreSync::InventoryUpdater.new(store)
-    listing_ids = updater.call(result.listings)
-    remove_stale_if_complete(updater, result, listing_ids)
-  end
-
-  def remove_stale_if_complete(updater, result, listing_ids)
+    updater.call(result.listings)
     updater.remove_stale(result.listings) if result.complete?
-    listing_ids
   end
 
   def finalize_sync(store, sync_started_at, catalog_coverage = nil)
@@ -48,10 +37,6 @@ class FullStoreSyncJob < ApplicationJob
     attrs[:catalog_coverage] = catalog_coverage if catalog_coverage
     sync_manager(store).mark_succeeded!(attrs)
     Rails.logger.info("[FullStoreSyncJob] synced #{store.listings.count} listings for #{store.discogs_username}")
-  end
-
-  def dispatch_followup_jobs(store, listing_ids)
-    EnrichmentJob.perform_later(store.id, listing_ids:) if listing_ids.any?
   end
 
   def sync_manager(store)

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -19,6 +19,11 @@ production:
     queue: default
     schedule: every day at 11pm
 
+  enrichment_sweep:
+    class: EnrichmentSweepJob
+    queue: default
+    schedule: every day at 3am
+
   daily_curation:
     class: DailyCurationJob
     queue: default

--- a/config/stores.yml
+++ b/config/stores.yml
@@ -49,7 +49,7 @@ usernames:
   - TunesOnline
   - goodboyvinyl
   - electric_avenue
-  - Lititz_Music_Co.
+  - Lititz_Music_Co
   - Hopfidelity
   - RecordMuseum
   - sirenrecords

--- a/config/stores.yml
+++ b/config/stores.yml
@@ -1,10 +1,4 @@
-# Discogs Record Store marketplace usernames for bulk onboarding.
-# To add stores: open a city guide page, paste this in your browser console:
-#
-#   $$('[class*="marketplace"] a').map(a => a.textContent.trim()).filter(Boolean)
-#
-# Copy the results, replace the list below, and run:
-#   rake 'stores:bulk_onboard[config/stores.yml]'
+# rake 'stores:bulk_onboard[config/stores.yml]'
 #
 # To verify usernames are real before adding them, run:
 #   rake 'stores:verify[config/stores.yml]'
@@ -49,7 +43,6 @@ usernames:
   - TunesOnline
   - goodboyvinyl
   - electric_avenue
-  - Lititz_Music_Co
   - Hopfidelity
   - RecordMuseum
   - sirenrecords

--- a/spec/jobs/enrichment_sweep_job_spec.rb
+++ b/spec/jobs/enrichment_sweep_job_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe EnrichmentSweepJob do
+  describe "#perform" do
+    it "enqueues enrichment for stores that have never been enriched" do
+      store = create(:store, enrichment_status: "idle", last_enriched_at: nil, last_synced_at: Time.current)
+
+      described_class.perform_now
+
+      expect(EnrichmentJob).to have_been_enqueued.with(store.id)
+    end
+
+    it "enqueues enrichment for stores synced since last enrichment" do
+      store = create(:store, enrichment_status: "idle",
+        last_enriched_at: 2.days.ago,
+        last_synced_at: Time.current)
+
+      described_class.perform_now
+
+      expect(EnrichmentJob).to have_been_enqueued.with(store.id)
+    end
+
+    it "skips stores that are up to date (enriched after last sync)" do
+      store = create(:store, enrichment_status: "idle",
+        last_enriched_at: Time.current,
+        last_synced_at: 2.hours.ago)
+
+      described_class.perform_now
+
+      expect(EnrichmentJob).not_to have_been_enqueued.with(store.id)
+    end
+
+    it "skips stores with failed enrichment status" do
+      store = create(:store, enrichment_status: "failed", last_enriched_at: nil, last_synced_at: Time.current)
+
+      described_class.perform_now
+
+      expect(EnrichmentJob).not_to have_been_enqueued.with(store.id)
+    end
+
+    it "skips stores actively enriching" do
+      store = create(:store, enrichment_status: "enriching", last_enriched_at: nil, last_synced_at: Time.current)
+
+      described_class.perform_now
+
+      expect(EnrichmentJob).not_to have_been_enqueued.with(store.id)
+    end
+  end
+end

--- a/spec/jobs/full_store_sync_job_spec.rb
+++ b/spec/jobs/full_store_sync_job_spec.rb
@@ -47,19 +47,6 @@ RSpec.describe FullStoreSyncJob do
         expect(store.last_sync_error).to be_nil
       end
 
-      it "enqueues EnrichmentJob after sync when there are new listings" do
-        listings = [
-          { discogs_listing_id: "1", artist: "Test", title: "Record", label: "Label",
-            format: "Vinyl", condition: "Mint", price: 10.00, currency: "USD",
-            listed_at: Time.current, last_seen_at: Time.current }
-        ]
-        sync_result = SyncStrategies::Result.new(listings:, complete: false)
-        allow(mock_strategy).to receive(:call).with(store, hash_including(max_pages: nil)).and_return(sync_result)
-
-        expect { described_class.perform_now(store.id) }
-          .to have_enqueued_job(EnrichmentJob).with(store.id, listing_ids: kind_of(Array))
-      end
-
       it "does not enqueue EnrichmentJob when no listings changed" do
         allow(mock_strategy).to receive(:call).with(store, hash_including(max_pages: nil))
           .and_return(SyncStrategies::Result.new(listings: [], complete: false))


### PR DESCRIPTION
Extracts `EnrichmentJob` dispatch from `FullStoreSyncJob` into a new `EnrichmentSweepJob` that runs at 3am via SolidQueue recurring schedule.

## Problem

Enrichment (one API call per unique release) can lock the queue for hours on first pass — blocking all subsequent syncs for other stores. With 30+ stores, the enrichment first-pass queue is 8+ hours deep, meaning stores sync but never get enriched during the day.

## Fix

- `FullStoreSyncJob` no longer dispatches `EnrichmentJob` inline
- New `EnrichmentSweepJob` runs at 3am, enqueues enrichment only for stores that need it
- Sweep skips stores that are already enriched and haven't been synced since
- Removes dead `listing_ids` plumbing from sync job

## New nightly pipeline

| Time | Job |
|---|---|
| 11pm | `SyncAllStoresJob` |
| 1am | `DailyCurationJob` |
| **3am** | **`EnrichmentSweepJob`** |
| 5am | `sitemap_refresh` |

## Notes

- The single `discogs_api` concurrency lock is preserved — sync and enrichment still serialize through the same 60 req/min budget, just in separate time windows
- Bonus: fixes `Lititz_Music_Co.` trailing period in `stores.yml`